### PR TITLE
fix: upgrade node-pty for Windows build support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,20 @@ Thanks for your interest in contributing! Here's how to get started.
 ## Development Setup
 
 1. **Node v24** is required — see `.nvmrc`. Use `nvm use` to switch.
-2. Install dependencies:
+2. **Windows only:** Visual Studio Build Tools 2022 with:
+   - "Desktop development with C++" workload
+   - MSVC v143 Spectre-mitigated libs (x86/x64) — install via the Individual Components tab, or from an admin terminal:
+     ```powershell
+     & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify `
+       --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools" `
+       --add Microsoft.VisualStudio.Component.VC.14.43.17.13.x86.x64.Spectre `
+       --quiet --norestart
+     ```
+3. Install dependencies:
    ```bash
    npm install
    ```
-3. Build and run:
+4. Build and run:
    ```bash
    npm run build
    npm start

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "dompurify": "^3.3.3",
         "electron-updater": "^6.8.3",
         "marked": "^17.0.5",
-        "node-pty": "^1.1.0",
+        "node-pty": "1.2.0-beta.12",
         "picomatch": "^4.0.3"
       },
       "bin": {
@@ -5937,9 +5937,9 @@
       }
     },
     "node_modules/node-pty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
-      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+      "integrity": "sha512-uExTCG/4VmSJa4+TjxFwPXv8BfacmfFEBL6JpxCMDghcwqzvD0yTcGmZ1fKOK6HY33tp0CelLblqTECJizc+Yw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "dompurify": "^3.3.3",
     "electron-updater": "^6.8.3",
     "marked": "^17.0.5",
-    "node-pty": "^1.1.0",
+    "node-pty": "^1.2.0-beta.12",
     "picomatch": "^4.0.3"
   }
 }


### PR DESCRIPTION
## Summary

- Upgrade `node-pty` from `^1.1.0` to `^1.2.0-beta.12` — removes winpty dependency that fails to build on Windows (`GetCommitHash.bat` not found during `electron-builder install-app-deps`)
- Add Windows prerequisites to CONTRIBUTING.md (Spectre-mitigated MSVC libs required for native module compilation)

Fixes #73, fixes #74

## Test plan

- [x] `npm install` completes without errors on Windows 11
- [x] `electron-builder install-app-deps` rebuilds node-pty successfully
- [x] App launches with `npm start`
- [x] Terminal sessions work correctly with ConPTY-only node-pty
- [ ] Verify Mac/Linux builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)