### PR TITLE
fix: add Windows CLI resolution support

### DIFF
--- a/src/main/providers/resolve-binary.ts
+++ b/src/main/providers/resolve-binary.ts
@@ -4,18 +4,33 @@ import * as os from 'os';
 import { execSync } from 'child_process';
 import { getFullPath } from '../pty-manager';
 
-const COMMON_BIN_DIRS = [
+const IS_WINDOWS = process.platform === 'win32';
+
+const WINDOWS_BIN_DIRS = [
+  path.join(os.homedir(), 'AppData', 'Roaming', 'npm'),               // npm global
+  path.join(os.homedir(), 'AppData', 'Local', 'npm'),
+  path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'claude-code'), // curl standalone
+  path.join(os.homedir(), 'AppData', 'Local', 'AnthropicClaude'),     // curl standalone alt
+  path.join(os.homedir(), 'AppData', 'Local', 'Programs'),            // generic Programs dir
+  'C:\\Program Files\\nodejs',
+  'C:\\Program Files (x86)\\nodejs',
+];
+
+const UNIX_BIN_DIRS = [
   '/usr/local/bin',
   '/opt/homebrew/bin',
   path.join(os.homedir(), '.local', 'bin'),
   path.join(os.homedir(), '.npm-global', 'bin'),
 ];
 
+const COMMON_BIN_DIRS = IS_WINDOWS ? WINDOWS_BIN_DIRS : UNIX_BIN_DIRS;
+
 export function resolveBinary(binaryName: string, cache: { path: string | null }): string {
   if (cache.path) return cache.path;
 
   const fullPath = getFullPath();
-  const candidates = COMMON_BIN_DIRS.map(dir => path.join(dir, binaryName));
+  const names = IS_WINDOWS ? [binaryName + '.cmd', binaryName + '.exe', binaryName] : [binaryName];
+  const candidates = COMMON_BIN_DIRS.flatMap(dir => names.map(n => path.join(dir, n)));
 
   for (const candidate of candidates) {
     try {
@@ -27,17 +42,18 @@ export function resolveBinary(binaryName: string, cache: { path: string | null }
   }
 
   try {
-    const resolved = execSync(`which ${binaryName}`, {
+    const whichCmd = IS_WINDOWS ? `where ${binaryName}` : `which ${binaryName}`;
+    const resolved = execSync(whichCmd, {
       env: { ...process.env, PATH: fullPath },
       encoding: 'utf-8',
       timeout: 3000,
-    }).trim();
+    }).trim().split('\n')[0].trim(); // `where` returns multiple lines on Windows
     if (resolved) {
       cache.path = resolved;
       return resolved;
     }
   } catch (err) {
-    console.warn(`Failed to resolve ${binaryName} path via which:`, err);
+    console.warn(`Failed to resolve ${binaryName} path:`, err);
   }
 
   cache.path = binaryName;
@@ -49,7 +65,8 @@ export function validateBinaryExists(
   displayName: string,
   installCommand: string,
 ): { ok: boolean; message: string } {
-  const candidates = COMMON_BIN_DIRS.map(dir => path.join(dir, binaryName));
+  const names = IS_WINDOWS ? [binaryName + '.cmd', binaryName + '.exe', binaryName] : [binaryName];
+  const candidates = COMMON_BIN_DIRS.flatMap(dir => names.map(n => path.join(dir, n)));
 
   for (const candidate of candidates) {
     try {
@@ -58,11 +75,12 @@ export function validateBinaryExists(
   }
 
   try {
-    const resolved = execSync(`which ${binaryName}`, {
+    const whichCmd = IS_WINDOWS ? `where ${binaryName}` : `which ${binaryName}`;
+    const resolved = execSync(whichCmd, {
       env: { ...process.env, PATH: getFullPath() },
       encoding: 'utf-8',
       timeout: 3000,
-    }).trim();
+    }).trim().split('\n')[0].trim();
     if (resolved) return { ok: true, message: '' };
   } catch {}
 

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -25,10 +25,27 @@ let cachedFullPath: string | null = null;
 export function getFullPath(): string {
   if (cachedFullPath) return cachedFullPath;
 
-  const shell = process.env.SHELL || '/bin/zsh';
   const currentPath = process.env.PATH || '';
 
-  // Try to get the real PATH from a login shell
+  if (process.platform === 'win32') {
+    // On Windows: PATH uses ';' separator. Augment with common install locations.
+    const home = os.homedir();
+    const extraDirs = [
+      path.join(home, 'AppData', 'Roaming', 'npm'),
+      path.join(home, 'AppData', 'Local', 'Programs', 'claude-code'),
+      path.join(home, 'AppData', 'Local', 'AnthropicClaude'),
+      path.join(home, '.local', 'bin'),
+      'C:\\Program Files\\nodejs',
+    ];
+    const pathSet = new Set(currentPath.split(';'));
+    for (const dir of extraDirs) pathSet.add(dir);
+    cachedFullPath = Array.from(pathSet).join(';');
+    return cachedFullPath;
+  }
+
+  const shell = process.env.SHELL || '/bin/zsh';
+
+  // Try to get the real PATH from a login shell (macOS/Linux)
   try {
     const shellPath = execSync(`${shell} -ilc 'echo __PATH__=$PATH'`, {
       encoding: 'utf-8',
@@ -54,9 +71,7 @@ export function getFullPath(): string {
   ];
 
   const pathSet = new Set(currentPath.split(':'));
-  for (const dir of extraDirs) {
-    pathSet.add(dir);
-  }
+  for (const dir of extraDirs) pathSet.add(dir);
   cachedFullPath = Array.from(pathSet).join(':');
   return cachedFullPath;
 }


### PR DESCRIPTION
## Problem

Vibeyard fails to detect any CLI provider on Windows with the error:
> "Claude Code CLI not found."

Two root causes:
1. `resolve-binary.ts` only searches Unix paths (`/usr/local/bin`, `/opt/homebrew/bin`) and uses `which` (not available on Windows)
2. `pty-manager.ts` `getFullPath()` tries to spawn a login shell (`/bin/zsh -ilc`) and splits PATH with `:` — both fail on Windows

## Fix

**`src/main/providers/resolve-binary.ts`**
- Detect `process.platform === 'win32'`
- Search Windows-specific paths: `AppData\Roaming\npm` (npm global), `AppData\Local\Programs\claude-code` and `AppData\Local\AnthropicClaude` (curl/standalone installer), `Program Files\nodejs`
- Try `.cmd` and `.exe` extensions (npm global installs create `.cmd` wrappers on Windows)
- Use `where` instead of `which` on Windows; take first line only (`where` returns multiple matches)

**`src/main/pty-manager.ts`**
- Add Windows branch in `getFullPath()`: use `;` as PATH separator, skip login shell, augment with same Windows dirs
- Unix path remains unchanged

## Tested

- Windows 11, Claude Code installed via **curl standalone installer** → detected on first launch ✅
- All 826 existing tests pass (`npm test`) ✅
- macOS/Linux behavior unchanged (platform guard) ✅

## Notes

The curl-based Windows installer places the binary in `AppData\Local\Programs\claude-code\` or `AppData\Local\AnthropicClaude\` depending on version. Both paths are now included.