### PR TITLE
feat: display current model name in session status line

### DIFF
--- a/src/main/hook-status.ts
+++ b/src/main/hook-status.ts
@@ -37,9 +37,13 @@ if not sid:
     sys.exit(0)
 cost=d.get('cost',{})
 ctx=d.get('context_window',{})
-if cost or ctx:
+model=d.get('model',{}).get('display_name','')
+if cost or ctx or model:
+    payload={'cost':cost,'context_window':ctx}
+    if model:
+        payload['model']=model
     with open(f'${STATUS_DIR}/{sid}.cost','w') as f:
-        json.dump({'cost':cost,'context_window':ctx},f)
+        json.dump(payload,f)
 claude_sid=d.get('session_id','')
 if claude_sid:
     with open(f'${STATUS_DIR}/{sid}.sessionid','w') as f:

--- a/src/renderer/components/terminal-pane.ts
+++ b/src/renderer/components/terminal-pane.ts
@@ -293,13 +293,14 @@ export function updateCostDisplay(sessionId: string, cost: CostInfo): void {
   if (!el) return;
 
   const costStr = `$${cost.totalCostUsd.toFixed(4)}`;
+  const modelPrefix = cost.model ? `${cost.model}  \u00b7  ` : '';
   if (cost.totalInputTokens > 0 || cost.totalOutputTokens > 0) {
-    el.textContent = `${costStr}  \u00b7  ${formatTokens(cost.totalInputTokens)} in / ${formatTokens(cost.totalOutputTokens)} out`;
+    el.textContent = `${modelPrefix}${costStr}  \u00b7  ${formatTokens(cost.totalInputTokens)} in / ${formatTokens(cost.totalOutputTokens)} out`;
     const durationSec = (cost.totalDurationMs / 1000).toFixed(1);
     const apiDurationSec = (cost.totalApiDurationMs / 1000).toFixed(1);
     (el as HTMLElement).title = `Cache read: ${formatTokens(cost.cacheReadTokens)} · Cache create: ${formatTokens(cost.cacheCreationTokens)} · Duration: ${durationSec}s · API: ${apiDurationSec}s`;
   } else {
-    el.textContent = `${costStr}`;
+    el.textContent = `${modelPrefix}${costStr}`;
     (el as HTMLElement).title = '';
   }
   showStatusBar(instance);

--- a/src/renderer/session-cost.test.ts
+++ b/src/renderer/session-cost.test.ts
@@ -61,6 +61,60 @@ describe('setCostData', () => {
   });
 });
 
+describe('setCostData model tracking', () => {
+  it('stores model display name when provided', () => {
+    setCostData('s1', {
+      cost: { total_cost_usd: 1.0, total_duration_ms: 1000, total_api_duration_ms: 800 },
+      context_window: { total_input_tokens: 100, total_output_tokens: 50, current_usage: { cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } },
+      model: 'Sonnet 4.6',
+    });
+    expect(getCost('s1')!.model).toBe('Sonnet 4.6');
+  });
+
+  it('preserves existing model when subsequent hook omits it', () => {
+    setCostData('s1', {
+      cost: { total_cost_usd: 1.0, total_duration_ms: 1000, total_api_duration_ms: 800 },
+      context_window: { total_input_tokens: 100, total_output_tokens: 50, current_usage: { cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } },
+      model: 'Sonnet 4.6',
+    });
+    setCostData('s1', {
+      cost: { total_cost_usd: 2.0, total_duration_ms: 2000, total_api_duration_ms: 1600 },
+      context_window: { total_input_tokens: 200, total_output_tokens: 100, current_usage: { cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } },
+    });
+    expect(getCost('s1')!.model).toBe('Sonnet 4.6');
+  });
+
+  it('updates model when it changes mid-session', () => {
+    setCostData('s1', {
+      cost: { total_cost_usd: 1.0, total_duration_ms: 1000, total_api_duration_ms: 800 },
+      context_window: { total_input_tokens: 100, total_output_tokens: 50, current_usage: { cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } },
+      model: 'Sonnet 4.6',
+    });
+    setCostData('s1', {
+      cost: { total_cost_usd: 2.0, total_duration_ms: 2000, total_api_duration_ms: 1600 },
+      context_window: { total_input_tokens: 200, total_output_tokens: 100, current_usage: { cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } },
+      model: 'Opus 4.6',
+    });
+    expect(getCost('s1')!.model).toBe('Opus 4.6');
+  });
+
+  it('model is undefined when never provided', () => {
+    setCostData('s1', { cost: { total_cost_usd: 1.0 }, context_window: {} });
+    expect(getCost('s1')!.model).toBeUndefined();
+  });
+});
+
+describe('restoreCost model', () => {
+  it('restores model from persisted state', () => {
+    restoreCost('s1', {
+      totalCostUsd: 1.0, totalInputTokens: 100, totalOutputTokens: 50,
+      cacheReadTokens: 0, cacheCreationTokens: 0, totalDurationMs: 0, totalApiDurationMs: 0,
+      model: 'Sonnet 4.6',
+    });
+    expect(getCost('s1')!.model).toBe('Sonnet 4.6');
+  });
+});
+
 describe('parseCost', () => {
   it('extracts last dollar amount from text', () => {
     parseCost('s1', 'Total: $0.50 then $1.23');

--- a/src/renderer/session-cost.ts
+++ b/src/renderer/session-cost.ts
@@ -1,5 +1,5 @@
 import { stripAnsi } from './ansi';
-import type { CostInfo } from '../shared/types';
+import type { CostData, CostInfo } from '../shared/types';
 
 export type { CostInfo } from '../shared/types';
 
@@ -11,17 +11,10 @@ const listeners: CostChangeCallback[] = [];
 // Search for dollar cost patterns (fallback)
 const COST_RE = /\$(\d+\.\d{2,})/g;
 
-export function setCostData(sessionId: string, rawData: { cost: Record<string, unknown>; context_window: Record<string, unknown> }): void {
-  const cost = rawData.cost as { total_cost_usd?: number; total_duration_ms?: number; total_api_duration_ms?: number };
-  const ctx = rawData.context_window as {
-    total_input_tokens?: number;
-    total_output_tokens?: number;
-    current_usage?: {
-      cache_read_input_tokens?: number;
-      cache_creation_input_tokens?: number;
-    };
-  };
+export function setCostData(sessionId: string, rawData: CostData): void {
+  const { cost, context_window: ctx, model } = rawData;
 
+  const existing = costs.get(sessionId);
   const info: CostInfo = {
     totalCostUsd: cost.total_cost_usd ?? 0,
     totalInputTokens: ctx.total_input_tokens ?? 0,
@@ -30,13 +23,14 @@ export function setCostData(sessionId: string, rawData: { cost: Record<string, u
     cacheCreationTokens: ctx.current_usage?.cache_creation_input_tokens ?? 0,
     totalDurationMs: cost.total_duration_ms ?? 0,
     totalApiDurationMs: cost.total_api_duration_ms ?? 0,
+    model: model ?? existing?.model,
   };
 
-  const existing = costs.get(sessionId);
   if (existing && existing.totalCostUsd === info.totalCostUsd
     && existing.totalInputTokens === info.totalInputTokens
     && existing.totalOutputTokens === info.totalOutputTokens
-    && existing.totalDurationMs === info.totalDurationMs) return;
+    && existing.totalDurationMs === info.totalDurationMs
+    && existing.model === info.model) return;
 
   costs.set(sessionId, info);
   for (const cb of listeners) cb(sessionId, info);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -54,6 +54,7 @@ export interface CostInfo {
   cacheCreationTokens: number;
   totalDurationMs: number;
   totalApiDurationMs: number;
+  model?: string;
 }
 
 export interface ContextWindowInfo {
@@ -211,6 +212,7 @@ export interface ReadinessResult {
 
 export interface CostData {
   cost: { total_cost_usd: number; total_duration_ms: number; total_api_duration_ms: number };
+  model?: string;
   context_window: {
     total_input_tokens: number;
     total_output_tokens: number;


### PR DESCRIPTION
## Summary

Adds the active CLI model name (e.g. `Sonnet 4.6`) to the session status bar, displayed before the cost and token info.

**Before:** `$0.3718  ·  30 in / 3.7k out`
**After:** `Sonnet 4.6  ·  $0.3718  ·  30 in / 3.7k out`

## Changes

- **`hook-status.ts`** — extracts `model.display_name` from the Claude CLI hook JSON and includes it in the `.cost` status file
- **`shared/types.ts`** — adds `model?: string` to `CostInfo` and `CostData`
- **`session-cost.ts`** — maps model through `setCostData()`, preserves the last known model when a subsequent hook fires without one, and adds `model` to the dedup guard so model changes always trigger a UI update
- **`terminal-pane.ts`** — prepends model name in `updateCostDisplay()`; gracefully omits it when absent (older CLI versions, non-Claude providers)

## Behaviour

- Model updates reactively when it changes mid-session (e.g. after `/model` switch)
- Persisted in `state.json` per session — survives app restarts
- Uses `display_name` from the hook payload (`Sonnet 4.6`, `Opus 4.6`, etc.) for a compact, readable label
- No UI change for providers that don't supply model data

## Test plan

- [x] 5 new unit tests covering: model extraction, mid-session model preservation, model change detection, missing model fallback, and state restoration
- [ ] Launch app, start a Claude session, verify model name appears in status bar
- [ ] Run `/model` mid-session, verify status bar updates to new model on next response
- [ ] Restart app, verify model name is restored from persisted state