### PR TITLE
Fix blank diff view with real-time git file watcher

### DIFF
--- a/src/main/git-watcher.ts
+++ b/src/main/git-watcher.ts
@@ -1,0 +1,97 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFile } from 'child_process';
+import type { BrowserWindow } from 'electron';
+
+const DEBOUNCE_MS = 300;
+const IGNORE_SEGMENTS = new Set(['.git', 'node_modules', 'dist', 'build', '.next', '.cache', 'coverage', '__pycache__']);
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let dirWatchers: fs.FSWatcher[] = [];
+let currentProjectPath: string | null = null;
+let currentWin: BrowserWindow | null = null;
+
+function notify(): void {
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => {
+    if (currentWin && !currentWin.isDestroyed()) {
+      currentWin.webContents.send('git:changed');
+    }
+  }, DEBOUNCE_MS);
+}
+
+function shouldIgnore(filename: string | null): boolean {
+  if (!filename) return false;
+  const first = filename.split(path.sep)[0];
+  return IGNORE_SEGMENTS.has(first);
+}
+
+function watchDir(dirPath: string, shouldSkip?: (filename: string | null) => boolean): void {
+  try {
+    const watcher = fs.watch(dirPath, { recursive: true }, (_event, filename) => {
+      if (shouldSkip && shouldSkip(filename)) return;
+      notify();
+    });
+    watcher.on('error', () => {}); // ignore errors (dir deleted, etc.)
+    dirWatchers.push(watcher);
+  } catch {
+    // Directory doesn't exist — that's fine
+  }
+}
+
+function resolveGitDir(projectPath: string): Promise<string> {
+  return new Promise((resolve) => {
+    execFile('git', ['rev-parse', '--git-dir'], { cwd: projectPath, timeout: 3000 }, (err, stdout) => {
+      if (err) {
+        resolve(path.join(projectPath, '.git'));
+        return;
+      }
+      const gitDir = stdout.trim();
+      // Could be absolute or relative
+      resolve(path.isAbsolute(gitDir) ? gitDir : path.join(projectPath, gitDir));
+    });
+  });
+}
+
+function stopAll(): void {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+  for (const w of dirWatchers) w.close();
+  dirWatchers = [];
+}
+
+const GIT_DIR_FILES = new Set(['index', 'HEAD']);
+
+async function setupWatchers(projectPath: string): Promise<void> {
+  const gitDir = await resolveGitDir(projectPath);
+
+  // Watch git dir for index changes (stage/unstage) and HEAD (branch switch, commit)
+  watchDir(gitDir, (filename) => !filename || !GIT_DIR_FILES.has(filename));
+
+  // Watch refs for commits, branch creation/deletion, remote updates
+  watchDir(path.join(gitDir, 'refs'));
+
+  // Watch working tree for file edits, filtering out ignored directories
+  watchDir(projectPath, shouldIgnore);
+}
+
+export async function startGitWatcher(win: BrowserWindow, projectPath: string): Promise<void> {
+  if (projectPath === currentProjectPath) return;
+  stopAll();
+  currentWin = win;
+  currentProjectPath = projectPath;
+  await setupWatchers(projectPath);
+}
+
+export function stopGitWatcher(): void {
+  stopAll();
+  currentWin = null;
+  currentProjectPath = null;
+}
+
+/** Trigger an immediate notification — call after stage/unstage/discard */
+export function notifyGitChanged(): void {
+  notify();
+}

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -9,6 +9,7 @@ import type { McpServerConfig } from './claude-cli';
 import { loadState, saveState, PersistedState } from './store';
 import { startWatching, cleanupSessionStatus } from './hook-status';
 import { getGitStatus, getGitFiles, getGitDiff, getGitWorktrees, gitStageFile, gitUnstageFile, gitDiscardFile } from './git-status';
+import { startGitWatcher, stopGitWatcher, notifyGitChanged } from './git-watcher';
 import { registerMcpHandlers } from './mcp-ipc-handlers';
 import { checkForUpdates, quitAndInstall } from './auto-updater';
 import { getProvider, getProviderMeta, getAllProviderMetas } from './providers/registry';
@@ -210,11 +211,26 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle('git:getWorktrees', (_event, projectPath: string) => getGitWorktrees(projectPath));
 
-  ipcMain.handle('git:stageFile', (_event, projectPath: string, filePath: string) => gitStageFile(projectPath, filePath));
+  ipcMain.handle('git:stageFile', async (_event, projectPath: string, filePath: string) => {
+    await gitStageFile(projectPath, filePath);
+    notifyGitChanged();
+  });
 
-  ipcMain.handle('git:unstageFile', (_event, projectPath: string, filePath: string) => gitUnstageFile(projectPath, filePath));
+  ipcMain.handle('git:unstageFile', async (_event, projectPath: string, filePath: string) => {
+    await gitUnstageFile(projectPath, filePath);
+    notifyGitChanged();
+  });
 
-  ipcMain.handle('git:discardFile', (_event, projectPath: string, filePath: string, area: string) => gitDiscardFile(projectPath, filePath, area as GitFileEntry['area']));
+  ipcMain.handle('git:discardFile', async (_event, projectPath: string, filePath: string, area: string) => {
+    await gitDiscardFile(projectPath, filePath, area as GitFileEntry['area']);
+    notifyGitChanged();
+  });
+
+  ipcMain.on('git:watchProject', (_event, projectPath: string) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    if (!win) return;
+    startGitWatcher(win, projectPath);
+  });
 
   ipcMain.handle('git:openInEditor', (_event, projectPath: string, filePath: string) => {
     const fullPath = path.join(projectPath, filePath);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7,6 +7,7 @@ import { createAppMenu } from './menu';
 import { restartAndResync } from './hook-status';
 import { initProviders, getAllProviders } from './providers/registry';
 import { initAutoUpdater } from './auto-updater';
+import { stopGitWatcher } from './git-watcher';
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -95,6 +96,7 @@ app.on('before-quit', () => {
     win.webContents.send('app:quitting');
   }
   killAllPtys();
+  stopGitWatcher();
   // Cleanup all providers
   for (const provider of getAllProviders()) {
     provider.cleanup();

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -53,6 +53,8 @@ export interface VibeyardApi {
     unstageFile(path: string, file: string): Promise<void>;
     discardFile(path: string, file: string, area: string): Promise<void>;
     openInEditor(path: string, file: string): Promise<void>;
+    watchProject(path: string): void;
+    onChanged(callback: () => void): () => void;
   };
   update: {
     checkNow(): Promise<void>;
@@ -177,6 +179,8 @@ const api: VibeyardApi = {
     unstageFile: (path: string, file: string) => ipcRenderer.invoke('git:unstageFile', path, file),
     discardFile: (path: string, file: string, area: string) => ipcRenderer.invoke('git:discardFile', path, file, area),
     openInEditor: (path: string, file: string) => ipcRenderer.invoke('git:openInEditor', path, file),
+    watchProject: (path: string) => ipcRenderer.send('git:watchProject', path),
+    onChanged: (callback: () => void) => onChannel('git:changed', callback),
   },
   update: {
     checkNow: () => ipcRenderer.invoke('update:checkNow'),

--- a/src/renderer/git-status.ts
+++ b/src/renderer/git-status.ts
@@ -29,6 +29,7 @@ const sessionWorktreeMap = new Map<string, string>();
 // Manual override: projectId → worktree path
 const manualOverride = new Map<string, string>();
 let worktreePollCounter = 0;
+let unwatchGitChanged: (() => void) | null = null;
 
 async function refreshWorktrees(projectId: string, projectPath: string): Promise<void> {
   try {
@@ -169,7 +170,7 @@ function startInterval(): void {
   if (pollTimer) return; // Already polling
   if (document.hidden || !appState.activeProject) return; // No reason to poll
   poll();
-  pollTimer = setInterval(poll, 10_000);
+  pollTimer = setInterval(poll, 60_000);
 }
 
 function stopInterval(): void {
@@ -181,6 +182,16 @@ function stopInterval(): void {
 
 export function startPolling(): void {
   startInterval();
+
+  // Subscribe to main-process file system watcher push events (once)
+  if (!unwatchGitChanged) {
+    unwatchGitChanged = window.vibeyard.git.onChanged(() => poll());
+  }
+
+  // Start watcher for current project
+  if (appState.activeProject) {
+    window.vibeyard.git.watchProject(appState.activeProject.path);
+  }
 
   // Pause/resume when window visibility changes
   document.addEventListener('visibilitychange', () => {
@@ -197,6 +208,7 @@ export function startPolling(): void {
     if (!appState.activeProject) {
       stopInterval();
     } else {
+      window.vibeyard.git.watchProject(appState.activeProject.path);
       startInterval();
     }
   });

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -45,6 +45,8 @@ export interface VibeyardApi {
     getFiles(path: string): Promise<unknown>;
     getDiff(path: string, file: string, area: string): Promise<string>;
     getWorktrees(path: string): Promise<GitWorktree[]>;
+    watchProject(path: string): void;
+    onChanged(callback: () => void): () => void;
   };
   update: {
     checkNow(): Promise<void>;


### PR DESCRIPTION
## Summary
- Adds a main-process file system watcher (`fs.watch`) that monitors `.git/index`, `.git/HEAD`, `.git/refs/`, and the working tree for changes
- Pushes `git:changed` IPC events to the renderer, replacing the 10-second polling with near-instant (~300ms debounced) updates
- Keeps a 60-second fallback poll as a safety net
- Calls `notifyGitChanged()` after stage/unstage/discard operations for immediate feedback

Closes #4

## Test plan
- [ ] Edit a file in a project → git panel updates within ~500ms
- [ ] Stage/unstage via context menu → immediate update
- [ ] Navigate between changed files → all diffs render correctly
- [ ] Switch branches in terminal → panel updates quickly
- [ ] Switch projects → watcher restarts on new project path
- [ ] `npm test` — all 552 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)