### PR TITLE
feat: add clickable URL and PR links in terminal output

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -221,6 +221,17 @@ export function registerIpcHandlers(): void {
     return shell.openPath(fullPath);
   });
 
+  ipcMain.handle('git:getRemoteUrl', (_event, projectPath: string) => {
+    try {
+      const resolved = path.resolve(projectPath);
+      if (!isWithinKnownProject(resolved)) return null;
+      const result = execSync('git remote get-url origin', { cwd: resolved, encoding: 'utf-8', timeout: 5000 });
+      return result.trim();
+    } catch {
+      return null;
+    }
+  });
+
   ipcMain.handle('pty:getCwd', (_event, sessionId: string) => getPtyCwd(sessionId));
 
   ipcMain.handle('fs:listFiles', (_event, cwd: string, query: string) => {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -53,6 +53,7 @@ export interface VibeyardApi {
     unstageFile(path: string, file: string): Promise<void>;
     discardFile(path: string, file: string, area: string): Promise<void>;
     openInEditor(path: string, file: string): Promise<void>;
+    getRemoteUrl(path: string): Promise<string | null>;
   };
   update: {
     checkNow(): Promise<void>;
@@ -177,6 +178,7 @@ const api: VibeyardApi = {
     unstageFile: (path: string, file: string) => ipcRenderer.invoke('git:unstageFile', path, file),
     discardFile: (path: string, file: string, area: string) => ipcRenderer.invoke('git:discardFile', path, file, area),
     openInEditor: (path: string, file: string) => ipcRenderer.invoke('git:openInEditor', path, file),
+    getRemoteUrl: (path: string) => ipcRenderer.invoke('git:getRemoteUrl', path),
   },
   update: {
     checkNow: () => ipcRenderer.invoke('update:checkNow'),

--- a/src/renderer/components/terminal-link-provider.ts
+++ b/src/renderer/components/terminal-link-provider.ts
@@ -51,3 +51,85 @@ export class FilePathLinkProvider implements ILinkProvider {
     callback(links.length > 0 ? links : undefined);
   }
 }
+
+export class UrlLinkProvider implements ILinkProvider {
+  constructor(private terminal: Terminal) {}
+
+  provideLinks(bufferLineNumber: number, callback: (links: ILink[] | undefined) => void): void {
+    const line = this.terminal.buffer.active.getLine(bufferLineNumber - 1);
+    if (!line) { callback(undefined); return; }
+
+    const lineText = line.translateToString(true);
+    const links: ILink[] = [];
+
+    for (const match of lineText.matchAll(/https?:\/\/\S+/g)) {
+      // Strip trailing punctuation that is unlikely to be part of the URL
+      const url = match[0].replace(/[.,;:!?()[\]'"]+$/, '');
+      const startX = match.index! + 1; // 1-based xterm coordinate
+      const endX = startX + url.length - 1;
+
+      links.push({
+        range: {
+          start: { x: startX, y: bufferLineNumber },
+          end: { x: endX, y: bufferLineNumber },
+        },
+        text: url,
+        activate: (event: MouseEvent) => {
+          if (!event.metaKey) return;
+          window.vibeyard.app.openExternal(url);
+        },
+      });
+    }
+
+    callback(links.length > 0 ? links : undefined);
+  }
+}
+
+function buildGitHubPrUrl(remoteUrl: string, prNumber: string): string | null {
+  const match = remoteUrl.match(/(?:git@github\.com:|https?:\/\/github\.com\/)([^/]+\/[^/]+?)(?:\.git)?$/);
+  if (match) return `https://github.com/${match[1]}/pull/${prNumber}`;
+  return null;
+}
+
+export class PrLinkProvider implements ILinkProvider {
+  private static readonly remoteUrlCache = new Map<string, Promise<string | null>>();
+
+  constructor(private projectPath: string, private terminal: Terminal) {}
+
+  provideLinks(bufferLineNumber: number, callback: (links: ILink[] | undefined) => void): void {
+    const line = this.terminal.buffer.active.getLine(bufferLineNumber - 1);
+    if (!line) { callback(undefined); return; }
+
+    const lineText = line.translateToString(true);
+    const links: ILink[] = [];
+
+    for (const match of lineText.matchAll(/PR\s+#(\d+)/g)) {
+      const fullText = match[0];
+      const prNumber = match[1];
+      const startX = match.index! + 1; // 1-based xterm coordinate
+      const endX = startX + fullText.length - 1;
+
+      links.push({
+        range: {
+          start: { x: startX, y: bufferLineNumber },
+          end: { x: endX, y: bufferLineNumber },
+        },
+        text: fullText,
+        activate: (event: MouseEvent) => {
+          if (!event.metaKey) return;
+          (async () => {
+            if (!PrLinkProvider.remoteUrlCache.has(this.projectPath)) {
+              PrLinkProvider.remoteUrlCache.set(this.projectPath, window.vibeyard.git.getRemoteUrl(this.projectPath));
+            }
+            const remoteUrl = await PrLinkProvider.remoteUrlCache.get(this.projectPath)!;
+            if (!remoteUrl) return;
+            const prUrl = buildGitHubPrUrl(remoteUrl, prNumber);
+            if (prUrl) window.vibeyard.app.openExternal(prUrl);
+          })();
+        },
+      });
+    }
+
+    callback(links.length > 0 ? links : undefined);
+  }
+}

--- a/src/renderer/components/terminal-pane.ts
+++ b/src/renderer/components/terminal-pane.ts
@@ -7,7 +7,7 @@ import { markFreshSession } from '../session-insights.js';
 import { removeSession as removeCostSession, type CostInfo } from '../session-cost.js';
 import { removeSession as removeContextSession, type ContextWindowInfo } from '../session-context.js';
 import type { ProviderId } from '../types.js';
-import { FilePathLinkProvider } from './terminal-link-provider.js';
+import { FilePathLinkProvider, UrlLinkProvider, PrLinkProvider } from './terminal-link-provider.js';
 
 interface TerminalInstance {
   terminal: Terminal;
@@ -119,7 +119,9 @@ export function createTerminalPane(
 
   instances.set(sessionId, instance);
 
-  // Register file path link provider for Cmd+Click
+  // Register link providers for Cmd+Click
+  terminal.registerLinkProvider(new UrlLinkProvider(terminal));
+  terminal.registerLinkProvider(new PrLinkProvider(projectPath, terminal));
   if (projectId) {
     terminal.registerLinkProvider(new FilePathLinkProvider(projectId, projectPath, terminal));
   }

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -45,6 +45,7 @@ export interface VibeyardApi {
     getFiles(path: string): Promise<unknown>;
     getDiff(path: string, file: string, area: string): Promise<string>;
     getWorktrees(path: string): Promise<GitWorktree[]>;
+    getRemoteUrl(path: string): Promise<string | null>;
   };
   update: {
     checkNow(): Promise<void>;
@@ -56,6 +57,7 @@ export interface VibeyardApi {
   };
   app: {
     getVersion(): Promise<string>;
+    openExternal(url: string): Promise<void>;
     onQuitting(callback: () => void): () => void;
   };
   mcp: {


### PR DESCRIPTION
## Summary

Thanks to @lauferism for filing issue #3 — great catch!

This PR implements both parts of the request:

- **URLs in terminal output are Cmd+clickable** — any `https://...` link in Claude's output is now detected by a `UrlLinkProvider` and opens in the browser on Cmd+click. Trailing punctuation (periods, parens, etc.) is stripped so the link resolves correctly.

- **`PR #N` in the status line is Cmd+clickable** — a `PrLinkProvider` detects `PR #N` references (e.g. in Claude Code's status bar after creating a PR) and resolves them to the full GitHub PR URL by reading the project's git remote. The remote URL is cached per project so the IPC call only happens once.

## Changes

- `src/renderer/components/terminal-link-provider.ts` — new `UrlLinkProvider` and `PrLinkProvider` classes; `buildGitHubPrUrl` helper handles both SSH and HTTPS remote formats
- `src/renderer/components/terminal-pane.ts` — registers both new providers on every terminal instance
- `src/main/ipc-handlers.ts` — new `git:getRemoteUrl` handler (secured by existing `isWithinKnownProject` check)
- `src/preload/preload.ts` + `src/renderer/types.ts` — expose `git.getRemoteUrl` and `app.openExternal` to the renderer

## Test plan

- [ ] Run `echo "Visit https://github.com/elirantutia/vibeyard/issues/3"` in a session → hover shows underline → Cmd+click opens browser
- [ ] URL with trailing period (`https://example.com.`) → stripped correctly
- [ ] After Claude creates a PR, status line shows `PR #N` → Cmd+click opens correct GitHub PR page
- [ ] SSH remote (`git@github.com:owner/repo.git`) resolves correctly
- [ ] Second Cmd+click on a PR link is instant (cached, no repeated IPC)
- [ ] Non-GitHub remote → Cmd+click does nothing, no crash

Closes #3