### PR TITLE
Fix: auto-fill project name from path on type/autocomplete

### DIFF
--- a/src/renderer/components/sidebar.ts
+++ b/src/renderer/components/sidebar.ts
@@ -107,10 +107,7 @@ export function promptNewProject(): void {
         const dir = await window.vibeyard.fs.browseDirectory();
         if (!dir) return;
         input.value = dir;
-        const nameInput = document.getElementById('modal-project-name') as HTMLInputElement | null;
-        if (nameInput && !nameInput.value.trim()) {
-          nameInput.value = dir.split('/').pop() || '';
-        }
+        autoFillName(dir);
       },
     },
   ], async (values) => {
@@ -128,6 +125,16 @@ export function promptNewProject(): void {
     closeModal();
     appState.addProject(name, projectPath);
   });
+
+  const nameInput = document.getElementById('modal-project-name') as HTMLInputElement | null;
+  let nameManuallyEdited = false;
+  nameInput?.addEventListener('input', () => { nameManuallyEdited = true; });
+
+  const autoFillName = (path: string) => {
+    if (nameInput && !nameManuallyEdited) {
+      nameInput.value = path.split('/').pop() || '';
+    }
+  };
 
   // Attach path autocomplete to the rendered input
   const pathInput = document.getElementById('modal-project-path') as HTMLInputElement | null;
@@ -160,6 +167,7 @@ export function promptNewProject(): void {
           e.preventDefault();
           pathInput.value = item.textContent!;
           hideDropdown();
+          autoFillName(pathInput.value);
         });
         dropdown.appendChild(item);
       }
@@ -168,6 +176,7 @@ export function promptNewProject(): void {
 
     pathInput.addEventListener('input', async () => {
       const value = pathInput.value;
+      autoFillName(value);
       const lastSlash = value.lastIndexOf('/');
       if (lastSlash === -1) { hideDropdown(); return; }
 
@@ -203,6 +212,7 @@ export function promptNewProject(): void {
         e.stopPropagation();
         pathInput.value = items[activeIndex].textContent!;
         hideDropdown();
+        autoFillName(pathInput.value);
       } else if (e.key === 'Escape') {
         hideDropdown();
       }
@@ -210,6 +220,7 @@ export function promptNewProject(): void {
 
     pathInput.addEventListener('blur', () => {
       setTimeout(hideDropdown, 100);
+      autoFillName(pathInput.value);
     });
   }
 }


### PR DESCRIPTION
## Summary
- Extracts `autoFillName()` helper to set project name from path basename, used by all path-setting code paths (Browse, autocomplete click, keyboard selection, input typing, blur)
- Tracks `nameManuallyEdited` flag so auto-fill updates the name live as the path changes, but stops once the user manually edits the name field
- Refactors Browse button handler to use the shared helper (deduplication)

Closes #25

## Test plan
- [ ] Type a path manually (e.g. `~/dev/some-project`) — name should update live as you type
- [ ] Select a path from autocomplete dropdown — name should auto-fill
- [ ] Use arrow keys + Enter/Tab to select autocomplete — name should auto-fill
- [ ] Manually edit the name field, then change the path — name should NOT be overwritten
- [ ] Use Browse button — name should still auto-fill as before
- [ ] Leave name empty, type path, tab away — name should fill on blur

🤖 Generated with [Claude Code](https://claude.com/claude-code)