### PR TITLE
feat: add Cmd+J as alternate shortcut to toggle project terminal

### DIFF
--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -41,6 +41,7 @@ export function initKeybindings(): void {
   shortcutManager.registerHandler('toggle-sidebar', () => toggleSidebar());
   shortcutManager.registerHandler('toggle-split', () => appState.toggleSwarm());
   shortcutManager.registerHandler('project-terminal', () => toggleProjectTerminal());
+  shortcutManager.registerHandler('project-terminal-alt', () => toggleProjectTerminal());
   shortcutManager.registerHandler('debug-panel', () => toggleDebugPanel());
   shortcutManager.registerHandler('git-panel', () => toggleGitPanel());
   shortcutManager.registerHandler('quick-open', () => showQuickOpen());

--- a/src/renderer/shortcuts.ts
+++ b/src/renderer/shortcuts.ts
@@ -33,6 +33,7 @@ export const SHORTCUT_DEFAULTS: ShortcutDefault[] = [
   { id: 'toggle-sidebar', label: 'Toggle Sidebar', category: 'Panels', defaultKeys: 'CmdOrCtrl+B' },
   { id: 'toggle-split', label: 'Toggle Split Mode', category: 'Panels', defaultKeys: 'CmdOrCtrl+\\' },
   { id: 'project-terminal', label: 'Project Terminal', category: 'Panels', defaultKeys: 'Ctrl+`' },
+  { id: 'project-terminal-alt', label: 'Project Terminal (Alt)', category: 'Panels', defaultKeys: 'CmdOrCtrl+J' },
   { id: 'debug-panel', label: 'Debug Panel', category: 'Panels', defaultKeys: 'CmdOrCtrl+Shift+D' },
   { id: 'git-panel', label: 'Git Panel', category: 'Panels', defaultKeys: 'CmdOrCtrl+Shift+G' },
   { id: 'quick-open', label: 'Quick Open File', category: 'Search & Help', defaultKeys: 'CmdOrCtrl+P' },


### PR DESCRIPTION
## Summary
- Adds `CmdOrCtrl+J` as a second keybinding for the project terminal toggle
- Keeps the existing `Ctrl+\`` shortcut intact
- Follows the existing pattern used by `new-session` / `new-session-alt`

## Test plan
- [ ] Press `Cmd+J` — project terminal panel opens
- [ ] Press `Cmd+J` again — panel closes
- [ ] Press `Ctrl+\`` — still works as before
- [ ] Check Help dialog / keybindings list shows both entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)