### PR TITLE
feat: Cmd+W closes active session, Cmd+Shift+W closes window

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -26,7 +26,16 @@ export function createAppMenu(debugMode = false): void {
           click: () => sendToRenderer('menu:new-session'),
         },
         { type: 'separator' },
-        isMac ? { role: 'close' as const } : { role: 'quit' as const },
+        isMac ? {
+          label: 'Close Session',
+          accelerator: 'CmdOrCtrl+W',
+          click: () => sendToRenderer('menu:close-session'),
+        } : { role: 'quit' as const },
+        ...(isMac ? [{
+          label: 'Close Window',
+          accelerator: 'CmdOrCtrl+Shift+W',
+          click: () => { BrowserWindow.getFocusedWindow()?.close(); },
+        }] : []),
       ],
     },
     {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -104,6 +104,7 @@ export interface VibeyardApi {
     onGotoSession(callback: (index: number) => void): () => void;
     onToggleDebug(callback: () => void): () => void;
     onUsageStats(callback: () => void): () => void;
+    onCloseSession(callback: () => void): () => void;
     rebuild(debugMode: boolean): Promise<void>;
   };
 }
@@ -232,6 +233,7 @@ const api: VibeyardApi = {
     onGotoSession: (cb) => onChannel('menu:goto-session', (index) => cb(index as number)),
     onToggleDebug: (cb) => onChannel('menu:toggle-debug', cb),
     onUsageStats: (cb) => onChannel('menu:usage-stats', cb),
+    onCloseSession: (cb) => onChannel('menu:close-session', cb),
     rebuild: (debugMode) => ipcRenderer.invoke('menu:rebuild', debugMode),
   },
 };

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -23,6 +23,11 @@ export function initKeybindings(): void {
   window.vibeyard.menu.onPrevSession(() => appState.cycleSession(-1));
   window.vibeyard.menu.onGotoSession((index) => appState.gotoSession(index));
   window.vibeyard.menu.onToggleDebug(() => toggleDebugPanel());
+  window.vibeyard.menu.onCloseSession(() => {
+    const project = appState.activeProject;
+    const session = appState.activeSession;
+    if (project && session) appState.removeSession(project.id, session.id);
+  });
 
   // Register shortcut handlers
   shortcutManager.registerHandler('new-session', () => quickNewSession());

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -85,5 +85,6 @@ export interface VibeyardApi {
     onGotoSession(callback: (index: number) => void): () => void;
     onToggleDebug(callback: () => void): () => void;
     onUsageStats(callback: () => void): () => void;
+    onCloseSession(callback: () => void): () => void;
   };
 }


### PR DESCRIPTION
## Summary

- `Cmd+W` now closes the currently active session tab (instead of the entire window)
- `Cmd+Shift+W` closes the main window (previous behavior of `Cmd+W`)
- Adds `menu:close-session` IPC channel wired through preload bridge to renderer

## Changes

- `src/main/menu.ts` — replaces `{ role: 'close' }` with two explicit menu items with custom accelerators
- `src/preload/preload.ts` — adds `onCloseSession` binding in the `menu` namespace (type + impl)
- `src/renderer/types.ts` — adds `onCloseSession` to the `VibeyardApi` menu type
- `src/renderer/keybindings.ts` — registers the `onCloseSession` handler, calling `appState.removeSession()` on the active project/session

## Test plan

- [ ] Open app with multiple sessions, press `Cmd+W` — active session closes, others remain
- [ ] Press `Cmd+W` with a single session — session closes (or no-op if no session)
- [ ] Press `Cmd+Shift+W` — main window closes
- [ ] Verify File menu shows "Close Session (⌘W)" and "Close Window (⌘⇧W)"

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)