### PR TITLE
Fix path autocomplete only showing first 20 directories

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -165,13 +165,15 @@ export function registerIpcHandlers(): void {
     return expandUserPath(filePath);
   });
 
-  ipcMain.handle('fs:listDirs', (_event, dirPath: string) => {
+  ipcMain.handle('fs:listDirs', (_event, dirPath: string, prefix?: string) => {
     try {
       const expanded = expandUserPath(dirPath);
       const entries = fs.readdirSync(expanded, { withFileTypes: true });
+      const lowerPrefix = prefix?.toLowerCase();
       return entries
-        .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+        .filter(e => e.isDirectory() && !e.name.startsWith('.') && (!lowerPrefix || e.name.toLowerCase().startsWith(lowerPrefix)))
         .map(e => path.join(expanded, e.name))
+        .sort((a, b) => a.localeCompare(b))
         .slice(0, 20);
     } catch {
       return [];

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -26,7 +26,7 @@ export interface VibeyardApi {
   fs: {
     isDirectory(path: string): Promise<boolean>;
     expandPath(path: string): Promise<string>;
-    listDirs(dirPath: string): Promise<string[]>;
+    listDirs(dirPath: string, prefix?: string): Promise<string[]>;
     browseDirectory(): Promise<string | null>;
     listFiles(cwd: string, query: string): Promise<string[]>;
     readFile(filePath: string): Promise<string>;
@@ -167,7 +167,7 @@ const api: VibeyardApi = {
   fs: {
     isDirectory: (path) => ipcRenderer.invoke('fs:isDirectory', path),
     expandPath: (path: string) => ipcRenderer.invoke('fs:expandPath', path),
-    listDirs: (dirPath: string) => ipcRenderer.invoke('fs:listDirs', dirPath),
+    listDirs: (dirPath: string, prefix?: string) => ipcRenderer.invoke('fs:listDirs', dirPath, prefix),
     browseDirectory: () => ipcRenderer.invoke('fs:browseDirectory'),
     listFiles: (cwd: string, query: string) => ipcRenderer.invoke('fs:listFiles', cwd, query),
     readFile: (filePath: string) => ipcRenderer.invoke('fs:readFile', filePath),

--- a/src/renderer/components/sidebar.ts
+++ b/src/renderer/components/sidebar.ts
@@ -183,12 +183,8 @@ export function promptNewProject(): void {
       const dirPart = value.substring(0, lastSlash + 1);
       const namePart = value.substring(lastSlash + 1).toLowerCase();
 
-      const dirs = await window.vibeyard.fs.listDirs(dirPart);
-      const filtered = namePart
-        ? dirs.filter(d => (d.split('/').pop() ?? '').toLowerCase().startsWith(namePart))
-        : dirs;
-
-      showSuggestions(filtered, dirPart);
+      const dirs = await window.vibeyard.fs.listDirs(dirPart, namePart || undefined);
+      showSuggestions(dirs, dirPart);
     });
 
     pathInput.addEventListener('keydown', (e) => {

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -22,7 +22,7 @@ export interface VibeyardApi {
   fs: {
     isDirectory(path: string): Promise<boolean>;
     expandPath(path: string): Promise<string>;
-    listDirs(dirPath: string): Promise<string[]>;
+    listDirs(dirPath: string, prefix?: string): Promise<string[]>;
     browseDirectory(): Promise<string | null>;
     listFiles(cwd: string, query: string): Promise<string[]>;
     readFile(filePath: string): Promise<string>;


### PR DESCRIPTION
## Summary
- Moves prefix filtering from renderer to the `fs:listDirs` IPC handler so filtering happens **before** the 20-item cap, not after
- Adds optional `prefix` parameter to `fs:listDirs` for server-side case-insensitive matching
- Results are now returned sorted alphabetically

Closes #26

## Test plan
- [ ] Open New Project dialog
- [ ] Type a path to a parent directory with >20 subdirectories (e.g. `~/git/aura-`)
- [ ] Verify all matching directories appear in the dropdown, sorted alphabetically
- [ ] Verify that with no prefix (just a trailing `/`), the first 20 dirs are shown
- [ ] Run `npm test` — all 753 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)