### PR TITLE
fix: resolve 4 UI bugs (z-index stacking, ghost resize, listener leaks)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@playwright/test": "^1.59.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-serialize": "^0.14.0",
@@ -33,6 +34,7 @@
         "electron": "^41.0.0",
         "electron-builder": "^26.8.1",
         "esbuild": "^0.27.4",
+        "happy-dom": "^20.8.9",
         "typescript": "^5.7.0",
         "vitest": "^4.1.0"
       },
@@ -1427,6 +1429,21 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.10",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
@@ -1878,6 +1895,23 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -3840,6 +3874,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -4617,6 +4664,24 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -6240,6 +6305,50 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -7727,6 +7836,16 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
@@ -7802,6 +7921,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -93,11 +93,13 @@
     "electron": "^41.0.0",
     "electron-builder": "^26.8.1",
     "esbuild": "^0.27.4",
+    "happy-dom": "^20.8.9",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@playwright/test": "^1.59.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-serialize": "^0.14.0",

--- a/src/renderer/components/file-viewer.bug.test.ts
+++ b/src/renderer/components/file-viewer.bug.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+/**
+ * Dynamic regression test: file-viewer.ts — selectionchange listener leak
+ *
+ * Bug: destroyFileViewerPane() removed the session from pendingReloads
+ * but did NOT clean up the document 'selectionchange' listener when the
+ * set became empty. If all viewers were destroyed while a reload was
+ * pending (user had text selected), the listener remained forever.
+ *
+ * Fix: destroyFileViewerPane() now calls removeSelectionListener() when
+ * pendingReloads reaches zero.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../state.js', () => ({
+  appState: {
+    on: vi.fn(),
+    activeProject: null,
+    preferences: {},
+  },
+}));
+
+vi.mock('./search-bar.js', () => ({
+  destroySearchBar: vi.fn(),
+  createSearchBar: vi.fn(() => document.createElement('div')),
+}));
+
+// Track addEventListener / removeEventListener calls on document
+const addedListeners: Map<string, EventListenerOrEventListenerObject[]> = new Map();
+const removedListeners: Map<string, EventListenerOrEventListenerObject[]> = new Map();
+
+const origAdd = document.addEventListener.bind(document);
+const origRemove = document.removeEventListener.bind(document);
+
+function selectionChangeListenerCount(): number {
+  return (addedListeners.get('selectionchange') ?? []).length -
+         (removedListeners.get('selectionchange') ?? []).length;
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  addedListeners.clear();
+  removedListeners.clear();
+
+  vi.spyOn(document, 'addEventListener').mockImplementation((type, listener, ...rest) => {
+    if (!addedListeners.has(type)) addedListeners.set(type, []);
+    addedListeners.get(type)!.push(listener);
+    origAdd(type, listener, ...rest as []);
+  });
+
+  vi.spyOn(document, 'removeEventListener').mockImplementation((type, listener, ...rest) => {
+    if (!removedListeners.has(type)) removedListeners.set(type, []);
+    removedListeners.get(type)!.push(listener);
+    origRemove(type, listener, ...rest as []);
+  });
+
+  // Provide window.vibeyard mock
+  (window as any).vibeyard = {
+    fs: {
+      unwatchFile: vi.fn(),
+      watchFile: vi.fn(() => vi.fn()),
+      readFile: vi.fn(() => Promise.resolve('')),
+    },
+  };
+
+  vi.resetModules();
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function makeFileViewer(sessionId: string) {
+  const { createFileViewerPane } = await import('./file-viewer.js');
+
+  // Create a mount point
+  const container = document.createElement('div');
+  container.id = `pane-${sessionId}`;
+  document.body.appendChild(container);
+
+  createFileViewerPane(sessionId, '/fake/path/file.ts', 'left', undefined);
+  return sessionId;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('file-viewer.ts — selectionchange listener cleanup', () => {
+  it('selectionchange listener is removed when last viewer is destroyed', async () => {
+    const { createFileViewerPane, destroyFileViewerPane } = await import('./file-viewer.js');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    createFileViewerPane('sess-1', '/fake/file.ts', 'left', undefined);
+
+    // Simulate a pending reload by selecting text while a file change is pending
+    // (The listener is added by ensureSelectionListener when there are pending reloads)
+    // We test indirectly: destroying the viewer should clean up even if listener was added
+    expect(selectionChangeListenerCount()).toBe(0); // not added until file change
+
+    destroyFileViewerPane('sess-1');
+
+    // Listener should not have been leaked (either never added, or properly removed)
+    expect(selectionChangeListenerCount()).toBe(0);
+  });
+
+  it('does not remove listener early if other viewers still have pending reloads', async () => {
+    const { createFileViewerPane, destroyFileViewerPane } = await import('./file-viewer.js');
+
+    const c1 = document.createElement('div');
+    const c2 = document.createElement('div');
+    document.body.appendChild(c1);
+    document.body.appendChild(c2);
+
+    createFileViewerPane('sess-a', '/fake/a.ts', 'left', undefined);
+    createFileViewerPane('sess-b', '/fake/b.ts', 'left', undefined);
+
+    // Destroy only one — listener (if any) should persist for the remaining viewer
+    destroyFileViewerPane('sess-a');
+
+    // Should not have negative listener count (can't remove more than added)
+    expect(selectionChangeListenerCount()).toBeGreaterThanOrEqual(0);
+
+    // Now destroy the last viewer
+    destroyFileViewerPane('sess-b');
+
+    // All cleaned up
+    expect(selectionChangeListenerCount()).toBe(0);
+  });
+});

--- a/src/renderer/components/file-viewer.ts
+++ b/src/renderer/components/file-viewer.ts
@@ -182,6 +182,11 @@ export function destroyFileViewerPane(sessionId: string): void {
     window.vibeyard.fs.unwatchFile(instance.resolvedPath);
   }
   pendingReloads.delete(sessionId);
+  // If no pending reloads remain, the selectionchange listener is no longer needed.
+  if (pendingReloads.size === 0 && removeSelectionListener) {
+    removeSelectionListener();
+    removeSelectionListener = null;
+  }
   destroySearchBar(sessionId);
   instance.element.remove();
   instances.delete(sessionId);

--- a/src/renderer/components/modal.bug.test.ts
+++ b/src/renderer/components/modal.bug.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+/**
+ * Dynamic regression test: modal.ts — cleanup ordering bug
+ *
+ * Bug: cleanup() was called AFTER overlay.classList.remove('hidden'),
+ * meaning old confirm/cancel listeners were still attached while the
+ * new modal was already visible.
+ *
+ * Fix: cleanup() now runs before classList.remove('hidden').
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./custom-select.js', () => ({
+  createCustomSelect: vi.fn(() => ({
+    element: document.createElement('div'),
+    destroy: vi.fn(),
+  })),
+}));
+
+function setupModalDOM() {
+  document.body.innerHTML = `
+    <div id="modal-overlay" class="hidden">
+      <div id="modal-title"></div>
+      <div id="modal-body"></div>
+      <button id="modal-cancel">Cancel</button>
+      <button id="modal-confirm">Confirm</button>
+    </div>
+  `;
+}
+
+describe('modal.ts — cleanup ordering', () => {
+  beforeEach(() => {
+    setupModalDOM();
+    vi.resetModules();
+  });
+
+  it('removes old confirm handler before new modal is shown', async () => {
+    const { showModal, closeModal } = await import('./modal.js');
+
+    const firstConfirm = vi.fn();
+    const secondConfirm = vi.fn();
+
+    // Open first modal
+    showModal('First', [], firstConfirm);
+    expect(document.getElementById('modal-overlay')!.classList.contains('hidden')).toBe(false);
+
+    // Open second modal immediately (without closing first)
+    showModal('Second', [], secondConfirm);
+
+    // Click confirm — should only call secondConfirm, not firstConfirm
+    document.getElementById('modal-confirm')!.click();
+    await Promise.resolve(); // flush microtasks
+
+    expect(secondConfirm).toHaveBeenCalledOnce();
+    expect(firstConfirm).not.toHaveBeenCalled();
+  });
+
+  it('old keydown (Enter) handler is removed when new modal opens', async () => {
+    const { showModal } = await import('./modal.js');
+
+    const firstConfirm = vi.fn();
+    const secondConfirm = vi.fn();
+
+    showModal('First', [], firstConfirm);
+    showModal('Second', [], secondConfirm);
+
+    // Simulate Enter key on the overlay
+    const overlay = document.getElementById('modal-overlay')!;
+    overlay.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await Promise.resolve();
+
+    expect(secondConfirm).toHaveBeenCalledOnce();
+    expect(firstConfirm).not.toHaveBeenCalled();
+  });
+
+  it('closeModal cleans up all handlers', async () => {
+    const { showModal, closeModal } = await import('./modal.js');
+    const onConfirm = vi.fn();
+
+    showModal('Test', [], onConfirm);
+    closeModal();
+
+    // After close, confirm click should not fire callback
+    document.getElementById('modal-confirm')!.click();
+    await Promise.resolve();
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(document.getElementById('modal-overlay')!.classList.contains('hidden')).toBe(true);
+  });
+});

--- a/src/renderer/components/modal.ts
+++ b/src/renderer/components/modal.ts
@@ -97,6 +97,9 @@ export function showModal(
     bodyEl.appendChild(div);
   }
 
+  // Clean up previous listeners before showing the modal
+  cleanup();
+
   overlay.classList.remove('hidden');
 
   // Focus first text input
@@ -107,9 +110,6 @@ export function showModal(
       firstInput.select();
     });
   }
-
-  // Clean up previous listeners
-  cleanup();
 
   const handleConfirm = async () => {
     const values: Record<string, string> = {};

--- a/src/renderer/components/sidebar.bug.test.ts
+++ b/src/renderer/components/sidebar.bug.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment happy-dom
+/**
+ * Dynamic regression test: sidebar.ts — ghost resize bug
+ *
+ * Bug: When the user started dragging the sidebar resize handle and
+ * released the mouse button OUTSIDE the browser window, the 'mouseup'
+ * event never fired on document. This left dragging=true, so the sidebar
+ * continued moving whenever the mouse re-entered the window.
+ *
+ * Fix: The 'mousemove' handler now checks e.buttons. If the mouse button
+ * is no longer held (e.buttons === 0), it resets the drag state.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../state.js', () => ({
+  appState: {
+    on: vi.fn(),
+    projects: [],
+    activeProjectId: null,
+    sidebarCollapsed: false,
+    sidebarWidth: null,
+    preferences: { sidebarViews: { costFooter: false } },
+    toggleSidebar: vi.fn(),
+    setSidebarWidth: vi.fn(),
+  },
+}));
+
+vi.mock('./modal.js', () => ({
+  showModal: vi.fn(),
+  setModalError: vi.fn(),
+  closeModal: vi.fn(),
+}));
+
+vi.mock('./preferences-modal.js', () => ({
+  showPreferencesModal: vi.fn(),
+}));
+
+vi.mock('../session-cost.js', () => ({
+  onChange: vi.fn(),
+  getAggregateCost: vi.fn(() => ({ totalCostUsd: 0 })),
+}));
+
+vi.mock('../session-unread.js', () => ({
+  hasUnreadInProject: vi.fn(() => false),
+  onChange: vi.fn(),
+}));
+
+// ── DOM setup ─────────────────────────────────────────────────────────────────
+
+function setupSidebarDOM() {
+  document.body.innerHTML = `
+    <div id="sidebar" style="width: 200px;"></div>
+    <div id="sidebar-resize-handle"></div>
+    <div id="sidebar-footer"></div>
+    <div id="btn-toggle-sidebar"></div>
+    <div id="btn-add-project"></div>
+    <div id="btn-preferences"></div>
+    <div id="project-list"></div>
+  `;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fireMousedown(el: Element, x = 200) {
+  el.dispatchEvent(new MouseEvent('mousedown', {
+    bubbles: true, cancelable: true, clientX: x, buttons: 1,
+  }));
+}
+
+function fireMousemove(x: number, buttons: number) {
+  document.dispatchEvent(new MouseEvent('mousemove', {
+    bubbles: true, clientX: x, buttons,
+  }));
+}
+
+function fireMouseup() {
+  document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('sidebar.ts — ghost resize', () => {
+  beforeEach(() => {
+    setupSidebarDOM();
+    vi.resetModules();
+  });
+
+  it('sidebar width updates normally during drag', async () => {
+    const { initSidebar } = await import('./sidebar.js');
+    const { appState } = await import('../state.js');
+    initSidebar();
+
+    const handle = document.getElementById('sidebar-resize-handle')!;
+    const sidebar = document.getElementById('sidebar')!;
+
+    fireMousedown(handle, 200);
+    fireMousemove(300, 1); // buttons=1: mouse held
+    expect(sidebar.style.width).toBe('300px');
+  });
+
+  it('ghost resize: mousemove with buttons=0 stops drag', async () => {
+    const { initSidebar } = await import('./sidebar.js');
+    const { appState } = await import('../state.js');
+    initSidebar();
+
+    const handle = document.getElementById('sidebar-resize-handle')!;
+    const sidebar = document.getElementById('sidebar')!;
+
+    // Start drag
+    fireMousedown(handle, 200);
+    fireMousemove(250, 1); // normal drag
+    expect(sidebar.style.width).toBe('250px');
+
+    // Simulate: user moved mouse outside window and released (mouseup never fired)
+    // Mouse re-enters with buttons=0 (button no longer held)
+    fireMousemove(350, 0); // buttons=0: mouse released outside window
+
+    // Sidebar should NOT have moved to 350px — drag was cancelled
+    expect(sidebar.style.width).toBe('250px');
+
+    // Further mousemoves should also not move the sidebar
+    fireMousemove(400, 0);
+    expect(sidebar.style.width).toBe('250px');
+  });
+
+  it('ghost resize: drag state is cleaned up (cursor reset, class removed)', async () => {
+    const { initSidebar } = await import('./sidebar.js');
+    initSidebar();
+
+    const handle = document.getElementById('sidebar-resize-handle')!;
+
+    fireMousedown(handle, 200);
+    expect(document.body.classList.contains('sidebar-resizing')).toBe(true);
+    expect(document.body.style.cursor).toBe('col-resize');
+
+    // Mouse released outside browser (buttons=0 on next mousemove)
+    fireMousemove(300, 0);
+
+    expect(document.body.classList.contains('sidebar-resizing')).toBe(false);
+    expect(document.body.style.cursor).toBe('');
+    expect(handle.classList.contains('active')).toBe(false);
+  });
+
+  it('normal mouseup still works correctly', async () => {
+    const { initSidebar } = await import('./sidebar.js');
+    initSidebar();
+
+    const handle = document.getElementById('sidebar-resize-handle')!;
+    const sidebar = document.getElementById('sidebar')!;
+
+    fireMousedown(handle, 200);
+    fireMousemove(280, 1);
+    fireMouseup(); // normal mouseup inside window
+
+    // Drag ended — further mousemove should not move sidebar
+    fireMousemove(400, 1);
+    expect(sidebar.style.width).toBe('280px');
+  });
+});

--- a/src/renderer/components/sidebar.ts
+++ b/src/renderer/components/sidebar.ts
@@ -235,6 +235,17 @@ function initResizeHandle(): void {
 
   document.addEventListener('mousemove', (e) => {
     if (!dragging) return;
+    // If mouse button was released outside the browser window, mouseup never fired.
+    // Detect this via e.buttons and clean up the dragging state.
+    if (!e.buttons) {
+      dragging = false;
+      resizeHandle.classList.remove('active');
+      document.body.classList.remove('sidebar-resizing');
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+      appState.setSidebarWidth(parseInt(sidebarEl.style.width, 10));
+      return;
+    }
     const width = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, e.clientX));
     sidebarEl.style.width = width + 'px';
   });

--- a/src/renderer/styles/modals.css
+++ b/src/renderer/styles/modals.css
@@ -9,7 +9,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
+  z-index: 300;
 }
 
 #modal-overlay.hidden, .modal-overlay.hidden {
@@ -119,7 +119,7 @@
   border: 1px solid var(--border);
   border-radius: 4px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
-  z-index: 200;
+  z-index: 310;
   margin-top: 2px;
 }
 
@@ -231,7 +231,7 @@
   border: 1px solid var(--border);
   border-radius: 4px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
-  z-index: 200;
+  z-index: 310;
   margin-top: 2px;
 }
 


### PR DESCRIPTION
## Summary

- **`modals.css`** — Modal overlay z-index raised from 100 → 300 (was below tab context menus at 200). Modal-internal dropdowns raised to 310. Previously, opening a modal while a context menu was visible caused the menu to render on top of the modal.

- **`sidebar.ts`** — Fix ghost sidebar resize. When the user started dragging the resize handle and released the mouse button outside the browser window, `mouseup` never fired on `document`, leaving `dragging = true`. The sidebar would then resume moving whenever the mouse re-entered the window. Fixed by checking `e.buttons` in the `mousemove` handler and resetting drag state when the mouse button is no longer held.

- **`file-viewer.ts`** — Clean up `selectionchange` listener in `destroyFileViewerPane`. If all file viewer panes were destroyed while a file-change reload was deferred (because the user had text selected), the `selectionchange` listener would remain on `document` indefinitely. Fixed by calling `removeSelectionListener()` when `pendingReloads` reaches zero after a destroy.

- **`modal.ts`** — Move `cleanup()` to before `overlay.classList.remove('hidden')` so stale confirm/cancel event listeners from the previous modal are removed before the new modal becomes visible.

## Test plan

- [ ] Open a tab context menu (right-click a tab), then open any modal — modal should appear on top of the menu
- [ ] Drag the sidebar resize handle, move mouse outside the browser window, release, move back — sidebar should stop moving
- [ ] Open multiple file viewers, trigger a file change while text is selected, then close all viewers — verify no lingering `selectionchange` listener (DevTools → Event Listeners on `document`)
- [ ] Rapidly open/close modals — confirm/cancel buttons should always trigger the correct callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)