### PR TITLE
fix: guard PTY operations against errors from exited processes (#70)

### DIFF
--- a/src/main/pty-manager.test.ts
+++ b/src/main/pty-manager.test.ts
@@ -289,8 +289,38 @@ describe('resizePty', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     expect(() => resizePty('s1', 120, 30)).not.toThrow();
-    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('s1'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('resizePty'));
     warnSpy.mockRestore();
+
+    // After an "already exited" error the handle must be dropped —
+    // a subsequent resize on the same session is a no-op.
+    mockResize.mockClear();
+    resizePty('s1', 80, 24);
+    expect(mockResize).not.toHaveBeenCalled();
+  });
+
+  // The map is pruned ONLY when the error signals process exit. A transient
+  // or unknown error must leave the handle intact so retries can succeed,
+  // otherwise the session would silently become unresponsive.
+  it('keeps the handle on transient (non-exit) errors (issue #70 review)', () => {
+    const proc = createMockPtyProcess();
+    mockSpawn.mockReturnValue(proc);
+    spawnPty('s1', '/project', null, false, '', 'claude', undefined, vi.fn(), vi.fn());
+
+    mockResize.mockImplementationOnce(() => {
+      throw new Error('EBUSY: some transient failure');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => resizePty('s1', 120, 30)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('s1'));
+    warnSpy.mockRestore();
+
+    // Handle is still registered — a subsequent successful resize must go through.
+    mockResize.mockClear();
+    resizePty('s1', 80, 24);
+    expect(mockResize).toHaveBeenCalledWith(80, 24);
   });
 });
 
@@ -306,7 +336,58 @@ describe('writePty error handling (issue #70)', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     expect(() => writePty('s1', 'hello')).not.toThrow();
-    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('s1'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('writePty'));
+    warnSpy.mockRestore();
+
+    // Handle dropped — subsequent write is a no-op.
+    mockWrite.mockClear();
+    writePty('s1', 'again');
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it('keeps the handle on transient (non-exit) errors (issue #70 review)', () => {
+    const proc = createMockPtyProcess();
+    mockSpawn.mockReturnValue(proc);
+    spawnPty('s1', '/project', null, false, '', 'claude', undefined, vi.fn(), vi.fn());
+
+    mockWrite.mockImplementationOnce(() => {
+      throw new Error('EAGAIN: resource temporarily unavailable');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => writePty('s1', 'hello')).not.toThrow();
+    warnSpy.mockRestore();
+
+    // Handle still registered — subsequent successful write must go through.
+    mockWrite.mockClear();
+    writePty('s1', 'again');
+    expect(mockWrite).toHaveBeenCalledWith('again');
+  });
+
+  // Security-review follow-up: sessionId arrives from the renderer over IPC
+  // and must be sanitised in log output so that crafted values (newlines,
+  // ANSI escape sequences) cannot confuse log consumers.
+  it('sanitises sessionId with control characters in log output', () => {
+    const proc = createMockPtyProcess();
+    mockSpawn.mockReturnValue(proc);
+    const hostileId = "evil\n[pty-manager] fake log line\x1b[31m";
+    spawnPty(hostileId, '/project', null, false, '', 'claude', undefined, vi.fn(), vi.fn());
+
+    mockWrite.mockImplementationOnce(() => {
+      throw new Error('Cannot write to a pty that has already exited');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    writePty(hostileId, 'hello');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const logged = warnSpy.mock.calls[0][0] as string;
+    // Raw newline/ESC must not appear in the logged string — JSON.stringify
+    // must have escaped them.
+    expect(logged).not.toMatch(/\n(?!$)/);
+    expect(logged).not.toContain('\x1b');
+    expect(logged).toContain('\\n');
     warnSpy.mockRestore();
   });
 });
@@ -323,7 +404,8 @@ describe('killPty error handling (issue #70)', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     expect(() => killPty('s1')).not.toThrow();
-    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('s1'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('killPty'));
     // After kill (even if it throws), a subsequent resize must be a no-op —
     // the handle is gone, so mockResize must not be called.
     mockResize.mockClear();

--- a/src/main/pty-manager.test.ts
+++ b/src/main/pty-manager.test.ts
@@ -274,6 +274,63 @@ describe('resizePty', () => {
     resizePty('s1', 200, 50);
     expect(mockResize).toHaveBeenCalledWith(200, 50);
   });
+
+  // Regression test for #70: node-pty on Windows throws synchronously from
+  // WindowsPtyAgent.resize when the underlying child has exited. Before the
+  // fix, this crashed the main process and killed every open session.
+  it('swallows errors from node-pty on already-exited PTY (issue #70)', () => {
+    const proc = createMockPtyProcess();
+    mockSpawn.mockReturnValue(proc);
+    spawnPty('s1', '/project', null, false, '', 'claude', undefined, vi.fn(), vi.fn());
+
+    mockResize.mockImplementationOnce(() => {
+      throw new Error('Cannot resize a pty that has already exited');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => resizePty('s1', 120, 30)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+describe('writePty error handling (issue #70)', () => {
+  it('swallows errors when writing to an already-exited PTY', () => {
+    const proc = createMockPtyProcess();
+    mockSpawn.mockReturnValue(proc);
+    spawnPty('s1', '/project', null, false, '', 'claude', undefined, vi.fn(), vi.fn());
+
+    mockWrite.mockImplementationOnce(() => {
+      throw new Error('Cannot write to a pty that has already exited');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => writePty('s1', 'hello')).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+describe('killPty error handling (issue #70)', () => {
+  it('swallows errors when killing an already-exited PTY and still drops the handle', () => {
+    const proc = createMockPtyProcess();
+    mockSpawn.mockReturnValue(proc);
+    spawnPty('s1', '/project', null, false, '', 'claude', undefined, vi.fn(), vi.fn());
+
+    mockKill.mockImplementationOnce(() => {
+      throw new Error('Cannot kill a pty that has already exited');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => killPty('s1')).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
+    // After kill (even if it throws), a subsequent resize must be a no-op —
+    // the handle is gone, so mockResize must not be called.
+    mockResize.mockClear();
+    resizePty('s1', 120, 30);
+    expect(mockResize).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });
 
 describe('killPty', () => {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -218,7 +218,31 @@ export async function spawnPty(
 // underlying child process has already exited (see microsoft/node-pty#887).
 // A single dead PTY must not be allowed to crash the main Electron process
 // — it would take down every other active session with it. Guard each
-// operation, log a warning, and drop the dead handle from the map.
+// operation, log a warning, and drop the dead handle only when the error
+// indicates the PTY is actually dead.
+
+/**
+ * True when a node-pty exception means the underlying process has already
+ * exited (as opposed to a transient or unknown failure). node-pty emits
+ * messages like "Cannot write to a pty that has already exited" / "Cannot
+ * resize a pty that has already exited" / "Cannot kill a pty that has
+ * already exited" — we only prune the map in that case, so a transient
+ * error does not silently leave the session unresponsive.
+ */
+function isPtyExitedError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /already exited/i.test(msg);
+}
+
+/**
+ * Escape sessionId for inclusion in a log message. sessionId arrives from
+ * the renderer over IPC, so it is semi-trusted — JSON.stringify neutralises
+ * newlines, ANSI escape sequences, and any other control characters that
+ * could confuse log output.
+ */
+function formatSessionIdForLog(sessionId: string): string {
+  return JSON.stringify(sessionId);
+}
 
 export function writePty(sessionId: string, data: string): void {
   const instance = ptys.get(sessionId);
@@ -226,8 +250,11 @@ export function writePty(sessionId: string, data: string): void {
   try {
     instance.process.write(data);
   } catch (err) {
-    console.warn(`[pty-manager] writePty("${sessionId}") failed: ${(err as Error).message}`);
-    ptys.delete(sessionId);
+    const message = (err as Error).message;
+    console.warn(`[pty-manager] writePty(${formatSessionIdForLog(sessionId)}) failed: ${message}`);
+    if (isPtyExitedError(err)) {
+      ptys.delete(sessionId);
+    }
   }
 }
 
@@ -237,8 +264,11 @@ export function resizePty(sessionId: string, cols: number, rows: number): void {
   try {
     instance.process.resize(cols, rows);
   } catch (err) {
-    console.warn(`[pty-manager] resizePty("${sessionId}") failed: ${(err as Error).message}`);
-    ptys.delete(sessionId);
+    const message = (err as Error).message;
+    console.warn(`[pty-manager] resizePty(${formatSessionIdForLog(sessionId)}) failed: ${message}`);
+    if (isPtyExitedError(err)) {
+      ptys.delete(sessionId);
+    }
   }
 }
 
@@ -248,8 +278,9 @@ export function killPty(sessionId: string): void {
   try {
     instance.process.kill();
   } catch (err) {
-    console.warn(`[pty-manager] killPty("${sessionId}") failed: ${(err as Error).message}`);
+    console.warn(`[pty-manager] killPty(${formatSessionIdForLog(sessionId)}) failed: ${(err as Error).message}`);
   } finally {
+    // kill is an intentional teardown — always drop the handle, even on throw.
     ptys.delete(sessionId);
   }
 }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -214,24 +214,42 @@ export async function spawnPty(
   ptys.set(sessionId, { process: ptyProcess, sessionId });
 }
 
+// node-pty on Windows throws synchronously from write/resize/kill when the
+// underlying child process has already exited (see microsoft/node-pty#887).
+// A single dead PTY must not be allowed to crash the main Electron process
+// — it would take down every other active session with it. Guard each
+// operation, log a warning, and drop the dead handle from the map.
+
 export function writePty(sessionId: string, data: string): void {
   const instance = ptys.get(sessionId);
-  if (instance) {
+  if (!instance) return;
+  try {
     instance.process.write(data);
+  } catch (err) {
+    console.warn(`[pty-manager] writePty("${sessionId}") failed: ${(err as Error).message}`);
+    ptys.delete(sessionId);
   }
 }
 
 export function resizePty(sessionId: string, cols: number, rows: number): void {
   const instance = ptys.get(sessionId);
-  if (instance) {
+  if (!instance) return;
+  try {
     instance.process.resize(cols, rows);
+  } catch (err) {
+    console.warn(`[pty-manager] resizePty("${sessionId}") failed: ${(err as Error).message}`);
+    ptys.delete(sessionId);
   }
 }
 
 export function killPty(sessionId: string): void {
   const instance = ptys.get(sessionId);
-  if (instance) {
+  if (!instance) return;
+  try {
     instance.process.kill();
+  } catch (err) {
+    console.warn(`[pty-manager] killPty("${sessionId}") failed: ${(err as Error).message}`);
+  } finally {
     ptys.delete(sessionId);
   }
 }


### PR DESCRIPTION
Fixes #70.
On Windows, node-pty throws synchronously from write/resize/kill when the child has already exited (microsoft/node-pty#887). This crashed the main process on relaunch after sessions were open, losing every session.
Guards the three call sites in pty-manager.ts with try/catch, logs a warning, and drops the dead handle.
Summary
try/catch around writePty, resizePty, killPty in src/main/pty-manager.ts.
Test plan

 npm run build passes
 npm test passes (1118 passed)
 3 regression tests added in pty-manager.test.ts
 Manually verified on Windows 11: repro scenario from #70 no longer crashes

Notes
Root cause is upstream in node-pty; this PR just stops one dead PTY from taking down the main process.