### PR TITLE
Terminal backdrops and WSL2-safe path handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1043,6 +1043,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/@gar/promise-retry": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.2.tgz",
+      "integrity": "sha512-Lm/ZLhDZcBECta3TmCQSngiQykFdfw+QtI1/GYMsZd4l3nG+P8WLB16XuS7WaBGLQ+9E+cOcWQsth9cayuGt8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@gar/promise-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.11",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
@@ -1053,109 +1076,6 @@
       },
       "peerDependencies": {
         "hono": "^4"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -1357,40 +1277,43 @@
       }
     },
     "node_modules/@npmcli/agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
-      "integrity": "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
+      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
+        "lru-cache": "^11.2.1",
         "socks-proxy-agent": "^8.0.3"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@npmcli/agent/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/@npmcli/fs": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
-      "integrity": "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@npmcli/fs/node_modules/semver": {
@@ -1414,17 +1337,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2091,13 +2003,13 @@
       "license": "MIT"
     },
     "node_modules/abbrev": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
-      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/accepts": {
@@ -2730,89 +2642,54 @@
       }
     },
     "node_modules/cacache": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
-      "integrity": "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.3.tgz",
+      "integrity": "sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/fs": "^4.0.0",
+        "@npmcli/fs": "^5.0.0",
         "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
         "minipass": "^7.0.3",
         "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^7.0.2",
-        "ssri": "^12.0.0",
-        "tar": "^7.4.3",
-        "unique-filename": "^4.0.0"
+        "ssri": "^13.0.0",
+        "unique-filename": "^5.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/cacache/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/cacache/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/cacache/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/cacache/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "20 || >=22"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -3522,13 +3399,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3817,17 +3687,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/end-of-stream": {
@@ -4281,36 +4140,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/form-data": {
@@ -4987,22 +4816,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/jake": {
       "version": "10.9.4",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
@@ -5499,26 +5312,26 @@
       }
     },
     "node_modules/make-fetch-happen": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
-      "integrity": "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==",
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.4.tgz",
+      "integrity": "sha512-vM2sG+wbVeVGYcCm16mM3d5fuem9oC28n436HjsGO3LcxoTI8LNVa4rwZDn3f76+cWyT4GGJDxjTYU1I2nr6zw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/agent": "^3.0.0",
-        "cacache": "^19.0.1",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
+        "minipass-fetch": "^5.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^1.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^12.0.0"
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/marked": {
@@ -5683,21 +5496,39 @@
       }
     },
     "node_modules/minipass-fetch": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
-      "integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
+        "minipass-sized": "^2.0.0",
         "minizlib": "^3.0.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       },
       "optionalDependencies": {
-        "encoding": "^0.1.13"
+        "iconv-lite": "^0.7.2"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minipass-flush": {
@@ -5753,26 +5584,13 @@
       }
     },
     "node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
         "node": ">=8"
@@ -5895,28 +5713,38 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.5.0.tgz",
-      "integrity": "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
+      "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^14.0.3",
-        "nopt": "^8.0.0",
-        "proc-log": "^5.0.0",
+        "make-fetch-happen": "^15.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^7.4.3",
+        "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
-        "which": "^5.0.0"
+        "which": "^6.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/node-gyp/node_modules/semver": {
@@ -5932,6 +5760,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/node-pty": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
@@ -5943,19 +5787,19 @@
       }
     },
     "node_modules/nopt": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
-      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^3.0.0"
+        "abbrev": "^4.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/normalize-url": {
@@ -6114,13 +5958,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -6150,28 +5987,31 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "8.3.0",
@@ -6315,13 +6155,13 @@
       }
     },
     "node_modules/proc-log": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
-      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/progress": {
@@ -7042,16 +6882,16 @@
       "optional": true
     },
     "node_modules/ssri": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
-      "integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.3"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/stackback": {
@@ -7112,37 +6952,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -7464,29 +7274,29 @@
       "license": "MIT"
     },
     "node_modules/unique-filename": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
-      "integrity": "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-5.0.0.tgz",
+      "integrity": "sha512-2RaJTAvAb4owyjllTfXzFClJ7WsGxlykkPvCr9pA//LD9goVq+m4PPAeBgNodGZ7nSrntT/auWpJ6Y5IFXcfjg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "unique-slug": "^5.0.0"
+        "unique-slug": "^6.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/unique-slug": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-5.0.0.tgz",
-      "integrity": "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-6.0.0.tgz",
+      "integrity": "sha512-4Lup7Ezn8W3d52/xBhZBVdx323ckxa7DEvd9kPQHppTkLoJXw6ltrBCyj5pnrxj0qKDxYMJ56CoxNuFCscdTiw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/universalify": {
@@ -7761,25 +7571,6 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "dist": "npm run build && electron-builder",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "sync": "bash scripts/sync-to-windows.sh"
   },
   "build": {
     "appId": "com.vibeyard.app",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,9 @@
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"
   },
+  "overrides": {
+    "node-gyp": "^12.1.0"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "pack": "npm run build && electron-builder --dir",
     "dist": "npm run build && electron-builder",
     "test": "vitest run",
+    "test:worktrees": "vitest run src/renderer/session-pty-cwd.test.ts src/renderer/state.test.ts src/main/git-status.test.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "sync": "bash scripts/sync-to-windows.sh"

--- a/scripts/sync-to-windows.sh
+++ b/scripts/sync-to-windows.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SRC="/home/sc7639/code/src/vibeyard/"
+DEST="/mnt/c/Users/scrot/vibeyard/"
+
+EXCLUDES=(
+  node_modules
+  dist
+  out
+  .git
+  coverage
+  .DS_Store
+  '*.tsbuildinfo'
+  '*.log'
+  squashfs-root
+)
+
+EXCLUDE_ARGS=()
+for e in "${EXCLUDES[@]}"; do
+  EXCLUDE_ARGS+=(--exclude "$e")
+done
+
+if ! command -v inotifywait &>/dev/null; then
+  echo "inotifywait not found. Install it with:"
+  echo "  sudo apt-get install inotify-tools"
+  exit 1
+fi
+
+do_sync() {
+  echo "[$(date +%H:%M:%S)] Syncing..."
+  rsync -av --delete "${EXCLUDE_ARGS[@]}" "$SRC" "$DEST"
+  echo "[$(date +%H:%M:%S)] Done."
+}
+
+# Initial sync
+do_sync
+
+echo "Watching for changes in $SRC ..."
+
+inotifywait -mrq -e modify,create,delete,move "$SRC" \
+  --exclude '(node_modules|dist|out|\.git|coverage|squashfs-root)' |
+while read -r _dir _event _file; do
+  do_sync
+done

--- a/src/main/background-image-read.candidates.test.ts
+++ b/src/main/background-image-read.candidates.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Preferences } from '../shared/types';
+
+vi.mock('./platform', () => ({
+  isWin: true,
+  isWslMode: (prefs?: Preferences) => Boolean(prefs?.wslEnabled),
+}));
+
+vi.mock('./wsl', () => ({
+  getDefaultWslDistro: () => 'Ubuntu',
+  getEffectiveDistro: (pref?: string) => pref ?? 'Ubuntu',
+  wslPathToWin: (linuxPath: string, distro = 'Ubuntu') =>
+    `\\\\wsl$\\${distro}${linuxPath.replace(/\//g, '\\')}`,
+}));
+
+import { collectBackgroundImageCandidates } from './background-image-read';
+
+describe('collectBackgroundImageCandidates (Windows + mocked WSL)', () => {
+  it('does not add \\\\wsl$\\ UNC fallbacks when WSL2 mode is off', () => {
+    const c = collectBackgroundImageCandidates('/home/u/bg.png', {
+      wslEnabled: false,
+      wslDistro: 'Ubuntu',
+    } as Preferences);
+    expect(c.some((p) => /wsl\$/i.test(p))).toBe(false);
+  });
+
+  it('adds \\\\wsl$\\ UNC fallbacks when WSL2 mode is on', () => {
+    const c = collectBackgroundImageCandidates('/home/u/bg.png', {
+      wslEnabled: true,
+      wslDistro: 'Ubuntu',
+    } as Preferences);
+    expect(c.some((p) => /wsl\$/i.test(p) && p.includes('home'))).toBe(true);
+  });
+});

--- a/src/main/background-image-read.test.ts
+++ b/src/main/background-image-read.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { sanitizeBackgroundImagePath, readBackgroundImageBuffer, readBackgroundImageAsDataUrl } from './background-image-read';
+
+describe('background-image-read', () => {
+  it('sanitize trims and strips double quotes', () => {
+    expect(sanitizeBackgroundImagePath('  "/tmp/x.jpg"  ')).toBe('/tmp/x.jpg');
+  });
+
+  it('sanitize returns null for empty', () => {
+    expect(sanitizeBackgroundImagePath('')).toBe(null);
+    expect(sanitizeBackgroundImagePath('   ')).toBe(null);
+  });
+
+  it('reads a tiny file as buffer', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'vy-bg-'));
+    const filePath = path.join(dir, 't.png');
+    await fs.writeFile(filePath, Buffer.from('hello'));
+    const hit = await readBackgroundImageBuffer(filePath, undefined, { maxBytes: 1_000_000 });
+    expect(hit?.mime).toBe('image/png');
+    expect(Buffer.from(hit!.data).toString()).toBe('hello');
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('readBackgroundImageAsDataUrl wraps buffer read', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'vy-bg2-'));
+    const filePath = path.join(dir, 'x.png');
+    await fs.writeFile(filePath, Buffer.from([0x41]));
+    const url = await readBackgroundImageAsDataUrl(filePath, undefined, { maxBytes: 1_000_000 });
+    expect(url).toMatch(/^data:image\/png;base64,/);
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+});

--- a/src/main/background-image-read.ts
+++ b/src/main/background-image-read.ts
@@ -1,0 +1,173 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { fileURLToPath } from 'node:url';
+import type { Preferences } from '../shared/types';
+import { expandUserPath } from './fs-utils';
+import { isWin, isWslMode } from './platform';
+import { resolvePathForMainProcess } from './project-fs-path';
+import { getDefaultWslDistro, getEffectiveDistro, wslPathToWin } from './wsl';
+
+/**
+ * Normalize user/IPC input into a filesystem path string.
+ */
+export function sanitizeBackgroundImagePath(raw: unknown): string | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  let s = raw.trim();
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+    s = s.slice(1, -1).trim();
+  }
+  if (s.startsWith('file://')) {
+    try {
+      s = fileURLToPath(s);
+    } catch {
+      return null;
+    }
+  }
+  return s.length > 0 ? s : null;
+}
+
+/**
+ * Paths to try in order when reading a backdrop image (first hit wins).
+ * Handles `~`, `file://`, Windows long paths, `/mnt/c/...`, and (when WSL2 mode is on) POSIX paths under the distro via `\\wsl$\...`.
+ */
+export function collectBackgroundImageCandidates(s: string, prefs?: Preferences): string[] {
+  const expanded = expandUserPath(s);
+  const out: string[] = [];
+  const add = (p: string) => {
+    if (!p) return;
+    const n = path.normalize(p);
+    const resolved = path.isAbsolute(n) ? n : path.resolve(n);
+    if (!out.includes(resolved)) out.push(resolved);
+  };
+
+  if (isWin) {
+    // `/mnt/c/Users/...` from synced prefs / WSL-style paths — resolve before `path.resolve('/')` quirks
+    const mnt = expanded.match(/^\/mnt\/([a-z])\/(.*)/i);
+    if (mnt) {
+      const drive = mnt[1].toUpperCase();
+      const tail = mnt[2].replace(/\//g, '\\');
+      add(`${drive}:\\${tail}`);
+    }
+    // Unix absolute under a WSL distro — try UNC(s) only when WSL2 execution mode is enabled
+    if (
+      isWslMode(prefs) &&
+      expanded.startsWith('/') &&
+      !expanded.startsWith('//') &&
+      !mnt
+    ) {
+      const d1 = getEffectiveDistro(prefs?.wslDistro) ?? getDefaultWslDistro();
+      if (d1) add(wslPathToWin(expanded, d1));
+      const d2 = getDefaultWslDistro();
+      if (d2 && d2 !== d1) add(wslPathToWin(expanded, d2));
+    }
+    // Avoid `path.resolve('/mnt/...')` on win32 (non-drive "absolute" paths mis-resolve)
+    const unixy = expanded.startsWith('/') && !expanded.startsWith('//');
+    if (!unixy) {
+      add(expanded);
+    }
+  } else {
+    add(expanded);
+  }
+
+  if (isWin) {
+    const primary = out[0];
+    if (
+      primary &&
+      /^[A-Za-z]:\\/.test(primary) &&
+      primary.length >= 240 &&
+      !primary.startsWith('\\\\?\\')
+    ) {
+      add(`\\\\?\\${primary}`);
+    }
+  }
+
+  return out;
+}
+
+/** Extensions accepted for terminal backdrop images (main + renderer browse filters). */
+export const BACKGROUND_IMAGE_EXT_TO_MIME: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.jfif': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.bmp': 'image/bmp',
+};
+
+export type BackgroundImageReadResult = { mime: string; data: Buffer };
+
+/** Extra strings to try for `fs.stat` (Windows drive paths + mixed slashes). */
+function fsPathStatVariants(candidate: string): string[] {
+  const out: string[] = [];
+  const add = (p: string) => {
+    if (p && !out.includes(p)) out.push(p);
+  };
+  add(candidate);
+  if (isWin) {
+    try {
+      add(path.win32.normalize(candidate));
+    } catch {
+      /* ignore */
+    }
+    const m = candidate.match(/^([A-Za-z]):[\\/]+(.*)$/);
+    if (m) {
+      add(`${m[1].toUpperCase()}:\\${m[2].replace(/\//g, '\\')}`);
+    }
+  }
+  return out;
+}
+
+/** Read image bytes from disk (used for renderer Blob URLs — avoids huge data: strings over IPC/CSS). */
+export async function readBackgroundImageBuffer(
+  raw: unknown,
+  prefs: Preferences | undefined,
+  options: { maxBytes: number; extToMime?: Record<string, string> },
+): Promise<BackgroundImageReadResult | null> {
+  const s = sanitizeBackgroundImagePath(raw);
+  if (!s) return null;
+  const extToMime = { ...BACKGROUND_IMAGE_EXT_TO_MIME, ...options.extToMime };
+  const expanded = expandUserPath(s);
+
+  /** Try dialog-style Windows paths before `resolvePathForMainProcess` (avoids rare resolve quirks). */
+  const head: string[] = [];
+  if (isWin && /^[A-Za-z]:[\\/]/.test(expanded)) {
+    head.push(path.win32.normalize(expanded));
+  }
+
+  const primary = resolvePathForMainProcess(expanded);
+  const rest = collectBackgroundImageCandidates(s, prefs);
+  const candidates = [...head, primary, ...rest.filter((c) => c !== primary && !head.includes(c))];
+
+  for (const candidate of candidates) {
+    for (const tryPath of fsPathStatVariants(candidate)) {
+      let stat: Awaited<ReturnType<typeof fs.stat>>;
+      try {
+        stat = await fs.stat(tryPath);
+      } catch {
+        continue;
+      }
+      if (!stat.isFile() || stat.size > options.maxBytes) continue;
+      const ext = path.extname(tryPath).toLowerCase();
+      const mime = extToMime[ext];
+      if (!mime) continue;
+      try {
+        const data = await fs.readFile(tryPath);
+        return { mime, data };
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}
+
+export async function readBackgroundImageAsDataUrl(
+  raw: unknown,
+  prefs: Preferences | undefined,
+  options: { maxBytes: number; extToMime?: Record<string, string> },
+): Promise<string | null> {
+  const hit = await readBackgroundImageBuffer(raw, prefs, options);
+  if (!hit) return null;
+  return `data:${hit.mime};base64,${hit.data.toString('base64')}`;
+}

--- a/src/main/claude-cli.ts
+++ b/src/main/claude-cli.ts
@@ -1,13 +1,69 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { homedir } from 'os';
-import { STATUS_DIR, getStatusLineScriptPath } from './hook-status';
+import { STATUS_DIR, getStatusDirForHookEmbed, getStatusLineScriptPath } from './hook-status';
+import { joinStoredProjectPath } from './project-fs-path';
 import { statusCmd as mkStatusCmd, captureSessionIdCmd as mkCaptureSessionIdCmd, captureToolFailureCmd as mkCaptureToolFailureCmd, installEventScript, wrapPythonHookCmd, installHookScripts } from './hook-commands';
 import { readJsonSafe, readDirSafe } from './fs-utils';
 import { getSupportedHookEvents as computeSupportedHookEvents } from './claude-hook-versions';
 import { getClaudeVersion } from './providers/claude-version';
 import { resolveBinary } from './providers/resolve-binary';
+import { isWin, isWslMode } from './platform';
+import { loadState } from './store';
+import { getEffectiveDistro, getWslHome, normalizeProjectPathForWslStorage, wslPathToWin } from './wsl';
 import type { McpServer, Agent, Skill, Command, ClaudeConfig, InspectorEventType } from '../shared/types';
+
+/**
+ * Returns the effective home directory for Claude config operations.
+ * In WSL mode, this is the WSL user's home via UNC path; otherwise the
+ * native Windows/macOS/Linux home.
+ */
+function effectiveHome(): string {
+  const state = loadState();
+  if (isWslMode(state.preferences)) {
+    const distro = getEffectiveDistro(state.preferences.wslDistro) ?? undefined;
+    return wslPathToWin(getWslHome(distro), distro);
+  }
+  return homedir();
+}
+
+/** User home for CLI config and data files (WSL home as UNC when WSL mode on Windows). */
+export function getEffectiveCliUserHome(): string {
+  return effectiveHome();
+}
+
+function claudeProjectsPathNorm(p: string): string {
+  const state = loadState();
+  const distro = isWin && isWslMode(state.preferences) ? getEffectiveDistro(state.preferences.wslDistro) ?? undefined : undefined;
+  return normalizeProjectPathForWslStorage(p, distro);
+}
+
+function matchingClaudeProjectJsonKeys(projects: Record<string, unknown>, projectPath: string): string[] {
+  const want = claudeProjectsPathNorm(projectPath);
+  return Object.keys(projects).filter((k) => claudeProjectsPathNorm(k) === want);
+}
+
+function canonicalClaudeJsonProjectKey(projectPath: string): string {
+  return claudeProjectsPathNorm(projectPath);
+}
+
+/** Slugs used under ~/.claude/projects/<slug>/ (may differ for UNC vs Linux path). */
+export function claudeProjectDirSlugs(projectPath: string): string[] {
+  const s = new Set<string>();
+  const slug = (p: string) => p.replace(/[^a-zA-Z0-9]/g, '-');
+  s.add(slug(projectPath));
+  s.add(slug(claudeProjectsPathNorm(projectPath)));
+  if (isWin && isWslMode(loadState().preferences)) {
+    try {
+      const distro = getEffectiveDistro(loadState().preferences.wslDistro) ?? undefined;
+      const linux = claudeProjectsPathNorm(projectPath);
+      s.add(slug(wslPathToWin(linux, distro)));
+    } catch {
+      /* ignore */
+    }
+  }
+  return [...s];
+}
 
 export type { McpServer, Agent, Skill, Command, ClaudeConfig } from '../shared/types';
 
@@ -77,7 +133,7 @@ function readAgentsFromDir(dirPath: string, scope: 'user' | 'project', category:
 
 /** Read agents from installed plugins */
 function readPluginAgents(): Agent[] {
-  const installedPath = path.join(homedir(), '.claude', 'plugins', 'installed_plugins.json');
+  const installedPath = path.join(effectiveHome(), '.claude', 'plugins', 'installed_plugins.json');
   const installed = readJsonSafe(installedPath);
   if (!installed || typeof installed.plugins !== 'object' || installed.plugins === null) return [];
 
@@ -98,7 +154,7 @@ function readPluginAgents(): Agent[] {
 
 /** Read skills from installed plugins */
 function readPluginSkills(): Skill[] {
-  const installedPath = path.join(homedir(), '.claude', 'plugins', 'installed_plugins.json');
+  const installedPath = path.join(effectiveHome(), '.claude', 'plugins', 'installed_plugins.json');
   const installed = readJsonSafe(installedPath);
   if (!installed || typeof installed.plugins !== 'object' || installed.plugins === null) return [];
 
@@ -155,7 +211,7 @@ function readSkillsFromDir(dirPath: string, scope: 'user' | 'project'): Skill[] 
 
 /** Get set of enabled plugin IDs from user settings */
 function getEnabledPlugins(): Set<string> {
-  const settings = readJsonSafe(path.join(homedir(), '.claude', 'settings.json'));
+  const settings = readJsonSafe(path.join(effectiveHome(), '.claude', 'settings.json'));
   if (!settings || typeof settings.enabledPlugins !== 'object' || settings.enabledPlugins === null) {
     return new Set();
   }
@@ -196,7 +252,7 @@ function isIdeHook(h: HookHandler): boolean {
  * Read and clean Claude settings, returning the settings object and cleaned hooks.
  */
 function prepareSettings(): { settings: Record<string, unknown>; cleaned: HooksConfig } {
-  const settingsPath = path.join(homedir(), '.claude', 'settings.json');
+  const settingsPath = path.join(effectiveHome(), '.claude', 'settings.json');
   let settings: Record<string, unknown> = {};
   try {
     settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
@@ -224,7 +280,7 @@ function prepareSettings(): { settings: Record<string, unknown>; cleaned: HooksC
 }
 
 function writeSettings(settings: Record<string, unknown>): void {
-  const settingsPath = path.join(homedir(), '.claude', 'settings.json');
+  const settingsPath = path.join(effectiveHome(), '.claude', 'settings.json');
   fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
   fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
 }
@@ -252,6 +308,7 @@ export function installHooksOnly(): void {
   // Hook to capture inspector events (tool names, cost snapshots, timestamps) into a JSONL log.
   // Each hook event appends one JSON line to STATUS_DIR/{sessionId}.events
   const captureEventCmd = (hookEvent: string, eventType: string) => {
+    const statusDirEmbed = getStatusDirForHookEmbed().replace(/\\/g, '\\\\');
     const pyCode = `import sys,json,os,time
 try:
  d=json.load(sys.stdin)
@@ -285,7 +342,7 @@ if cw:
   "context_window_size":cw.get("context_window_size",200000),
   "used_percentage":cw.get("used_percentage",0)
  }
-status_dir=r'${STATUS_DIR}'
+status_dir=r'${statusDirEmbed}'
 if tn and "${hookEvent}"=="PostToolUse":
  import random,string as st
  tr=d.get("tool_result","") or d.get("tool_response","")
@@ -384,7 +441,7 @@ with open(os.path.join(status_dir,sid+".events"),"a") as f:
  * Install only the statusLine setting (exclusive — overwrites any existing value).
  */
 export function installStatusLine(): void {
-  const settingsPath = path.join(homedir(), '.claude', 'settings.json');
+  const settingsPath = path.join(effectiveHome(), '.claude', 'settings.json');
   let settings: Record<string, unknown> = {};
   try {
     settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
@@ -426,14 +483,18 @@ function readMcpFromClaudeJson(filePath: string, projectPath?: string): McpServe
   // Project-specific (local scope) servers stored under projects key
   if (projectPath && typeof json.projects === 'object' && json.projects !== null) {
     const projects = json.projects as Record<string, Record<string, unknown>>;
-    const projectEntry = projects[projectPath];
-    if (projectEntry && typeof projectEntry.mcpServers === 'object' && projectEntry.mcpServers !== null) {
-      for (const [name, config] of Object.entries(projectEntry.mcpServers as Record<string, unknown>)) {
-        const cfg = config as Record<string, unknown>;
-        const url = (cfg.url as string) || (cfg.command as string) || '';
-        servers.push({ name, url, status: 'configured', scope: 'project', filePath });
+    const byName = new Map<string, McpServer>();
+    for (const key of matchingClaudeProjectJsonKeys(projects, projectPath)) {
+      const projectEntry = projects[key];
+      if (projectEntry && typeof projectEntry.mcpServers === 'object' && projectEntry.mcpServers !== null) {
+        for (const [name, config] of Object.entries(projectEntry.mcpServers as Record<string, unknown>)) {
+          const cfg = config as Record<string, unknown>;
+          const url = (cfg.url as string) || (cfg.command as string) || '';
+          byName.set(name, { name, url, status: 'configured', scope: 'project', filePath });
+        }
       }
     }
+    for (const s of byName.values()) servers.push(s);
   }
 
   return servers;
@@ -472,16 +533,22 @@ export function addMcpServer(
   scope: 'user' | 'project',
   projectPath?: string,
 ): void {
-  const filePath = path.join(homedir(), '.claude.json');
+  const filePath = path.join(effectiveHome(), '.claude.json');
   const json = readJsonSafe(filePath) ?? {};
 
   if (scope === 'project' && projectPath) {
     const projects = (json.projects ?? {}) as Record<string, Record<string, unknown>>;
-    const entry = projects[projectPath] ?? {};
-    const servers = (entry.mcpServers ?? {}) as Record<string, unknown>;
+    const canonical = canonicalClaudeJsonProjectKey(projectPath);
+    const aliasKeys = matchingClaudeProjectJsonKeys(projects, projectPath);
+    let merged: Record<string, unknown> = {};
+    for (const k of aliasKeys) {
+      merged = { ...merged, ...projects[k] };
+      if (k !== canonical) delete projects[k];
+    }
+    const servers = (merged.mcpServers ?? {}) as Record<string, unknown>;
     servers[name] = config;
-    entry.mcpServers = servers;
-    projects[projectPath] = entry;
+    merged.mcpServers = servers;
+    projects[canonical] = merged;
     json.projects = projects;
   } else {
     const servers = (json.mcpServers ?? {}) as Record<string, unknown>;
@@ -507,10 +574,13 @@ export function removeMcpServer(
 
   if (scope === 'project' && projectPath) {
     const projects = json.projects as Record<string, Record<string, unknown>> | undefined;
-    const entry = projects?.[projectPath];
-    if (entry && typeof entry.mcpServers === 'object' && entry.mcpServers !== null) {
-      const servers = entry.mcpServers as Record<string, unknown>;
-      delete servers[name];
+    if (!projects) return;
+    for (const key of matchingClaudeProjectJsonKeys(projects, projectPath)) {
+      const entry = projects[key];
+      if (entry && typeof entry.mcpServers === 'object' && entry.mcpServers !== null) {
+        const servers = entry.mcpServers as Record<string, unknown>;
+        delete servers[name];
+      }
     }
   } else {
     if (typeof json.mcpServers === 'object' && json.mcpServers !== null) {
@@ -523,7 +593,7 @@ export function removeMcpServer(
 }
 
 export async function getClaudeConfig(projectPath: string): Promise<ClaudeConfig> {
-  const home = homedir();
+  const home = effectiveHome();
   const claudeDir = path.join(home, '.claude');
 
   // MCP Servers from multiple sources (matching Claude CLI resolution order)
@@ -537,8 +607,8 @@ export async function getClaudeConfig(projectPath: string): Promise<ClaudeConfig
   );
   // 3. Project-level: .claude/settings.json and .mcp.json
   const projectServers = readMcpServers(
-    path.join(projectPath, '.claude', 'settings.json'),
-    path.join(projectPath, '.mcp.json'),
+    joinStoredProjectPath(projectPath, '.claude', 'settings.json'),
+    joinStoredProjectPath(projectPath, '.mcp.json'),
     'project',
   );
   // 4. System-managed servers
@@ -555,7 +625,7 @@ export async function getClaudeConfig(projectPath: string): Promise<ClaudeConfig
   // Agents
   const pluginAgents = readPluginAgents();
   const userAgents = readAgentsFromDir(path.join(claudeDir, 'agents'), 'user', 'plugin');
-  const projectAgents = readAgentsFromDir(path.join(projectPath, '.claude', 'agents'), 'project', 'plugin');
+  const projectAgents = readAgentsFromDir(joinStoredProjectPath(projectPath, '.claude', 'agents'), 'project', 'plugin');
 
   const agentNames = new Set<string>();
   const agents: Agent[] = [];
@@ -571,7 +641,7 @@ export async function getClaudeConfig(projectPath: string): Promise<ClaudeConfig
   // Skills
   const pluginSkills = readPluginSkills();
   const userSkills = readSkillsFromDir(path.join(claudeDir, 'skills'), 'user');
-  const projectSkills = readSkillsFromDir(path.join(projectPath, '.claude', 'skills'), 'project');
+  const projectSkills = readSkillsFromDir(joinStoredProjectPath(projectPath, '.claude', 'skills'), 'project');
 
   const skillNames = new Set<string>();
   const skills: Skill[] = [];
@@ -586,7 +656,7 @@ export async function getClaudeConfig(projectPath: string): Promise<ClaudeConfig
 
   // Commands
   const userCommands = readCommandsFromDir(path.join(claudeDir, 'commands'), 'user');
-  const projectCommands = readCommandsFromDir(path.join(projectPath, '.claude', 'commands'), 'project');
+  const projectCommands = readCommandsFromDir(joinStoredProjectPath(projectPath, '.claude', 'commands'), 'project');
 
   const commandNames = new Set<string>();
   const commands: Command[] = [];

--- a/src/main/codex-config.ts
+++ b/src/main/codex-config.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { homedir } from 'os';
 import { fileExists, readDirSafe, readFileSafe } from './fs-utils';
+import { joinStoredProjectPath } from './project-fs-path';
 import type { Agent, McpServer, ProviderConfig, Skill } from '../shared/types';
 
 function parseFrontmatter(filePath: string): Record<string, string> {
@@ -133,7 +134,7 @@ function readMcpServersFromToml(filePath: string, scope: 'user' | 'project'): Mc
 
 export async function getCodexConfig(projectPath: string): Promise<ProviderConfig> {
   const codexDir = path.join(homedir(), '.codex');
-  const projectCodexDir = path.join(projectPath, '.codex');
+  const projectCodexDir = joinStoredProjectPath(projectPath, '.codex');
 
   const userMcp = readMcpServersFromToml(path.join(codexDir, 'config.toml'), 'user');
   const projectMcp = readMcpServersFromToml(path.join(projectCodexDir, 'config.toml'), 'project');

--- a/src/main/codex-hooks.ts
+++ b/src/main/codex-hooks.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { homedir } from 'os';
-import { STATUS_DIR } from './hook-status';
+import { getStatusDirForHookEmbed } from './hook-status';
 import { statusCmd as mkStatusCmd, captureSessionIdCmd as mkCaptureSessionIdCmd, installEventScript, wrapPythonHookCmd, installHookScripts } from './hook-commands';
 import { readFileSafe, readJsonSafe } from './fs-utils';
 import type { InspectorEventType, SettingsValidationResult } from '../shared/types';
@@ -131,6 +131,7 @@ export function installCodexHooks(): void {
   const captureSessionIdCmd = mkCaptureSessionIdCmd(SESSION_ID_VAR, CODEX_HOOK_MARKER);
 
   const captureEventCmd = (hookEvent: string, eventType: string) => {
+    const statusDirEmbed = getStatusDirForHookEmbed().replace(/\\/g, '\\\\');
     const pyCode = `import sys,json,os,time
 try:
  d=json.load(sys.stdin)
@@ -150,7 +151,7 @@ for fld in ("session_id","cwd","model","turn_id"):
  v=d.get(fld,"")
  if v:
   e[fld]=v
-status_dir=r'${STATUS_DIR}'
+status_dir=r'${statusDirEmbed}'
 with open(os.path.join(status_dir,sid+".events"),"a") as f:
  f.write(json.dumps(e)+"\\n")
 `;

--- a/src/main/config-watcher.ts
+++ b/src/main/config-watcher.ts
@@ -3,6 +3,9 @@ import * as path from 'path';
 import * as os from 'os';
 import type { BrowserWindow } from 'electron';
 import type { ProviderId } from '../shared/types';
+import { isWslMode } from './platform';
+import { loadState } from './store';
+import { joinStoredProjectPath } from './project-fs-path';
 
 const DEBOUNCE_MS = 500;
 
@@ -49,27 +52,36 @@ function stopAll(): void {
 }
 
 function setupClaudeWatchers(projectPath: string): void {
-  const home = os.homedir();
+  const state = loadState();
+  let home: string;
+
+  if (isWslMode(state.preferences)) {
+    const { getWslHomePath, wslPathToWin, getEffectiveDistro } = require('./wsl') as typeof import('./wsl');
+    const distro = getEffectiveDistro(state.preferences.wslDistro) ?? undefined;
+    // Watch WSL-side config files via UNC paths
+    home = wslPathToWin(require('./wsl').getWslHome(distro), distro);
+  } else {
+    home = os.homedir();
+  }
+
   const claudeDir = path.join(home, '.claude');
 
-  // Config files
   const files = [
     path.join(home, '.claude.json'),
     path.join(claudeDir, 'settings.json'),
     path.join(home, '.mcp.json'),
-    path.join(projectPath, '.claude', 'settings.json'),
-    path.join(projectPath, '.mcp.json'),
+    joinStoredProjectPath(projectPath, '.claude', 'settings.json'),
+    joinStoredProjectPath(projectPath, '.mcp.json'),
   ];
   for (const f of files) watchFile(f);
 
-  // Directories for agents/skills/commands
   const dirs = [
     path.join(claudeDir, 'agents'),
     path.join(claudeDir, 'skills'),
     path.join(claudeDir, 'commands'),
-    path.join(projectPath, '.claude', 'agents'),
-    path.join(projectPath, '.claude', 'skills'),
-    path.join(projectPath, '.claude', 'commands'),
+    joinStoredProjectPath(projectPath, '.claude', 'agents'),
+    joinStoredProjectPath(projectPath, '.claude', 'skills'),
+    joinStoredProjectPath(projectPath, '.claude', 'commands'),
   ];
   for (const d of dirs) watchDir(d);
 }
@@ -80,15 +92,15 @@ function setupCodexWatchers(projectPath: string): void {
 
   const files = [
     path.join(codexDir, 'config.toml'),
-    path.join(projectPath, '.codex', 'config.toml'),
+    joinStoredProjectPath(projectPath, '.codex', 'config.toml'),
   ];
   for (const f of files) watchFile(f);
 
   const dirs = [
     path.join(codexDir, 'agents'),
     path.join(codexDir, 'skills'),
-    path.join(projectPath, '.codex', 'agents'),
-    path.join(projectPath, '.codex', 'skills'),
+    joinStoredProjectPath(projectPath, '.codex', 'agents'),
+    joinStoredProjectPath(projectPath, '.codex', 'skills'),
   ];
   for (const d of dirs) watchDir(d);
 }
@@ -98,7 +110,7 @@ function setupGeminiWatchers(projectPath: string): void {
 
   const files = [
     path.join(home, '.gemini', 'settings.json'),
-    path.join(projectPath, '.gemini', 'settings.json'),
+    joinStoredProjectPath(projectPath, '.gemini', 'settings.json'),
   ];
   for (const f of files) watchFile(f);
 }

--- a/src/main/gemini-config.ts
+++ b/src/main/gemini-config.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { homedir } from 'os';
 import { readJsonSafe } from './fs-utils';
+import { joinStoredProjectPath } from './project-fs-path';
 import type { McpServer, ProviderConfig } from '../shared/types';
 
 function readMcpServersFromJson(filePath: string, scope: 'user' | 'project'): McpServer[] {
@@ -19,7 +20,7 @@ function readMcpServersFromJson(filePath: string, scope: 'user' | 'project'): Mc
 
 export async function getGeminiConfig(projectPath: string): Promise<ProviderConfig> {
   const geminiDir = path.join(homedir(), '.gemini');
-  const projectGeminiDir = path.join(projectPath, '.gemini');
+  const projectGeminiDir = joinStoredProjectPath(projectPath, '.gemini');
 
   const userMcp = readMcpServersFromJson(path.join(geminiDir, 'settings.json'), 'user');
   const projectMcp = readMcpServersFromJson(path.join(projectGeminiDir, 'settings.json'), 'project');

--- a/src/main/gemini-hooks.ts
+++ b/src/main/gemini-hooks.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { homedir } from 'os';
-import { STATUS_DIR } from './hook-status';
+import { getStatusDirForHookEmbed } from './hook-status';
 import { statusCmd as mkStatusCmd, captureSessionIdCmd as mkCaptureSessionIdCmd, installEventScript, wrapPythonHookCmd, installHookScripts } from './hook-commands';
 import { readJsonSafe } from './fs-utils';
 import type { InspectorEventType, SettingsValidationResult } from '../shared/types';
@@ -65,6 +65,7 @@ export function installGeminiHooks(): void {
     mkStatusCmd(event, status, SESSION_ID_VAR, GEMINI_HOOK_MARKER);
 
   const captureEventCmd = (hookEvent: string, eventType: string) => {
+    const statusDirEmbed = getStatusDirForHookEmbed().replace(/\\/g, '\\\\');
     const pyCode = `import sys,json,os,time
 try:
  d=json.load(sys.stdin)
@@ -84,7 +85,7 @@ for fld in ("session_id","cwd"):
  v=d.get(fld,"")
  if v:
   e[fld]=v
-status_dir=r'${STATUS_DIR}'
+status_dir=r'${statusDirEmbed}'
 with open(os.path.join(status_dir,sid+".events"),"a") as f:
  f.write(json.dumps(e)+"\\n")
 `;

--- a/src/main/git-status.test.ts
+++ b/src/main/git-status.test.ts
@@ -14,7 +14,16 @@ import * as path from 'path';
 import { execFile } from 'child_process';
 import { readFileSync } from 'fs';
 import * as store from './store';
-import { getGitStatus, getGitFiles, getGitDiff, getGitWorktrees, isPathWithinKnownLinkedWorktree, clearWorktreeRootsCache } from './git-status';
+import {
+  getGitStatus,
+  getGitFiles,
+  getGitDiff,
+  getGitWorktrees,
+  isPathWithinKnownLinkedWorktree,
+  clearWorktreeRootsCache,
+  resolveWorktreeDestination,
+  createGitWorktree,
+} from './git-status';
 
 const mockExecFile = vi.mocked(execFile);
 const mockReadFileSync = vi.mocked(readFileSync);
@@ -371,5 +380,55 @@ describe('linked worktree path helpers', () => {
     simulateExecFile(new Error('git failed') as ExecFileException, '');
     await getGitWorktrees('/repo');
     expect(isPathWithinKnownLinkedWorktree(path.resolve('/repo-wt/x'))).toBe(false);
+  });
+});
+
+describe('resolveWorktreeDestination', () => {
+  it('joins a relative path to the parent of the repo root', () => {
+    expect(resolveWorktreeDestination('/home/u/code/src/fridge-inventory-app', 'fridge-wt')).toBe(
+      path.normalize('/home/u/code/src/fridge-wt'),
+    );
+  });
+
+  it('does not nest under the repo directory', () => {
+    expect(resolveWorktreeDestination('/repo/my-app', 'wt')).toBe(path.normalize('/repo/wt'));
+  });
+
+  it('leaves absolute paths unchanged (only normalizes)', () => {
+    expect(resolveWorktreeDestination('/repo/my-app', '/tmp/explicit-wt')).toBe('/tmp/explicit-wt');
+  });
+});
+
+describe('createGitWorktree', () => {
+  const noWslPrefs = {
+    version: 1 as const,
+    activeProjectId: null,
+    projects: [],
+    preferences: {
+      soundOnSessionWaiting: true,
+      notificationsDesktop: true,
+      debugMode: false,
+      sessionHistoryEnabled: true,
+      insightsEnabled: true,
+      autoTitleEnabled: true,
+    },
+  };
+
+  it('passes repo-parent-relative path to git worktree add', async () => {
+    vi.spyOn(store, 'loadState').mockReturnValue(noWslPrefs as never);
+    simulateExecFile(null, '');
+    await createGitWorktree('/home/u/code/src/my-app', 'parallel-wt');
+    const args = mockExecFile.mock.calls[0][1] as string[];
+    expect(args).toContain(path.normalize('/home/u/code/src/parallel-wt'));
+    expect(args.join(' ')).toContain('worktree add');
+  });
+
+  it('passes absolute worktree path through to git', async () => {
+    vi.spyOn(store, 'loadState').mockReturnValue(noWslPrefs as never);
+    simulateExecFile(null, '');
+    const abs = path.normalize('/var/worktrees/foo');
+    await createGitWorktree('/home/u/code/src/my-app', abs);
+    const args = mockExecFile.mock.calls[0][1] as string[];
+    expect(args).toContain(abs);
   });
 });

--- a/src/main/git-status.test.ts
+++ b/src/main/git-status.test.ts
@@ -10,9 +10,11 @@ vi.mock('fs', () => ({
   readFileSync: vi.fn(),
 }));
 
+import * as path from 'path';
 import { execFile } from 'child_process';
 import { readFileSync } from 'fs';
-import { getGitStatus, getGitFiles, getGitDiff, getGitWorktrees } from './git-status';
+import * as store from './store';
+import { getGitStatus, getGitFiles, getGitDiff, getGitWorktrees, isPathWithinKnownLinkedWorktree, clearWorktreeRootsCache } from './git-status';
 
 const mockExecFile = vi.mocked(execFile);
 const mockReadFileSync = vi.mocked(readFileSync);
@@ -26,6 +28,7 @@ function simulateExecFile(err: ExecFileException | null, stdout: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  clearWorktreeRootsCache();
 });
 
 describe('getGitStatus', () => {
@@ -309,5 +312,64 @@ describe('getGitWorktrees', () => {
 
     expect(worktrees).toHaveLength(1);
     expect(worktrees[0].path).toBe('/repo');
+  });
+});
+
+describe('linked worktree path helpers', () => {
+  const mockState = {
+    version: 1 as const,
+    activeProjectId: null,
+    projects: [
+      {
+        id: 'p1',
+        name: 'Repo',
+        path: '/repo',
+        sessions: [] as never[],
+        activeSessionId: null,
+        layout: { mode: 'tabs' as const, splitPanes: [], splitDirection: 'horizontal' as const },
+      },
+    ],
+    preferences: {
+      soundOnSessionWaiting: true,
+      notificationsDesktop: true,
+      debugMode: false,
+      sessionHistoryEnabled: true,
+      insightsEnabled: true,
+      autoTitleEnabled: true,
+    },
+  };
+
+  it('treats paths under a linked worktree as in-scope when worktrees are cached', async () => {
+    vi.spyOn(store, 'loadState').mockReturnValue(mockState);
+    const output = [
+      'worktree /repo',
+      'HEAD abcdef1234567890abcdef1234567890abcdef12',
+      'branch refs/heads/main',
+      '',
+      'worktree /repo-wt',
+      'HEAD abcdef1234567890abcdef1234567890abcdef12',
+      'branch refs/heads/feature',
+    ].join('\n');
+    simulateExecFile(null, output);
+    await getGitWorktrees('/repo');
+    expect(isPathWithinKnownLinkedWorktree(path.resolve('/repo-wt/foo.ts'))).toBe(true);
+    expect(isPathWithinKnownLinkedWorktree(path.resolve('/other/outside'))).toBe(false);
+  });
+
+  it('drops cached roots when worktree list fails', async () => {
+    vi.spyOn(store, 'loadState').mockReturnValue(mockState);
+    const ok = [
+      'worktree /repo',
+      'HEAD abc',
+      '',
+      'worktree /repo-wt',
+      'HEAD abc',
+      'branch refs/heads/feature',
+    ].join('\n');
+    simulateExecFile(null, ok);
+    await getGitWorktrees('/repo');
+    simulateExecFile(new Error('git failed') as ExecFileException, '');
+    await getGitWorktrees('/repo');
+    expect(isPathWithinKnownLinkedWorktree(path.resolve('/repo-wt/x'))).toBe(false);
   });
 });

--- a/src/main/git-status.test.ts
+++ b/src/main/git-status.test.ts
@@ -397,6 +397,21 @@ describe('resolveWorktreeDestination', () => {
   it('leaves absolute paths unchanged (only normalizes)', () => {
     expect(resolveWorktreeDestination('/repo/my-app', '/tmp/explicit-wt')).toBe('/tmp/explicit-wt');
   });
+
+  it('resolves \\wsl$\\ repo + relative folder to a Linux sibling path (not under the repo)', () => {
+    expect(
+      resolveWorktreeDestination('\\\\wsl$\\Ubuntu\\home\\u\\code\\src\\audio-articles', 'companion-pdf'),
+    ).toBe('/home/u/code/src/companion-pdf');
+  });
+
+  it('does not nest a POSIX absolute destination under a \\wsl$\\ repo (win32 join bug)', () => {
+    expect(
+      resolveWorktreeDestination(
+        '\\\\wsl$\\Ubuntu\\home\\sc7639\\code\\src\\audio-articles',
+        '/home/sc7639/code/src/companion-pdf',
+      ),
+    ).toBe('/home/sc7639/code/src/companion-pdf');
+  });
 });
 
 describe('createGitWorktree', () => {

--- a/src/main/git-status.ts
+++ b/src/main/git-status.ts
@@ -311,6 +311,41 @@ export async function createGitBranch(cwd: string, branch: string): Promise<void
   await execGit(cwd, ['checkout', '-b', branch]);
 }
 
+/**
+ * Where `git worktree add` should place a new checkout.
+ * Relative segments resolve next to the repo's parent directory (sibling of the project
+ * folder), not under the repo — avoids nested worktrees inside the main tree.
+ */
+export function resolveWorktreeDestination(repoRoot: string, userWorktreePath: string): string {
+  const rootNorm = path.normalize(repoRoot.trim());
+  const wt = userWorktreePath.trim();
+  if (!wt) return wt;
+  if (path.isAbsolute(wt)) return path.normalize(wt);
+  return path.normalize(path.join(path.dirname(rootNorm), wt));
+}
+
+/** Add a linked worktree (`git worktree add`). Longer timeout for checkout-heavy trees. */
+export async function createGitWorktree(repoRoot: string, worktreePath: string, newBranch?: string): Promise<void> {
+  const g = resolveGitCommand(repoRoot);
+  const wt = resolveWorktreeDestination(repoRoot, worktreePath);
+  if (!wt) throw new Error('Worktree path is required');
+  const nb = newBranch?.trim();
+  const args = nb
+    ? (['worktree', 'add', '-b', nb, wt, 'HEAD'] as const)
+    : (['worktree', 'add', wt, 'HEAD'] as const);
+  return new Promise((resolve, reject) => {
+    execFile(
+      g.bin,
+      [...g.prefixArgs, ...args],
+      { cwd: g.execCwd, timeout: 120_000, maxBuffer: 1024 * 1024 },
+      (err) => {
+        if (err) reject(err);
+        else resolve();
+      },
+    );
+  });
+}
+
 export function gitStageFile(cwd: string, filePath: string): Promise<void> {
   return execGit(cwd, ['add', '--', filePath]);
 }

--- a/src/main/git-status.ts
+++ b/src/main/git-status.ts
@@ -3,9 +3,11 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import type { GitWorktree, GitFileEntry } from '../shared/types';
+import { expandUserPath } from './fs-utils';
 import { isWslMode } from './platform';
 import { loadState } from './store';
 import { joinStoredProjectPath, pathIsWithinStoredProject } from './project-fs-path';
+import { uncWslPathToLinuxPath } from './wsl';
 
 /**
  * Resolve the git binary and cwd for execution.
@@ -311,17 +313,52 @@ export async function createGitBranch(cwd: string, branch: string): Promise<void
   await execGit(cwd, ['checkout', '-b', branch]);
 }
 
+function collapsePosixPathSegments(p: string): string {
+  let s = p.replace(/\/+/g, '/');
+  if (s.length > 1) s = s.replace(/\/$/, '');
+  return s;
+}
+
+/**
+ * Repo root as a Linux absolute path (`/home/...`), or null when the root is a native
+ * Windows tree (`C:\...`) with no WSL UNC mapping.
+ */
+function repoRootAsLinuxForWorktree(repoRoot: string): string | null {
+  const t = repoRoot.trim();
+  const fromUnc = uncWslPathToLinuxPath(t);
+  if (fromUnc !== null) return collapsePosixPathSegments(fromUnc);
+  const slash = t.replace(/\\/g, '/');
+  if (slash.startsWith('/') && !/^[A-Za-z]:\//.test(slash)) {
+    return collapsePosixPathSegments(slash);
+  }
+  return null;
+}
+
 /**
  * Where `git worktree add` should place a new checkout.
  * Relative segments resolve next to the repo's parent directory (sibling of the project
  * folder), not under the repo — avoids nested worktrees inside the main tree.
+ *
+ * Uses `path.posix` when the repo root is Linux-shaped or `\\wsl$\...`, so a user-entered
+ * POSIX absolute path like `/home/me/wt` is never joined with `path.win32` against a UNC
+ * root (which would incorrectly nest under the project and can yield broken destinations).
  */
 export function resolveWorktreeDestination(repoRoot: string, userWorktreePath: string): string {
+  const wtExpanded = expandUserPath(userWorktreePath.trim());
+  if (!wtExpanded) return wtExpanded;
+
+  const linuxRepo = repoRootAsLinuxForWorktree(repoRoot.trim());
+  if (linuxRepo !== null) {
+    const uncDest = uncWslPathToLinuxPath(wtExpanded);
+    if (uncDest !== null) return path.posix.normalize(uncDest);
+    const wt = wtExpanded.replace(/\\/g, '/');
+    if (path.posix.isAbsolute(wt)) return path.posix.normalize(wt);
+    return path.posix.normalize(path.posix.join(path.posix.dirname(linuxRepo), wt));
+  }
+
   const rootNorm = path.normalize(repoRoot.trim());
-  const wt = userWorktreePath.trim();
-  if (!wt) return wt;
-  if (path.isAbsolute(wt)) return path.normalize(wt);
-  return path.normalize(path.join(path.dirname(rootNorm), wt));
+  if (path.isAbsolute(wtExpanded)) return path.normalize(wtExpanded);
+  return path.normalize(path.join(path.dirname(rootNorm), wtExpanded));
 }
 
 /** Add a linked worktree (`git worktree add`). Longer timeout for checkout-heavy trees. */

--- a/src/main/git-status.ts
+++ b/src/main/git-status.ts
@@ -1,9 +1,85 @@
-import { execFile } from 'child_process';
+import { execFile, execFileSync } from 'child_process';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import type { GitWorktree, GitFileEntry } from '../shared/types';
+import { isWslMode } from './platform';
+import { loadState } from './store';
+import { joinStoredProjectPath, pathIsWithinStoredProject } from './project-fs-path';
+
+/**
+ * Resolve the git binary and cwd for execution.
+ * In WSL mode, routes through `wsl.exe -d <distro> -- git`.
+ */
+export function resolveGitCommand(cwd: string): { bin: string; prefixArgs: string[]; execCwd: string } {
+  const state = loadState();
+  if (isWslMode(state.preferences)) {
+    const { getEffectiveDistro, winPathToWsl, uncWslPathToLinuxPath } = require('./wsl') as typeof import('./wsl');
+    const distro = getEffectiveDistro(state.preferences.wslDistro) || 'Ubuntu';
+    const fromUnc = uncWslPathToLinuxPath(cwd);
+    const linuxCwd = fromUnc
+      ? fromUnc
+      : cwd.includes('\\') || /^[A-Za-z]:/.test(cwd)
+        ? winPathToWsl(cwd, distro)
+        : cwd;
+    return {
+      bin: 'wsl.exe',
+      prefixArgs: ['-d', distro, '--', 'git', '-C', linuxCwd],
+      execCwd: os.tmpdir(),
+    };
+  }
+  return { bin: 'git', prefixArgs: [], execCwd: cwd };
+}
+
+/** Tracked file paths from `git ls-files` (works with POSIX project roots in WSL mode). */
+export function getGitTrackedFiles(projectPath: string): string[] {
+  const g = resolveGitCommand(projectPath);
+  try {
+    const out = execFileSync(g.bin, [...g.prefixArgs, 'ls-files'], {
+      cwd: g.execCwd,
+      encoding: 'utf-8',
+      timeout: 5000,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return out.split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
 
 export type { GitWorktree, GitFileEntry } from '../shared/types';
+
+/** Queried project path → non-bare worktree roots (for fs access + watchers). */
+const worktreeRootsByProject = new Map<string, string[]>();
+
+function worktreeCacheKey(projectPath: string): string {
+  return projectPath.replace(/\\/g, '/');
+}
+
+export function clearWorktreeRootsCache(): void {
+  worktreeRootsByProject.clear();
+}
+
+function recordWorktreeRoots(projectPath: string, worktrees: GitWorktree[]): void {
+  const roots = worktrees.filter((w) => !w.isBare).map((w) => w.path.replace(/\\/g, '/'));
+  worktreeRootsByProject.set(worktreeCacheKey(projectPath), roots);
+}
+
+/**
+ * True when the path lies under a linked worktree of a known project (sibling dirs, etc.).
+ * Populated when `getGitWorktrees` runs for that project's stored root path.
+ */
+export function isPathWithinKnownLinkedWorktree(resolvedAbsolute: string): boolean {
+  const state = loadState();
+  for (const p of state.projects) {
+    const roots = worktreeRootsByProject.get(worktreeCacheKey(p.path));
+    if (!roots) continue;
+    for (const root of roots) {
+      if (pathIsWithinStoredProject(resolvedAbsolute, root)) return true;
+    }
+  }
+  return false;
+}
 
 export interface GitStatus {
   isGitRepo: boolean;
@@ -29,10 +105,11 @@ const NOT_A_REPO: GitStatus = {
 
 export function getGitStatus(cwd: string): Promise<GitStatus> {
   return new Promise((resolve) => {
+    const g = resolveGitCommand(cwd);
     execFile(
-      'git',
-      ['status', '--porcelain=v2', '--branch'],
-      { cwd, timeout: 5000 },
+      g.bin,
+      [...g.prefixArgs, 'status', '--porcelain=v2', '--branch'],
+      { cwd: g.execCwd, timeout: 5000 },
       (err, stdout) => {
         if (err) {
           resolve(NOT_A_REPO);
@@ -90,8 +167,7 @@ export function getGitStatus(cwd: string): Promise<GitStatus> {
 export function getGitDiff(cwd: string, filePath: string, area: string): Promise<string> {
   return new Promise((resolve) => {
     if (area === 'untracked') {
-      // Read file content and format as "all added" diff
-      const fullPath = path.join(cwd, filePath);
+      const fullPath = joinStoredProjectPath(cwd, filePath);
       try {
         const content = fs.readFileSync(fullPath, 'utf-8');
         const lines = content.split('\n');
@@ -104,14 +180,15 @@ export function getGitDiff(cwd: string, filePath: string, area: string): Promise
       return;
     }
 
-    const args = area === 'staged'
+    const diffArgs = area === 'staged'
       ? ['diff', '--cached', '--', filePath]
       : ['diff', '--', filePath];
 
+    const g = resolveGitCommand(cwd);
     execFile(
-      'git',
-      args,
-      { cwd, timeout: 10000, maxBuffer: 1024 * 1024 },
+      g.bin,
+      [...g.prefixArgs, ...diffArgs],
+      { cwd: g.execCwd, timeout: 10000, maxBuffer: 1024 * 1024 },
       (err, stdout) => {
         if (err && !stdout) {
           resolve('(no diff available)');
@@ -134,10 +211,11 @@ function xyToStatus(ch: string): 'added' | 'modified' | 'deleted' | 'renamed' {
 
 export function getGitFiles(cwd: string): Promise<GitFileEntry[]> {
   return new Promise((resolve) => {
+    const g = resolveGitCommand(cwd);
     execFile(
-      'git',
-      ['status', '--porcelain=v2'],
-      { cwd, timeout: 5000, maxBuffer: 1024 * 1024 },
+      g.bin,
+      [...g.prefixArgs, 'status', '--porcelain=v2'],
+      { cwd: g.execCwd, timeout: 5000, maxBuffer: 1024 * 1024 },
       (err, stdout) => {
         if (err) {
           resolve([]);
@@ -186,8 +264,9 @@ export function getGitFiles(cwd: string): Promise<GitFileEntry[]> {
 }
 
 function execGit(cwd: string, args: string[]): Promise<void> {
+  const g = resolveGitCommand(cwd);
   return new Promise((resolve, reject) => {
-    execFile('git', args, { cwd, timeout: 5000 }, (err) => {
+    execFile(g.bin, [...g.prefixArgs, ...args], { cwd: g.execCwd, timeout: 5000 }, (err) => {
       if (err) reject(err);
       else resolve();
     });
@@ -195,8 +274,9 @@ function execGit(cwd: string, args: string[]): Promise<void> {
 }
 
 function execGitWithOutput(cwd: string, args: string[]): Promise<string> {
+  const g = resolveGitCommand(cwd);
   return new Promise((resolve, reject) => {
-    execFile('git', args, { cwd, timeout: 5000, maxBuffer: 1024 * 1024 }, (err, stdout) => {
+    execFile(g.bin, [...g.prefixArgs, ...args], { cwd: g.execCwd, timeout: 5000, maxBuffer: 1024 * 1024 }, (err, stdout) => {
       if (err) reject(err);
       else resolve(stdout);
     });
@@ -241,7 +321,7 @@ export function gitUnstageFile(cwd: string, filePath: string): Promise<void> {
 
 export function gitDiscardFile(cwd: string, filePath: string, area: GitFileEntry['area']): Promise<void> {
   if (area === 'untracked') {
-    const fullPath = path.join(cwd, filePath);
+    const fullPath = joinStoredProjectPath(cwd, filePath);
     return fs.promises.unlink(fullPath);
   }
   return execGit(cwd, ['checkout', '--', filePath]);
@@ -249,12 +329,15 @@ export function gitDiscardFile(cwd: string, filePath: string, area: GitFileEntry
 
 export function getGitWorktrees(cwd: string): Promise<GitWorktree[]> {
   return new Promise((resolve) => {
+    const g = resolveGitCommand(cwd);
     execFile(
-      'git',
-      ['worktree', 'list', '--porcelain'],
-      { cwd, timeout: 5000 },
+      g.bin,
+      [...g.prefixArgs, 'worktree', 'list', '--porcelain'],
+      { cwd: g.execCwd, timeout: 5000 },
       (err, stdout) => {
+        const key = worktreeCacheKey(cwd);
         if (err) {
+          worktreeRootsByProject.delete(key);
           resolve([]);
           return;
         }
@@ -291,6 +374,7 @@ export function getGitWorktrees(cwd: string): Promise<GitWorktree[]> {
           }
         }
 
+        recordWorktreeRoots(cwd, worktrees);
         resolve(worktrees);
       }
     );
@@ -299,7 +383,8 @@ export function getGitWorktrees(cwd: string): Promise<GitWorktree[]> {
 
 export function getGitRemoteUrl(cwd: string): Promise<string | null> {
   return new Promise((resolve) => {
-    execFile('git', ['remote', 'get-url', 'origin'], { cwd }, (err, stdout) => {
+    const g = resolveGitCommand(cwd);
+    execFile(g.bin, [...g.prefixArgs, 'remote', 'get-url', 'origin'], { cwd: g.execCwd }, (err, stdout) => {
       if (err) { resolve(null); return; }
       const raw = stdout.trim();
       // Normalize SSH (git@github.com:owner/repo.git) to HTTPS

--- a/src/main/git-watcher.ts
+++ b/src/main/git-watcher.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFile } from 'child_process';
 import type { BrowserWindow } from 'electron';
+import { resolveGitCommand, getGitWorktrees } from './git-status';
+import { joinStoredProjectPath, projectRootForFsWatch, storedPathToMainFs } from './project-fs-path';
 
 const DEBOUNCE_MS = 300;
 const IGNORE_SEGMENTS = new Set(['.git', 'node_modules', 'dist', 'build', '.next', '.cache', 'coverage', '__pycache__']);
@@ -40,15 +42,17 @@ function watchDir(dirPath: string, shouldSkip?: (filename: string | null) => boo
 }
 
 function resolveGitDir(projectPath: string): Promise<string> {
+  const g = resolveGitCommand(projectPath);
   return new Promise((resolve) => {
-    execFile('git', ['rev-parse', '--git-dir'], { cwd: projectPath, timeout: 3000 }, (err, stdout) => {
+    execFile(g.bin, [...g.prefixArgs, 'rev-parse', '--git-dir'], { cwd: g.execCwd, timeout: 3000 }, (err, stdout) => {
       if (err) {
-        resolve(path.join(projectPath, '.git'));
+        resolve(joinStoredProjectPath(projectPath, '.git'));
         return;
       }
-      const gitDir = stdout.trim();
-      // Could be absolute or relative
-      resolve(path.isAbsolute(gitDir) ? gitDir : path.join(projectPath, gitDir));
+      const raw = stdout.trim().replace(/\\/g, '/');
+      const root = projectPath.replace(/\\/g, '/');
+      const gitDir = path.posix.isAbsolute(raw) ? raw : path.posix.join(root, raw);
+      resolve(storedPathToMainFs(gitDir));
     });
   });
 }
@@ -73,8 +77,19 @@ async function setupWatchers(projectPath: string): Promise<void> {
   // Watch refs for commits, branch creation/deletion, remote updates
   watchDir(path.join(gitDir, 'refs'));
 
-  // Watch working tree for file edits, filtering out ignored directories
-  watchDir(projectPath, shouldIgnore);
+  // Watch every linked worktree working tree (main checkout + `git worktree add` paths)
+  const worktrees = await getGitWorktrees(projectPath);
+  const watchedRoots = new Set<string>();
+  for (const wt of worktrees) {
+    if (wt.isBare) continue;
+    const fsRoot = projectRootForFsWatch(wt.path);
+    if (watchedRoots.has(fsRoot)) continue;
+    watchedRoots.add(fsRoot);
+    watchDir(fsRoot, shouldIgnore);
+  }
+  if (watchedRoots.size === 0) {
+    watchDir(projectRootForFsWatch(projectPath), shouldIgnore);
+  }
 
   // Watch HEAD file directly for reliable branch-switch detection.
   // The recursive .git/ watcher may miss HEAD changes when macOS FSEvents

--- a/src/main/hook-commands.ts
+++ b/src/main/hook-commands.ts
@@ -13,7 +13,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { STATUS_DIR, SCRIPT_DIR } from './hook-status';
+import { STATUS_DIR, SCRIPT_DIR, getWslHookPaths } from './hook-status';
 import { isWin, pythonBin as PY } from './platform';
 
 // Python helper scripts are written to STATUS_DIR via installEventScript()
@@ -83,6 +83,11 @@ export function statusCmd(
   sessionIdVar: string,
   hookMarker: string,
 ): string {
+  const wslPaths = getWslHookPaths();
+  if (wslPaths) {
+    const py = `${wslPaths.scriptDir}/status_writer.py`;
+    return `sh -c 'mkdir -p ${wslPaths.statusDir} && echo ${event}:${status} > ${wslPaths.statusDir}/$${sessionIdVar}.status ${hookMarker}'`;
+  }
   if (isWin) {
     const py = path.join(SCRIPT_DIR, 'status_writer.py').replace(/\\/g, '/');
     const dir = STATUS_DIR.replace(/\\/g, '/');
@@ -98,6 +103,11 @@ export function captureSessionIdCmd(
   sessionIdVar: string,
   hookMarker: string,
 ): string {
+  const wslPaths = getWslHookPaths();
+  if (wslPaths) {
+    const py = `${wslPaths.scriptDir}/session_id_capture.py`;
+    return `${wslPaths.pythonBin} "${py}" "${sessionIdVar}" "${wslPaths.statusDir}" "${hookMarker}"`;
+  }
   const py = path.join(SCRIPT_DIR, 'session_id_capture.py').replace(/\\/g, '/');
   const dir = STATUS_DIR.replace(/\\/g, '/');
   return `${PY} "${py}" "${sessionIdVar}" "${dir}" "${hookMarker}"`;
@@ -110,6 +120,11 @@ export function captureToolFailureCmd(
   sessionIdVar: string,
   hookMarker: string,
 ): string {
+  const wslPaths = getWslHookPaths();
+  if (wslPaths) {
+    const py = `${wslPaths.scriptDir}/tool_failure_capture.py`;
+    return `${wslPaths.pythonBin} "${py}" "${sessionIdVar}" "${wslPaths.statusDir}" "${hookMarker}"`;
+  }
   const py = path.join(SCRIPT_DIR, 'tool_failure_capture.py').replace(/\\/g, '/');
   const dir = STATUS_DIR.replace(/\\/g, '/');
   return `${PY} "${py}" "${sessionIdVar}" "${dir}" "${hookMarker}"`;
@@ -144,6 +159,11 @@ export function wrapPythonHookCmd(
   hookMarker: string,
   _pipeStdin = true,
 ): string {
+  const wslPaths = getWslHookPaths();
+  if (wslPaths) {
+    const pyCmd = `${wslPaths.scriptDir}/${scriptName}`;
+    return `${wslPaths.pythonBin} "${pyCmd}" "${hookMarker}"`;
+  }
   const pyCmd = path.join(SCRIPT_DIR, scriptName).replace(/\\/g, '/');
   return `${PY} "${pyCmd}" "${hookMarker}"`;
 }

--- a/src/main/hook-status.ts
+++ b/src/main/hook-status.ts
@@ -2,11 +2,39 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { BrowserWindow } from 'electron';
-import { isWin } from './platform';
+import { isWin, isWslMode } from './platform';
+import { loadState } from './store';
 
 export const STATUS_DIR = path.join(os.tmpdir(), 'vibeyard');
 export const SCRIPT_DIR = path.join(os.homedir(), '.vibeyard', 'run');
 const STATUSLINE_SCRIPT = path.join(SCRIPT_DIR, isWin ? 'statusline.cmd' : 'statusline.sh');
+
+/**
+ * When WSL mode is active, return the STATUS_DIR and SCRIPT_DIR as Linux paths
+ * that are accessible from both Windows (for watching) and WSL (for writing).
+ * The Windows temp dir maps to `/mnt/c/...` inside WSL.
+ */
+export function getWslHookPaths(): { statusDir: string; scriptDir: string; pythonBin: string; statusLineScript: string } | null {
+  const state = loadState();
+  if (!isWslMode(state.preferences)) return null;
+  const { winPathToWsl, getEffectiveDistro } = require('./wsl') as typeof import('./wsl');
+  const distro = getEffectiveDistro(state.preferences.wslDistro);
+  return {
+    statusDir: winPathToWsl(STATUS_DIR, distro ?? undefined),
+    scriptDir: winPathToWsl(SCRIPT_DIR, distro ?? undefined),
+    pythonBin: '/usr/bin/python3',
+    statusLineScript: winPathToWsl(SCRIPT_DIR, distro ?? undefined) + '/statusline.sh',
+  };
+}
+
+/**
+ * Path to embed in generated Python hook scripts. In WSL mode this is a Linux path
+ * (`/mnt/c/...`) so scripts running inside WSL can open status files.
+ */
+export function getStatusDirForHookEmbed(): string {
+  const wslPaths = getWslHookPaths();
+  return wslPaths?.statusDir ?? STATUS_DIR;
+}
 
 const KNOWN_EXTENSIONS = ['.status', '.sessionid', '.cost', '.toolfailure', '.events'];
 
@@ -29,6 +57,8 @@ function isKnownExtension(filename: string): boolean {
 }
 
 export function getStatusLineScriptPath(): string {
+  const wslPaths = getWslHookPaths();
+  if (wslPaths) return wslPaths.statusLineScript;
   return STATUSLINE_SCRIPT;
 }
 
@@ -42,8 +72,44 @@ export function installStatusLineScript(): void {
   // interfere with cmd.exe's >> redirection parsing on some Windows versions.
   const statusDir = STATUS_DIR.replace(/\\/g, '/');
 
+  const wslPaths = getWslHookPaths();
+
   let script: string;
-  if (isWin) {
+  if (wslPaths) {
+    // WSL mode: generate a Unix shell script that writes to the shared temp dir
+    // (the Windows temp dir mounted inside WSL via /mnt/c/...)
+    const wslStatusDir = wslPaths.statusDir;
+    script = `#!/bin/sh
+/usr/bin/python3 -c "
+import sys,json,os
+try:
+    d=json.load(sys.stdin)
+except:
+    sys.exit(0)
+sid=os.environ.get('CLAUDE_IDE_SESSION_ID','')
+if not sid:
+    sys.exit(0)
+cost=d.get('cost',{})
+ctx=d.get('context_window',{})
+model=d.get('model',{}).get('display_name','')
+if cost or ctx or model:
+    payload={'cost':cost,'context_window':ctx}
+    if model:
+        payload['model']=model
+    with open(f'${wslStatusDir}/{sid}.cost','w') as f:
+        json.dump(payload,f)
+claude_sid=d.get('session_id','')
+if claude_sid:
+    with open(f'${wslStatusDir}/{sid}.sessionid','w') as f:
+        f.write(claude_sid)
+" 2>>${wslStatusDir}/statusline.log
+`;
+    // Write the script to the Windows-side SCRIPT_DIR (accessible from WSL via /mnt/c/...)
+    fs.writeFileSync(STATUSLINE_SCRIPT.replace(/\.cmd$/, '.sh'), script, { mode: 0o755 });
+    // Also write a .sh copy at the standard location
+    fs.writeFileSync(path.join(SCRIPT_DIR, 'statusline.sh'), script, { mode: 0o755 });
+    return;
+  } else if (isWin) {
     // On Windows, write a Python helper script and a .cmd wrapper
     const pyScript = `import sys,json,os
 try:

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -6,10 +6,10 @@ import { execSync } from 'child_process';
 import { spawnPty, spawnShellPty, writePty, resizePty, killPty, isSilencedExit, getPtyCwd } from './pty-manager';
 import { addMcpServer, removeMcpServer } from './claude-cli';
 import type { McpServerConfig } from './claude-cli';
-import { loadState, saveState, PersistedState } from './store';
+import { loadState, saveState, PersistedState, normalizeWslProjectPaths } from './store';
 import { startWatching, cleanupSessionStatus } from './hook-status';
 import { startCodexSessionWatcher, registerPendingCodexSession, unregisterCodexSession } from './codex-session-watcher';
-import { getGitStatus, getGitFiles, getGitDiff, getGitWorktrees, gitStageFile, gitUnstageFile, gitDiscardFile, getGitRemoteUrl, listGitBranches, checkoutGitBranch, createGitBranch } from './git-status';
+import { getGitStatus, getGitFiles, getGitDiff, getGitWorktrees, gitStageFile, gitUnstageFile, gitDiscardFile, getGitRemoteUrl, listGitBranches, checkoutGitBranch, createGitBranch, isPathWithinKnownLinkedWorktree } from './git-status';
 import { startGitWatcher, stopGitWatcher, notifyGitChanged } from './git-watcher';
 import { watchFile as watchFileForChanges, unwatchFile as unwatchFileForChanges, setFileWatcherWindow } from './file-watcher';
 import { registerMcpHandlers } from './mcp-ipc-handlers';
@@ -20,23 +20,21 @@ import { buildHandoffPrompt } from './providers/resume-handoff';
 import type { ProviderId, GitFileEntry, SettingsValidationResult } from '../shared/types';
 import { analyzeReadiness } from './readiness/analyzer';
 import { expandUserPath } from './fs-utils';
-import { isMac, isWin } from './platform';
-
-/**
- * Check if a resolved path is within one of the known project directories.
- */
-function isWithinKnownProject(resolvedPath: string): boolean {
-  const state = loadState();
-  return state.projects.some(p => resolvedPath.startsWith(p.path + path.sep) || resolvedPath === p.path);
-}
+import { isMac, isWin, isWslMode } from './platform';
+import { joinStoredProjectPath, pathIsWithinStoredProject, resolvePathForMainProcess } from './project-fs-path';
+import { getEffectiveDistro, normalizeProjectPathForWslStorage } from './wsl';
 
 /**
  * Check if a resolved path is allowed for reading:
  * within a known project directory OR a known config location.
  */
-function isAllowedReadPath(resolvedPath: string): boolean {
+function isAllowedReadPath(incomingPath: string): boolean {
+  const resolved = resolvePathForMainProcess(incomingPath);
   // Allow files within known project directories
-  if (isWithinKnownProject(resolvedPath)) {
+  if (loadState().projects.some((p) => pathIsWithinStoredProject(resolved, p.path))) {
+    return true;
+  }
+  if (isPathWithinKnownLinkedWorktree(resolved)) {
     return true;
   }
 
@@ -57,7 +55,7 @@ function isAllowedReadPath(resolvedPath: string): boolean {
     allowedPaths.push('/etc/claude-code/');
   }
 
-  return allowedPaths.some(allowed => resolvedPath === allowed || resolvedPath.startsWith(allowed));
+  return allowedPaths.some((allowed) => resolved === allowed || resolved.startsWith(allowed));
 }
 
 let hookWatcherStarted = false;
@@ -158,7 +156,7 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle('fs:isDirectory', (_event, filePath: string) => {
     try {
-      return fs.statSync(expandUserPath(filePath)).isDirectory();
+      return fs.statSync(resolvePathForMainProcess(expandUserPath(filePath))).isDirectory();
     } catch {
       return false;
     }
@@ -170,7 +168,7 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle('fs:listDirs', (_event, dirPath: string, prefix?: string) => {
     try {
-      const expanded = expandUserPath(dirPath);
+      const expanded = resolvePathForMainProcess(expandUserPath(dirPath));
       const entries = fs.readdirSync(expanded, { withFileTypes: true });
       const lowerPrefix = prefix?.toLowerCase();
       return entries
@@ -188,6 +186,7 @@ export function registerIpcHandlers(): void {
   });
 
   ipcMain.handle('store:save', (_event, state: PersistedState) => {
+    normalizeWslProjectPaths(state);
     saveState(state);
   });
 
@@ -249,9 +248,27 @@ export function registerIpcHandlers(): void {
   ipcMain.handle('fs:browseDirectory', async () => {
     const win = BrowserWindow.getAllWindows()[0];
     if (!win) return null;
-    const result = await dialog.showOpenDialog(win, { properties: ['openDirectory'] });
+
+    const state = loadState();
+    const dialogOpts: Electron.OpenDialogOptions = { properties: ['openDirectory'] };
+
+    // When WSL mode is active, start the dialog in the WSL filesystem
+    if (isWslMode(state.preferences)) {
+      const { getEffectiveDistro } = require('./wsl') as typeof import('./wsl');
+      const distro = getEffectiveDistro(state.preferences.wslDistro);
+      if (distro) {
+        dialogOpts.defaultPath = `\\\\wsl$\\${distro}\\`;
+      }
+    }
+
+    const result = await dialog.showOpenDialog(win, dialogOpts);
     if (result.canceled || result.filePaths.length === 0) return null;
-    return result.filePaths[0];
+    const picked = result.filePaths[0];
+    if (isWslMode(state.preferences)) {
+      const distro = getEffectiveDistro(state.preferences.wslDistro) ?? undefined;
+      return normalizeProjectPathForWslStorage(picked, distro);
+    }
+    return picked;
   });
 
   ipcMain.on('app:focus', () => {
@@ -368,7 +385,7 @@ export function registerIpcHandlers(): void {
   });
 
   ipcMain.handle('git:openInEditor', (_event, projectPath: string, filePath: string) => {
-    const fullPath = path.join(projectPath, filePath);
+    const fullPath = joinStoredProjectPath(projectPath, filePath);
     return shell.openPath(fullPath);
   });
 
@@ -376,8 +393,10 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle('fs:listFiles', (_event, cwd: string, query: string) => {
     try {
-      const resolvedCwd = path.resolve(cwd);
-      if (!isWithinKnownProject(resolvedCwd)) {
+      const resolvedCwd = resolvePathForMainProcess(cwd);
+      const state = loadState();
+      const inProjectRoot = state.projects.some((p) => pathIsWithinStoredProject(resolvedCwd, p.path));
+      if (!inProjectRoot && !isPathWithinKnownLinkedWorktree(resolvedCwd)) {
         return [];
       }
       let files: string[];
@@ -433,8 +452,8 @@ export function registerIpcHandlers(): void {
   ipcMain.handle('fs:readFile', (_event, filePath: string) => {
     try {
       // Security: resolve to absolute and check it's within a known project directory
-      const resolved = path.resolve(filePath);
-      if (!isAllowedReadPath(resolved)) {
+      const resolved = resolvePathForMainProcess(filePath);
+      if (!isAllowedReadPath(filePath)) {
         console.warn(`fs:readFile blocked: ${resolved} is not within an allowed path`);
         return '';
       }
@@ -446,15 +465,15 @@ export function registerIpcHandlers(): void {
   });
 
   ipcMain.on('fs:watchFile', (event, filePath: string) => {
-    const resolved = path.resolve(filePath);
-    if (!isAllowedReadPath(resolved)) return;
+    const resolved = resolvePathForMainProcess(filePath);
+    if (!isAllowedReadPath(filePath)) return;
     const win = BrowserWindow.fromWebContents(event.sender);
     if (win) setFileWatcherWindow(win);
     watchFileForChanges(resolved);
   });
 
   ipcMain.on('fs:unwatchFile', (_event, filePath: string) => {
-    const resolved = path.resolve(filePath);
+    const resolved = resolvePathForMainProcess(filePath);
     unwatchFileForChanges(resolved);
   });
 
@@ -507,6 +526,35 @@ export function registerIpcHandlers(): void {
       console.error('mcp:removeServer failed:', err);
       return { success: false, error: String(err) };
     }
+  });
+
+  // ── WSL2 integration ──────────────────────────────────────────────
+
+  ipcMain.handle('wsl:isAvailable', () => {
+    if (!isWin) return false;
+    const { isWslAvailable } = require('./wsl') as typeof import('./wsl');
+    return isWslAvailable();
+  });
+
+  ipcMain.handle('wsl:getDistros', () => {
+    if (!isWin) return [];
+    const { getWslDistros } = require('./wsl') as typeof import('./wsl');
+    return getWslDistros();
+  });
+
+  ipcMain.handle('wsl:getDefaultDistro', () => {
+    if (!isWin) return null;
+    const { getDefaultWslDistro } = require('./wsl') as typeof import('./wsl');
+    return getDefaultWslDistro();
+  });
+
+  ipcMain.handle('wsl:browseDirs', (_event, dirPath: string, prefix?: string) => {
+    if (!isWin) return [];
+    const state = loadState();
+    if (!isWslMode(state.preferences)) return [];
+    const { wslListDirs, getEffectiveDistro } = require('./wsl') as typeof import('./wsl');
+    const distro = getEffectiveDistro(state.preferences.wslDistro) ?? undefined;
+    return wslListDirs(dirPath, prefix, distro);
   });
 
   registerMcpHandlers();

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -9,7 +9,7 @@ import type { McpServerConfig } from './claude-cli';
 import { loadState, saveState, PersistedState, normalizeWslProjectPaths } from './store';
 import { startWatching, cleanupSessionStatus } from './hook-status';
 import { startCodexSessionWatcher, registerPendingCodexSession, unregisterCodexSession } from './codex-session-watcher';
-import { getGitStatus, getGitFiles, getGitDiff, getGitWorktrees, gitStageFile, gitUnstageFile, gitDiscardFile, getGitRemoteUrl, listGitBranches, checkoutGitBranch, createGitBranch, isPathWithinKnownLinkedWorktree } from './git-status';
+import { getGitStatus, getGitFiles, getGitDiff, getGitWorktrees, gitStageFile, gitUnstageFile, gitDiscardFile, getGitRemoteUrl, listGitBranches, checkoutGitBranch, createGitBranch, createGitWorktree, isPathWithinKnownLinkedWorktree } from './git-status';
 import { startGitWatcher, stopGitWatcher, notifyGitChanged } from './git-watcher';
 import { watchFile as watchFileForChanges, unwatchFile as unwatchFileForChanges, setFileWatcherWindow } from './file-watcher';
 import { registerMcpHandlers } from './mcp-ipc-handlers';
@@ -281,6 +281,14 @@ export function registerIpcHandlers(): void {
   });
 
   ipcMain.handle('app:getVersion', () => app.getVersion());
+
+  ipcMain.handle('app:setZoomFactor', (event, factor: unknown) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win.isDestroyed()) return;
+    const z = typeof factor === 'number' ? factor : Number(factor);
+    if (!Number.isFinite(z) || z < 0.5 || z > 4) return;
+    win.webContents.setZoomFactor(z);
+  });
   ipcMain.handle('app:getBrowserPreloadPath', () =>
     path.join(__dirname, '..', '..', 'preload', 'preload', 'browser-tab-preload.js')
   );
@@ -383,6 +391,14 @@ export function registerIpcHandlers(): void {
     await createGitBranch(projectPath, branch);
     notifyGitChanged();
   });
+
+  ipcMain.handle(
+    'git:createWorktree',
+    async (_event, projectPath: string, worktreePath: string, newBranch?: string) => {
+      await createGitWorktree(projectPath, worktreePath, newBranch);
+      notifyGitChanged();
+    },
+  );
 
   ipcMain.handle('git:openInEditor', (_event, projectPath: string, filePath: string) => {
     const fullPath = joinStoredProjectPath(projectPath, filePath);

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { execSync } from 'child_process';
 import { spawnPty, spawnShellPty, writePty, resizePty, killPty, isSilencedExit, getPtyCwd } from './pty-manager';
-import { addMcpServer, removeMcpServer } from './claude-cli';
+import { addMcpServer, removeMcpServer, getEffectiveCliUserHome } from './claude-cli';
 import type { McpServerConfig } from './claude-cli';
 import { loadState, saveState, PersistedState, normalizeWslProjectPaths } from './store';
 import { startWatching, cleanupSessionStatus } from './hook-status';
@@ -23,6 +23,7 @@ import { expandUserPath } from './fs-utils';
 import { isMac, isWin, isWslMode } from './platform';
 import { joinStoredProjectPath, pathIsWithinStoredProject, resolvePathForMainProcess } from './project-fs-path';
 import { getEffectiveDistro, normalizeProjectPathForWslStorage } from './wsl';
+import { readBackgroundImageBuffer, BACKGROUND_IMAGE_EXT_TO_MIME } from './background-image-read';
 
 /**
  * Check if a resolved path is allowed for reading:
@@ -39,13 +40,21 @@ function isAllowedReadPath(incomingPath: string): boolean {
   }
 
   // Allow known config files/directories used by supported CLIs
-  const home = os.homedir();
-  const allowedPaths = [
-    path.join(home, '.claude.json'),
-    path.join(home, '.mcp.json'),
-    path.join(home, '.claude') + path.sep,
-    path.join(home, '.codex') + path.sep,
-  ];
+  const state = loadState();
+  const nativeHome = os.homedir();
+  const homes =
+    isWin && isWslMode(state.preferences)
+      ? [getEffectiveCliUserHome(), nativeHome]
+      : [nativeHome];
+  const allowedPaths: string[] = [];
+  for (const home of homes) {
+    allowedPaths.push(
+      path.join(home, '.claude.json'),
+      path.join(home, '.mcp.json'),
+      path.join(home, '.claude') + path.sep,
+      path.join(home, '.codex') + path.sep,
+    );
+  }
 
   if (isMac) {
     allowedPaths.push('/Library/Application Support/ClaudeCode/');
@@ -269,6 +278,26 @@ export function registerIpcHandlers(): void {
       return normalizeProjectPathForWslStorage(picked, distro);
     }
     return picked;
+  });
+
+  const MAX_BG_IMAGE_BYTES = 15 * 1024 * 1024;
+  const bgImageExtensions = Object.keys(BACKGROUND_IMAGE_EXT_TO_MIME).map((e) => e.slice(1));
+
+  ipcMain.handle('app:browseImageFile', async () => {
+    const win = BrowserWindow.getAllWindows()[0];
+    if (!win) return null;
+    const result = await dialog.showOpenDialog(win, {
+      properties: ['openFile'],
+      filters: [{ name: 'Images', extensions: bgImageExtensions }],
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+    return result.filePaths[0];
+  });
+
+  /** Returns `{ mime, data }` with `data` as `Buffer` (renderer receives `ArrayBuffer`/`Uint8Array`). */
+  ipcMain.handle('app:readBackgroundImage', async (_event, filePath: unknown) => {
+    const state = loadState();
+    return readBackgroundImageBuffer(filePath, state.preferences, { maxBytes: MAX_BG_IMAGE_BYTES });
   });
 
   ipcMain.on('app:focus', () => {
@@ -495,7 +524,8 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle('stats:getCache', () => {
     try {
-      const statsPath = path.join(os.homedir(), '.claude', 'stats-cache.json');
+      // Match ~/.claude resolution used for settings and session logs (WSL mode → distro home).
+      const statsPath = path.join(getEffectiveCliUserHome(), '.claude', 'stats-cache.json');
       const raw = fs.readFileSync(statsPath, 'utf-8');
       return JSON.parse(raw);
     } catch {

--- a/src/main/path-precedence.test.ts
+++ b/src/main/path-precedence.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./platform', () => ({
+  isWin: false,
+  pathSep: ':',
+}));
+
+vi.mock('os', () => ({
+  homedir: vi.fn(() => '/home/tester'),
+}));
+
+import { mergePreferredBinDirsFirst } from './path-precedence';
+
+describe('mergePreferredBinDirsFirst', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prepends user-local dirs before system paths', () => {
+    const out = mergePreferredBinDirsFirst('/usr/local/bin:/usr/bin:/bin');
+    expect(out.split(':')[0]).toBe('/home/tester/.local/bin');
+    expect(out.split(':')[1]).toBe('/home/tester/.npm-global/bin');
+    expect(out).toContain('/opt/homebrew/bin');
+    expect(out).toContain('/usr/local/bin');
+    expect(out.indexOf('/home/tester/.local/bin')).toBeLessThan(out.indexOf('/usr/local/bin'));
+  });
+
+  it('dedupes repeated segments', () => {
+    const out = mergePreferredBinDirsFirst('/usr/local/bin:/home/tester/.local/bin:/usr/local/bin');
+    const parts = out.split(':');
+    expect(parts.filter((p) => p === '/usr/local/bin').length).toBe(1);
+  });
+});

--- a/src/main/path-precedence.ts
+++ b/src/main/path-precedence.ts
@@ -1,0 +1,30 @@
+import * as os from 'os';
+import * as path from 'path';
+import { isWin, pathSep } from './platform';
+
+/**
+ * Rebuild PATH so user-local and common install dirs are searched before
+ * system paths. Fixes `which` picking an older `/usr/local/bin/foo` when a
+ * newer copy exists under `~/.local/bin` (npm global default on Linux).
+ */
+export function mergePreferredBinDirsFirst(pathEnv: string): string {
+  const home = os.homedir();
+  const preferred = isWin
+    ? [path.join(home, 'AppData', 'Roaming', 'npm'), path.join(home, '.local', 'bin')]
+    : [
+        path.join(home, '.local', 'bin'),
+        path.join(home, '.npm-global', 'bin'),
+        '/opt/homebrew/bin',
+        '/usr/local/bin',
+      ];
+  const parts = pathEnv.split(pathSep).filter(Boolean);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const p of [...preferred, ...parts]) {
+    if (!seen.has(p)) {
+      seen.add(p);
+      out.push(p);
+    }
+  }
+  return out.join(pathSep);
+}

--- a/src/main/platform.ts
+++ b/src/main/platform.ts
@@ -6,6 +6,8 @@
  * platform-conditional logic discoverable and prevents drift across modules.
  */
 
+import type { Preferences } from '../shared/types';
+
 export const isWin = process.platform === 'win32';
 export const isMac = process.platform === 'darwin';
 export const isLinux = process.platform === 'linux';
@@ -18,3 +20,16 @@ export const whichCmd = isWin ? 'where' : 'which';
 
 /** Python interpreter used by hook scripts. */
 export const pythonBin = isWin ? 'python' : '/usr/bin/python3';
+
+/**
+ * Returns true when WSL execution mode is active.
+ * This is only possible on Windows with `wslEnabled` set in preferences.
+ * Lazily imports the WSL module to avoid pulling it in on non-Windows platforms.
+ */
+export function isWslMode(prefs?: Preferences): boolean {
+  if (!isWin) return false;
+  if (!prefs?.wslEnabled) return false;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { isWslAvailable } = require('./wsl') as typeof import('./wsl');
+  return isWslAvailable();
+}

--- a/src/main/prerequisites-wsl-python.test.ts
+++ b/src/main/prerequisites-wsl-python.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as child_process from 'child_process';
+
+vi.mock('./store', () => ({
+  loadState: vi.fn(() => ({
+    version: 1,
+    projects: [],
+    activeProjectId: null,
+    preferences: { wslEnabled: true, wslDistro: 'Ubuntu' },
+  })),
+}));
+
+vi.mock('./wsl', () => ({
+  getEffectiveDistro: vi.fn(() => 'Ubuntu'),
+}));
+
+vi.mock('./platform', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./platform')>();
+  return {
+    ...mod,
+    isWin: true,
+    isWslMode: vi.fn(() => true),
+  };
+});
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+    execSync: vi.fn(),
+  };
+});
+
+import { checkPythonAvailable } from './prerequisites';
+
+describe('checkPythonAvailable (WSL mode)', () => {
+  beforeEach(() => {
+    vi.mocked(child_process.execFileSync).mockReset();
+    vi.mocked(child_process.execSync).mockReset();
+  });
+
+  it('returns null when python3 works in WSL', () => {
+    vi.mocked(child_process.execFileSync).mockReturnValue('Python 3.12.0');
+    expect(checkPythonAvailable()).toBeNull();
+    expect(child_process.execFileSync).toHaveBeenCalledWith(
+      'wsl.exe',
+      ['-d', 'Ubuntu', '--', 'python3', '--version'],
+      expect.objectContaining({ encoding: 'utf-8' }),
+    );
+  });
+
+  it('falls back to /usr/bin/python3 when python3 fails', () => {
+    vi.mocked(child_process.execFileSync)
+      .mockImplementationOnce(() => {
+        throw new Error('missing');
+      })
+      .mockReturnValueOnce('Python 3.12.0');
+    expect(checkPythonAvailable()).toBeNull();
+    expect(child_process.execFileSync).toHaveBeenCalledTimes(2);
+    expect(child_process.execFileSync).toHaveBeenLastCalledWith(
+      'wsl.exe',
+      ['-d', 'Ubuntu', '--', '/usr/bin/python3', '--version'],
+      expect.any(Object),
+    );
+  });
+
+  it('returns help when both interpreters are missing', () => {
+    vi.mocked(child_process.execFileSync).mockImplementation(() => {
+      throw new Error('missing');
+    });
+    const msg = checkPythonAvailable();
+    expect(msg).toContain('Python 3 not found in WSL');
+  });
+});

--- a/src/main/prerequisites.ts
+++ b/src/main/prerequisites.ts
@@ -1,26 +1,62 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { execSync } from 'child_process';
-import { isWin, pathSep, whichCmd } from './platform';
+import { execSync, execFileSync } from 'child_process';
+import { isWin, pathSep, whichCmd, isWslMode } from './platform';
+import { loadState } from './store';
+import { getEffectiveDistro } from './wsl';
+
+const WINDOWS_PYTHON_HELP =
+  'Python not found.\n\n' +
+  'Vibeyard uses Python on Windows for session tracking (cost, status, events).\n' +
+  'These features will not work until Python is installed and available on PATH.\n\n' +
+  'Install Python from https://www.python.org/downloads/ or via:\n' +
+  '  winget install Python.Python.3\n';
+
+const WSL_PYTHON_HELP =
+  'Python 3 not found in WSL.\n\n' +
+  'Vibeyard uses Python inside your WSL distro for session tracking (cost, status, events).\n\n' +
+  'Install Python 3 in that distro, for example:\n' +
+  '  sudo apt update && sudo apt install -y python3\n';
+
+const WSL_DISTRO_HELP =
+  'Could not determine the WSL distribution for Python.\n\n' +
+  'Install a WSL distro or choose one in Preferences → WSL2 Integration.\n';
+
+function checkWslPython(distro: string): string | null {
+  const opts = { encoding: 'utf-8' as const, timeout: 5000, stdio: 'pipe' as const };
+  for (const py of ['python3', '/usr/bin/python3']) {
+    try {
+      execFileSync('wsl.exe', ['-d', distro, '--', py, '--version'], opts);
+      return null;
+    } catch {
+      // try next
+    }
+  }
+  return WSL_PYTHON_HELP;
+}
 
 /**
- * Check whether Python is available on Windows (needed for hook scripts).
+ * Check whether Python is available for hook scripts.
+ * On Windows without WSL mode: `python` on PATH.
+ * On Windows with WSL mode: `python3` (or `/usr/bin/python3`) inside the chosen distro.
  * Returns null if OK or not on Windows, or a warning message if missing.
  */
 export function checkPythonAvailable(): string | null {
   if (!isWin) return null;
+
+  const state = loadState();
+  if (isWslMode(state.preferences)) {
+    const distro = getEffectiveDistro(state.preferences.wslDistro);
+    if (!distro) return WSL_DISTRO_HELP;
+    return checkWslPython(distro);
+  }
+
   try {
     execSync('python --version', { encoding: 'utf-8', timeout: 3000, stdio: 'pipe' });
     return null;
   } catch {
-    return (
-      'Python not found.\n\n' +
-      'Vibeyard uses Python on Windows for session tracking (cost, status, events).\n' +
-      'These features will not work until Python is installed and available on PATH.\n\n' +
-      'Install Python from https://www.python.org/downloads/ or via:\n' +
-      '  winget install Python.Python.3\n'
-    );
+    return WINDOWS_PYTHON_HELP;
   }
 }
 

--- a/src/main/project-fs-path.test.ts
+++ b/src/main/project-fs-path.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import * as path from 'path';
+import { resolvePathForMainProcess } from './project-fs-path';
+
+describe('resolvePathForMainProcess', () => {
+  it('trims whitespace before resolving', () => {
+    const r = resolvePathForMainProcess('  /tmp/vibeyard-project-fs-path-test  ');
+    expect(r).toBe(path.resolve('/tmp/vibeyard-project-fs-path-test'));
+  });
+});

--- a/src/main/project-fs-path.ts
+++ b/src/main/project-fs-path.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { expandUserPath } from './fs-utils';
 import { isWin, isWslMode } from './platform';
 import { loadState } from './store';
-import { getEffectiveDistro, normalizeProjectPathForWslStorage, wslPathToWin } from './wsl';
+import { getEffectiveDistro, normalizeProjectPathForWslStorage, uncWslPathToLinuxPath, wslPathToWin } from './wsl';
 
 function wslDistro(): string | undefined {
   return getEffectiveDistro(loadState().preferences.wslDistro) ?? undefined;
@@ -41,10 +41,17 @@ export function joinStoredProjectPath(storedRoot: string, ...segments: string[])
 
 /** Resolve a path string for main-process `fs` (handles POSIX `/...` under WSL mode). */
 export function resolvePathForMainProcess(filePath: string): string {
-  let x = expandUserPath(filePath);
+  let x = expandUserPath(filePath.trim());
   if (isWin && isWslMode(loadState().preferences)) {
+    // Prefer UNC → Linux mapping so mixed `/` and `\` WSL paths are not mis-handled by
+    // `path.win32` (e.g. `path.resolve('/home/...')` → `\home\...` on Windows).
+    const fromUnc = uncWslPathToLinuxPath(x);
+    if (fromUnc !== null) {
+      x = storedPathToMainFs(fromUnc);
+      return path.resolve(x);
+    }
     const s = x.replace(/\\/g, '/');
-    if (s.startsWith('/')) {
+    if (s.startsWith('/') && !/^[A-Za-z]:\//.test(s)) {
       x = storedPathToMainFs(s);
     }
   }

--- a/src/main/project-fs-path.ts
+++ b/src/main/project-fs-path.ts
@@ -1,0 +1,85 @@
+import * as path from 'path';
+import { expandUserPath } from './fs-utils';
+import { isWin, isWslMode } from './platform';
+import { loadState } from './store';
+import { getEffectiveDistro, normalizeProjectPathForWslStorage, wslPathToWin } from './wsl';
+
+function wslDistro(): string | undefined {
+  return getEffectiveDistro(loadState().preferences.wslDistro) ?? undefined;
+}
+
+/**
+ * Stored project path (POSIX under WSL, or native path) → path Node `fs` can use
+ * on Windows (UNC for Linux-side trees).
+ */
+export function storedPathToMainFs(storedPath: string): string {
+  if (!isWin || !isWslMode(loadState().preferences)) {
+    return storedPath;
+  }
+  const norm = storedPath.replace(/\\/g, '/');
+  if (norm.startsWith('/')) {
+    return wslPathToWin(norm, wslDistro());
+  }
+  return storedPath;
+}
+
+/**
+ * Join a stored project root with path segments; returns a path usable with
+ * `fs.*` and `shell.openPath` on Windows under WSL mode.
+ */
+export function joinStoredProjectPath(storedRoot: string, ...segments: string[]): string {
+  if (!isWin || !isWslMode(loadState().preferences)) {
+    return path.join(storedRoot, ...segments);
+  }
+  const root = storedRoot.replace(/\\/g, '/');
+  const combined = path.posix.join(root, ...segments.map((x) => x.replace(/\\/g, '/')));
+  if (combined.startsWith('/')) {
+    return wslPathToWin(combined, wslDistro());
+  }
+  return path.join(storedRoot, ...segments);
+}
+
+/** Resolve a path string for main-process `fs` (handles POSIX `/...` under WSL mode). */
+export function resolvePathForMainProcess(filePath: string): string {
+  let x = expandUserPath(filePath);
+  if (isWin && isWslMode(loadState().preferences)) {
+    const s = x.replace(/\\/g, '/');
+    if (s.startsWith('/')) {
+      x = storedPathToMainFs(s);
+    }
+  }
+  return path.resolve(x);
+}
+
+/** True if `resolvedAbsolute` is the project root or a file under it. */
+/** Project root as a path `fs.watch` / `readdir` can use on Windows under WSL mode. */
+export function projectRootForFsWatch(projectPath: string): string {
+  const n = projectPath.replace(/\\/g, '/');
+  if (isWin && isWslMode(loadState().preferences) && n.startsWith('/')) {
+    return storedPathToMainFs(n);
+  }
+  return path.resolve(projectPath);
+}
+
+/**
+ * True when two stored project roots refer to the same tree (e.g. `/home/u/p` vs `\\wsl$\Ubuntu\home\u\p`).
+ */
+export function storedProjectPathsEquivalent(a: string, b: string): boolean {
+  if (a === b) return true;
+  const distro =
+    isWin && isWslMode(loadState().preferences)
+      ? getEffectiveDistro(loadState().preferences.wslDistro) ?? undefined
+      : undefined;
+  return normalizeProjectPathForWslStorage(a, distro) === normalizeProjectPathForWslStorage(b, distro);
+}
+
+export function pathIsWithinStoredProject(resolvedAbsolute: string, storedProjectPath: string): boolean {
+  if (isWin && isWslMode(loadState().preferences) && storedProjectPath.replace(/\\/g, '/').startsWith('/')) {
+    const base = storedPathToMainFs(storedProjectPath).replace(/\//g, '\\').toLowerCase();
+    const rel = resolvedAbsolute.replace(/\//g, '\\').toLowerCase();
+    return rel === base || rel.startsWith(base + '\\');
+  }
+  const rp = path.resolve(resolvedAbsolute);
+  const sp = path.resolve(storedProjectPath);
+  return rp === sp || rp.startsWith(sp + path.sep);
+}

--- a/src/main/providers/claude-provider.test.ts
+++ b/src/main/providers/claude-provider.test.ts
@@ -71,7 +71,7 @@ describe('meta', () => {
 describe('resolveBinaryPath', () => {
   const firstCandidate = isWin
     ? path.join('/mock/home', 'AppData', 'Roaming', 'npm', 'claude.cmd')
-    : '/usr/local/bin/claude';
+    : path.join('/mock/home', '.local', 'bin', 'claude');
 
   it('returns candidate path when existsSync returns true', () => {
     mockExistsSync.mockImplementation((p) => p === firstCandidate);

--- a/src/main/providers/claude-provider.ts
+++ b/src/main/providers/claude-provider.ts
@@ -1,13 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
 import type { BrowserWindow } from 'electron';
 import type { CliProvider } from './provider';
 import type { CliProviderMeta, ProviderConfig, SettingsValidationResult } from '../../shared/types';
 import { getFullPath } from '../pty-manager';
 import { installStatusLineScript, cleanupAll as cleanupHookStatus } from '../hook-status';
 import { startConfigWatcher as startConfigWatch, stopConfigWatcher as stopConfigWatch } from '../config-watcher';
-import { installHooksOnly, installStatusLine, getClaudeConfig } from '../claude-cli';
+import { installHooksOnly, installStatusLine, getClaudeConfig, claudeProjectDirSlugs, getEffectiveCliUserHome } from '../claude-cli';
 import { guardedInstall, validateSettings, reinstallSettings } from '../settings-guard';
 import { resolveBinary, validateBinaryExists } from './resolve-binary';
 
@@ -104,10 +103,12 @@ export class ClaudeProvider implements CliProvider {
   }
 
   getTranscriptPath(cliSessionId: string, projectPath: string): string | null {
-    // Claude encodes the project path by replacing any non-alphanumeric char with '-'
-    const slug = projectPath.replace(/[^a-zA-Z0-9]/g, '-');
-    const filePath = path.join(os.homedir(), '.claude', 'projects', slug, `${cliSessionId}.jsonl`);
-    return fs.existsSync(filePath) ? filePath : null;
+    const base = path.join(getEffectiveCliUserHome(), '.claude', 'projects');
+    for (const slug of claudeProjectDirSlugs(projectPath)) {
+      const filePath = path.join(base, slug, `${cliSessionId}.jsonl`);
+      if (fs.existsSync(filePath)) return filePath;
+    }
+    return null;
   }
 
   parseCostFromOutput(rawText: string): { totalCostUsd: number } | null {

--- a/src/main/providers/codex-provider.test.ts
+++ b/src/main/providers/codex-provider.test.ts
@@ -8,6 +8,7 @@ vi.mock('fs', () => ({
 
 vi.mock('os', () => ({
   homedir: () => '/mock/home',
+  tmpdir: () => '/tmp',
 }));
 
 vi.mock('child_process', () => ({

--- a/src/main/providers/codex-provider.ts
+++ b/src/main/providers/codex-provider.ts
@@ -1,11 +1,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
 import type { CliProvider } from './provider';
 import type { CliProviderMeta, ProviderConfig, SettingsValidationResult } from '../../shared/types';
 import { getFullPath } from '../pty-manager';
 import { resolveBinary, validateBinaryExists } from './resolve-binary';
 import { getCodexConfig } from '../codex-config';
+import { getEffectiveCliUserHome } from '../claude-cli';
 import { installCodexHooks, validateCodexHooks, cleanupCodexHooks, SESSION_ID_VAR } from '../codex-hooks';
 import { startConfigWatcher as startConfigWatch, stopConfigWatcher as stopConfigWatch } from '../config-watcher';
 import type { BrowserWindow } from 'electron';
@@ -94,7 +94,7 @@ export class CodexProvider implements CliProvider {
 
   getTranscriptPath(cliSessionId: string, _projectPath: string): string | null {
     try {
-      const root = path.join(os.homedir(), '.codex', 'sessions');
+      const root = path.join(getEffectiveCliUserHome(), '.codex', 'sessions');
       const suffix = `-${cliSessionId}.jsonl`;
       // sessions are partitioned as YYYY/MM/DD/rollout-<ts>-<id>.jsonl.
       // Walk newest-first and return on first match.

--- a/src/main/providers/gemini-provider.test.ts
+++ b/src/main/providers/gemini-provider.test.ts
@@ -8,6 +8,7 @@ vi.mock('fs', () => ({
 
 vi.mock('os', () => ({
   homedir: () => '/mock/home',
+  tmpdir: () => '/tmp',
 }));
 
 vi.mock('child_process', () => ({

--- a/src/main/providers/gemini-provider.ts
+++ b/src/main/providers/gemini-provider.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
 import type { CliProvider } from './provider';
 import type { CliProviderMeta, ProviderConfig, SettingsValidationResult } from '../../shared/types';
 import { getFullPath } from '../pty-manager';
 import { resolveBinary, validateBinaryExists } from './resolve-binary';
+import { getEffectiveCliUserHome } from '../claude-cli';
 import { getGeminiConfig } from '../gemini-config';
+import { storedProjectPathsEquivalent } from '../project-fs-path';
 import { installGeminiHooks, validateGeminiHooks, cleanupGeminiHooks, SESSION_ID_VAR } from '../gemini-hooks';
 import { startConfigWatcher as startConfigWatch, stopConfigWatcher as stopConfigWatch } from '../config-watcher';
 import type { BrowserWindow } from 'electron';
@@ -96,7 +97,7 @@ export class GeminiProvider implements CliProvider {
 
   getTranscriptPath(cliSessionId: string, projectPath: string): string | null {
     try {
-      const tmpRoot = path.join(os.homedir(), '.gemini', 'tmp');
+      const tmpRoot = path.join(getEffectiveCliUserHome(), '.gemini', 'tmp');
       if (!fs.existsSync(tmpRoot)) return null;
 
       // Find the project key dir whose .project_root matches our projectPath
@@ -105,7 +106,7 @@ export class GeminiProvider implements CliProvider {
         const projectRootFile = path.join(tmpRoot, entry, '.project_root');
         try {
           const contents = fs.readFileSync(projectRootFile, 'utf-8').trim();
-          if (contents === projectPath) {
+          if (storedProjectPathsEquivalent(contents, projectPath)) {
             chatsDir = path.join(tmpRoot, entry, 'chats');
             break;
           }

--- a/src/main/providers/resolve-binary.ts
+++ b/src/main/providers/resolve-binary.ts
@@ -3,9 +3,12 @@ import * as path from 'path';
 import * as os from 'os';
 import { execSync, execFileSync } from 'child_process';
 import { getFullPath } from '../pty-manager';
+import { mergePreferredBinDirsFirst } from '../path-precedence';
 import { isWin, whichCmd, isWslMode } from '../platform';
 import { loadState } from '../store';
 
+// Unix: prefer user-level installs (~/.local/bin from npm -g, etc.) before
+// /usr/local and Homebrew so a newer CLI in $HOME wins over an older system copy.
 const COMMON_BIN_DIRS = isWin
   ? [
       path.join(os.homedir(), 'AppData', 'Roaming', 'npm'),
@@ -13,10 +16,10 @@ const COMMON_BIN_DIRS = isWin
       path.join(os.homedir(), '.local', 'bin'),
     ]
   : [
-      '/usr/local/bin',
-      '/opt/homebrew/bin',
       path.join(os.homedir(), '.local', 'bin'),
       path.join(os.homedir(), '.npm-global', 'bin'),
+      '/opt/homebrew/bin',
+      '/usr/local/bin',
     ];
 
 const WIN_EXTENSIONS = ['.cmd', '.exe', '.ps1', ''];
@@ -56,14 +59,44 @@ function whichBinaryInWsl(binaryName: string, distro: string): string | null {
   const cached = wslBinaryCache.get(key);
   if (cached) return cached;
 
+  const { getWslHome } = require('../wsl') as typeof import('../wsl');
+  const home = getWslHome(distro);
+  const candidates = [
+    path.posix.join(home, '.local', 'bin', binaryName),
+    path.posix.join(home, '.npm-global', 'bin', binaryName),
+    path.posix.join('/opt/homebrew', 'bin', binaryName),
+    path.posix.join('/usr/local', 'bin', binaryName),
+  ];
+  for (const c of candidates) {
+    try {
+      execFileSync('wsl.exe', ['-d', distro, '--', 'test', '-x', c], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 3000,
+      });
+      wslBinaryCache.set(key, c);
+      return c;
+    } catch {
+      // try next
+    }
+  }
+
+  const pathPrefix = [
+    path.posix.join(home, '.local', 'bin'),
+    path.posix.join(home, '.npm-global', 'bin'),
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+  ].join(':');
   try {
-    const resolved = execFileSync('wsl.exe', ['-d', distro, '--', 'which', binaryName], {
-      encoding: 'utf8',
-      timeout: 5000,
-    }).trim();
-    if (resolved) {
-      wslBinaryCache.set(key, resolved);
-      return resolved;
+    const out = execFileSync(
+      'wsl.exe',
+      ['-d', distro, '--', 'sh', '-c', 'PATH="$1:$PATH" command -v "$2"', '_', pathPrefix, binaryName],
+      { encoding: 'utf8', timeout: 5000 },
+    )
+      .trim()
+      .split(/\r?\n/)[0];
+    if (out) {
+      wslBinaryCache.set(key, out);
+      return out;
     }
   } catch {
     // not found
@@ -97,7 +130,7 @@ export function resolveBinary(binaryName: string, cache: { path: string | null }
     }
   }
 
-  const resolved = whichBinary(binaryName, fullPath);
+  const resolved = whichBinary(binaryName, mergePreferredBinDirsFirst(fullPath));
   if (resolved) {
     cache.path = resolved;
     return resolved;
@@ -132,7 +165,7 @@ export function validateBinaryExists(
     if (findBinaryInDir(dir, binaryName)) return { ok: true, message: '' };
   }
 
-  if (whichBinary(binaryName, getFullPath())) return { ok: true, message: '' };
+  if (whichBinary(binaryName, mergePreferredBinDirsFirst(getFullPath()))) return { ok: true, message: '' };
 
   return {
     ok: false,

--- a/src/main/providers/resolve-binary.ts
+++ b/src/main/providers/resolve-binary.ts
@@ -1,9 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { getFullPath } from '../pty-manager';
-import { isWin, whichCmd } from '../platform';
+import { isWin, whichCmd, isWslMode } from '../platform';
+import { loadState } from '../store';
 
 const COMMON_BIN_DIRS = isWin
   ? [
@@ -18,7 +19,6 @@ const COMMON_BIN_DIRS = isWin
       path.join(os.homedir(), '.npm-global', 'bin'),
     ];
 
-// On Windows, CLI tools installed via npm are .cmd shims
 const WIN_EXTENSIONS = ['.cmd', '.exe', '.ps1', ''];
 
 function findBinaryInDir(dir: string, binaryName: string): string | null {
@@ -41,7 +41,6 @@ function whichBinary(binaryName: string, envPath: string): string | null {
       encoding: 'utf-8',
       timeout: 3000,
     }).trim();
-    // 'where' on Windows may return multiple lines — take the first
     const firstLine = resolved.split(/\r?\n/)[0];
     return firstLine || null;
   } catch {
@@ -49,8 +48,44 @@ function whichBinary(binaryName: string, envPath: string): string | null {
   }
 }
 
+/** Resolve a binary inside WSL via `wsl.exe -d <distro> -- which <binary>`. */
+const wslBinaryCache = new Map<string, string>();
+
+function whichBinaryInWsl(binaryName: string, distro: string): string | null {
+  const key = `${distro}:${binaryName}`;
+  const cached = wslBinaryCache.get(key);
+  if (cached) return cached;
+
+  try {
+    const resolved = execFileSync('wsl.exe', ['-d', distro, '--', 'which', binaryName], {
+      encoding: 'utf8',
+      timeout: 5000,
+    }).trim();
+    if (resolved) {
+      wslBinaryCache.set(key, resolved);
+      return resolved;
+    }
+  } catch {
+    // not found
+  }
+  return null;
+}
+
 export function resolveBinary(binaryName: string, cache: { path: string | null }): string {
   if (cache.path) return cache.path;
+
+  const state = loadState();
+  if (isWslMode(state.preferences)) {
+    const { getEffectiveDistro } = require('../wsl') as typeof import('../wsl');
+    const distro = getEffectiveDistro(state.preferences.wslDistro) || 'Ubuntu';
+    const resolved = whichBinaryInWsl(binaryName, distro);
+    if (resolved) {
+      cache.path = resolved;
+      return resolved;
+    }
+    cache.path = binaryName;
+    return binaryName;
+  }
 
   const fullPath = getFullPath();
 
@@ -77,6 +112,22 @@ export function validateBinaryExists(
   displayName: string,
   installCommand: string,
 ): { ok: boolean; message: string } {
+  const state = loadState();
+  if (isWslMode(state.preferences)) {
+    const { getEffectiveDistro } = require('../wsl') as typeof import('../wsl');
+    const distro = getEffectiveDistro(state.preferences.wslDistro) || 'Ubuntu';
+    if (whichBinaryInWsl(binaryName, distro)) return { ok: true, message: '' };
+    return {
+      ok: false,
+      message:
+        `${displayName} not found inside WSL (${distro}).\n\n` +
+        `Vibeyard WSL mode requires ${displayName} installed in your WSL distro.\n\n` +
+        `Open your WSL terminal and install it with:\n` +
+        `  ${installCommand}\n\n` +
+        `After installing, restart Vibeyard.`,
+    };
+  }
+
   for (const dir of COMMON_BIN_DIRS) {
     if (findBinaryInDir(dir, binaryName)) return { ok: true, message: '' };
   }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -2,10 +2,11 @@ import * as pty from 'node-pty';
 import { execSync, execFile } from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
-import type { ProviderId } from '../shared/types';
+import type { ProviderId, Preferences } from '../shared/types';
 import { getProvider } from './providers/registry';
 import { registerSession } from './hook-status';
-import { isWin, pathSep } from './platform';
+import { isWin, pathSep, isWslMode } from './platform';
+import { loadState } from './store';
 
 interface PtyInstance {
   process: pty.IPty;
@@ -90,7 +91,6 @@ export function spawnPty(
   onExit: (exitCode: number, signal?: number) => void
 ): void {
   if (ptys.has(sessionId)) {
-    // Silence the old PTY's exit event so it doesn't remove the new session
     silencedExits.add(sessionId);
     killPty(sessionId);
   }
@@ -99,20 +99,48 @@ export function spawnPty(
 
   const provider = getProvider(providerId);
   const env = provider.buildEnv(sessionId, { ...process.env } as Record<string, string>);
-  const args = provider.buildArgs({ cliSessionId, isResume, extraArgs, initialPrompt });
-  const shell = provider.resolveBinaryPath();
+  const cliArgs = provider.buildArgs({ cliSessionId, isResume, extraArgs, initialPrompt });
+  const cliBinary = provider.resolveBinaryPath();
+
+  const state = loadState();
+  const wslActive = isWslMode(state.preferences);
+
+  let shell: string;
+  let args: string[];
+  let ptyCwd: string;
+
+  if (wslActive) {
+    const { getEffectiveDistro, winPathToWsl, uncWslPathToLinuxPath } = require('./wsl') as typeof import('./wsl');
+    const distro = getEffectiveDistro(state.preferences.wslDistro) || 'Ubuntu';
+
+    shell = 'wsl.exe';
+    // Linux cwd for the CLI: `wsl` was previously spawned without --cd, so Claude
+    // always saw `/mnt/c/.../Temp`. `--cd` sets the WSL working directory.
+    const fromUnc = uncWslPathToLinuxPath(cwd);
+    ptyCwd = fromUnc
+      ? fromUnc
+      : cwd.includes('\\') || /^[A-Za-z]:/.test(cwd)
+        ? winPathToWsl(cwd, distro)
+        : cwd;
+
+    const envPairs = [`CLAUDE_IDE_SESSION_ID=${env.CLAUDE_IDE_SESSION_ID || sessionId}`];
+    args = ['-d', distro, '--cd', ptyCwd, '--', 'env', ...envPairs, cliBinary, ...cliArgs];
+  } else {
+    shell = cliBinary;
+    args = cliArgs;
+    ptyCwd = cwd;
+  }
 
   const ptyProcess = pty.spawn(shell, args, {
     name: 'xterm-256color',
     cols: 120,
     rows: 30,
-    cwd,
-    env,
+    cwd: wslActive ? os.tmpdir() : ptyCwd,
+    env: wslActive ? process.env as Record<string, string> : env,
   });
 
   ptyProcess.onData((data) => onData(data));
   ptyProcess.onExit(({ exitCode, signal }) => {
-    // Only remove from map if this PTY is still the active one for this session
     const current = ptys.get(sessionId);
     if (current?.process === ptyProcess) {
       ptys.delete(sessionId);
@@ -155,15 +183,41 @@ export function spawnShellPty(
     killPty(sessionId);
   }
 
-  const shell = isWin
-    ? (process.env.COMSPEC || 'cmd.exe')
-    : (process.env.SHELL || '/bin/zsh');
+  const state = loadState();
+  const wslActive = isWslMode(state.preferences);
+
+  let shell: string;
+  let shellArgs: string[];
+  let ptyCwd: string;
+
+  if (wslActive) {
+    const { getEffectiveDistro, winPathToWsl, uncWslPathToLinuxPath } = require('./wsl') as typeof import('./wsl');
+    const distro = getEffectiveDistro(state.preferences.wslDistro) || 'Ubuntu';
+    shell = 'wsl.exe';
+    const fromUnc = uncWslPathToLinuxPath(cwd);
+    const wslShellCwd = fromUnc
+      ? fromUnc
+      : cwd.includes('\\') || /^[A-Za-z]:/.test(cwd)
+        ? winPathToWsl(cwd, distro)
+        : cwd;
+    shellArgs = ['-d', distro, '--cd', wslShellCwd];
+    ptyCwd = os.tmpdir();
+  } else if (isWin) {
+    shell = process.env.COMSPEC || 'cmd.exe';
+    shellArgs = [];
+    ptyCwd = cwd;
+  } else {
+    shell = process.env.SHELL || '/bin/zsh';
+    shellArgs = [];
+    ptyCwd = cwd;
+  }
+
   const shellEnv = { ...process.env, PATH: getFullPath() };
-  const ptyProcess = pty.spawn(shell, [], {
+  const ptyProcess = pty.spawn(shell, shellArgs, {
     name: 'xterm-256color',
     cols: 120,
     rows: 15,
-    cwd,
+    cwd: ptyCwd,
     env: shellEnv,
   });
 

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -6,6 +6,7 @@ import type { ProviderId, Preferences } from '../shared/types';
 import { getProvider } from './providers/registry';
 import { registerSession } from './hook-status';
 import { isWin, pathSep, isWslMode } from './platform';
+import { mergePreferredBinDirsFirst } from './path-precedence';
 import { loadState } from './store';
 
 interface PtyInstance {
@@ -40,7 +41,7 @@ export function getFullPath(): string {
     for (const dir of extraDirs) {
       pathSet.add(dir);
     }
-    cachedFullPath = Array.from(pathSet).join(pathSep);
+    cachedFullPath = mergePreferredBinDirsFirst(Array.from(pathSet).join(pathSep));
     return cachedFullPath;
   }
 
@@ -55,18 +56,18 @@ export function getFullPath(): string {
     });
     const match = shellPath.match(/__PATH__=(.+)/);
     if (match && match[1]) {
-      cachedFullPath = match[1].trim();
+      cachedFullPath = mergePreferredBinDirsFirst(match[1].trim());
       return cachedFullPath;
     }
   } catch (err) { console.warn('Failed to resolve PATH from login shell:', err); }
 
-  // Fallback: merge current PATH with common directories
+  // Fallback: merge current PATH with common directories (user-local first; see resolve-binary.ts)
   const home = os.homedir();
   const extraDirs = [
-    '/usr/local/bin',
-    '/opt/homebrew/bin',
     path.join(home, '.local', 'bin'),
     path.join(home, '.npm-global', 'bin'),
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
     '/usr/local/sbin',
     '/opt/homebrew/sbin',
   ];
@@ -75,7 +76,7 @@ export function getFullPath(): string {
   for (const dir of extraDirs) {
     pathSet.add(dir);
   }
-  cachedFullPath = Array.from(pathSet).join(pathSep);
+  cachedFullPath = mergePreferredBinDirsFirst(Array.from(pathSet).join(pathSep));
   return cachedFullPath;
 }
 

--- a/src/main/readiness/checkers/claude-context.ts
+++ b/src/main/readiness/checkers/claude-context.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { joinStoredProjectPath } from '../../project-fs-path';
 import picomatch from 'picomatch';
 import type { ReadinessCheck } from '../../../shared/types';
 import type { ReadinessCheckProducer, TaggedCheck, AnalysisContext } from '../types';
@@ -30,7 +31,7 @@ function findSensitiveFiles(trackedFiles: string[]): string[] {
 }
 
 function checkClaudeignore(projectPath: string, trackedFiles: string[]): ReadinessCheck {
-  const exists = fileExists(path.join(projectPath, '.claudeignore'));
+  const exists = fileExists(joinStoredProjectPath(projectPath, '.claudeignore'));
   const fileCount = trackedFiles.length;
   const sensitiveFiles = findSensitiveFiles(trackedFiles);
 

--- a/src/main/readiness/checkers/context-optimization.ts
+++ b/src/main/readiness/checkers/context-optimization.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { joinStoredProjectPath } from '../../project-fs-path';
 import * as fs from 'fs';
 import picomatch from 'picomatch';
 import type { ReadinessCheck } from '../../../shared/types';
@@ -13,7 +14,7 @@ const VIBEYARDIGNORE_HEADER = `# Files and patterns to exclude from AI readiness
 `;
 
 function ensureVibeyardignore(projectPath: string): void {
-  const filePath = path.join(projectPath, '.vibeyardignore');
+  const filePath = joinStoredProjectPath(projectPath, '.vibeyardignore');
   if (fileExists(filePath)) return;
   try {
     fs.writeFileSync(filePath, VIBEYARDIGNORE_HEADER + DEFAULT_SCAN_IGNORE.join('\n') + '\n', 'utf-8');
@@ -24,7 +25,7 @@ function ensureVibeyardignore(projectPath: string): void {
 
 function loadScanIgnorePatterns(projectPath: string): string[] {
   const patterns: string[] = [];
-  const content = readFileSafe(path.join(projectPath, '.vibeyardignore'));
+  const content = readFileSafe(joinStoredProjectPath(projectPath, '.vibeyardignore'));
   if (content) {
     for (const raw of content.split('\n')) {
       const line = raw.trim();
@@ -74,7 +75,7 @@ function checkLargeFiles(projectPath: string, trackedFiles: string[]): Readiness
     checked++;
 
     try {
-      const fullPath = path.join(projectPath, file);
+      const fullPath = joinStoredProjectPath(projectPath, file);
       const lines = countFileLines(fullPath);
       if (lines > LINE_THRESHOLD) {
         largeFiles.push(`${file} (${lines} lines)`);

--- a/src/main/readiness/checkers/custom-extensions.ts
+++ b/src/main/readiness/checkers/custom-extensions.ts
@@ -1,10 +1,11 @@
 import * as path from 'path';
+import { joinStoredProjectPath } from '../../project-fs-path';
 import type { ReadinessCheck } from '../../../shared/types';
 import type { ReadinessCheckProducer, TaggedCheck, AnalysisContext } from '../types';
 import { dirExists, readDirSafe } from '../utils';
 
 function checkCustomCommands(projectPath: string): ReadinessCheck {
-  const commandsDir = path.join(projectPath, '.claude', 'commands');
+  const commandsDir = joinStoredProjectPath(projectPath, '.claude', 'commands');
   const files = readDirSafe(commandsDir).filter(f => f.endsWith('.md'));
   const has = files.length > 0;
   return {
@@ -19,7 +20,7 @@ function checkCustomCommands(projectPath: string): ReadinessCheck {
 }
 
 function checkCustomSkills(projectPath: string): ReadinessCheck {
-  const skillsDir = path.join(projectPath, '.claude', 'skills');
+  const skillsDir = joinStoredProjectPath(projectPath, '.claude', 'skills');
   let has = false;
   if (dirExists(skillsDir)) {
     const entries = readDirSafe(skillsDir);
@@ -37,7 +38,7 @@ function checkCustomSkills(projectPath: string): ReadinessCheck {
 }
 
 function checkCustomAgents(projectPath: string): ReadinessCheck {
-  const agentsDir = path.join(projectPath, '.claude', 'agents');
+  const agentsDir = joinStoredProjectPath(projectPath, '.claude', 'agents');
   const files = readDirSafe(agentsDir).filter(f => f.endsWith('.md'));
   const has = files.length > 0;
   return {

--- a/src/main/readiness/checkers/instruction-file-checks.ts
+++ b/src/main/readiness/checkers/instruction-file-checks.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import { joinStoredProjectPath } from '../../project-fs-path';
 import type { ReadinessCheck } from '../../../shared/types';
 import { fileExists, readFileSafe } from '../utils';
 
@@ -9,7 +9,7 @@ export interface InstructionFileOpts {
 }
 
 export function checkFileExists(projectPath: string, opts: InstructionFileOpts): ReadinessCheck {
-  const exists = fileExists(path.join(projectPath, opts.fileName));
+  const exists = fileExists(joinStoredProjectPath(projectPath, opts.fileName));
   return {
     id: `${opts.idPrefix}-exists`,
     name: `${opts.displayName} exists`,
@@ -147,7 +147,7 @@ export function checkFileSize(content: string | null, opts: InstructionFileOpts)
 }
 
 export function checkNotBloated(projectPath: string, opts: InstructionFileOpts): ReadinessCheck {
-  const content = readFileSafe(path.join(projectPath, opts.fileName));
+  const content = readFileSafe(joinStoredProjectPath(projectPath, opts.fileName));
   if (!content) {
     return {
       id: `${opts.idPrefix}-bloat`,
@@ -175,7 +175,7 @@ export function checkNotBloated(projectPath: string, opts: InstructionFileOpts):
 }
 
 export function runAllInstructionChecks(projectPath: string, opts: InstructionFileOpts): ReadinessCheck[] {
-  const content = readFileSafe(path.join(projectPath, opts.fileName));
+  const content = readFileSafe(joinStoredProjectPath(projectPath, opts.fileName));
   return [
     checkFileExists(projectPath, opts),
     checkBuildCommands(content, opts),

--- a/src/main/readiness/utils.ts
+++ b/src/main/readiness/utils.ts
@@ -1,16 +1,11 @@
 import * as fs from 'fs';
-import { execSync } from 'child_process';
 import type { ReadinessCheck } from '../../shared/types';
+import { getGitTrackedFiles } from '../git-status';
 
 export { readFileSafe, fileExists, dirExists, readDirSafe } from '../fs-utils';
 
 export function getTrackedFiles(projectPath: string): string[] {
-  try {
-    const output = execSync('git ls-files', { cwd: projectPath, encoding: 'utf-8', timeout: 5000 });
-    return output.split('\n').filter(Boolean);
-  } catch {
-    return [];
-  }
+  return getGitTrackedFiles(projectPath);
 }
 
 /**

--- a/src/main/settings-guard.ts
+++ b/src/main/settings-guard.ts
@@ -1,8 +1,7 @@
 import * as path from 'path';
-import { homedir } from 'os';
 import { ipcMain, BrowserWindow } from 'electron';
 import { getStatusLineScriptPath } from './hook-status';
-import { HOOK_MARKER, installHooksOnly, installStatusLine, getSupportedHookEvents } from './claude-cli';
+import { HOOK_MARKER, installHooksOnly, installStatusLine, getSupportedHookEvents, getEffectiveCliUserHome } from './claude-cli';
 import { readJsonSafe } from './fs-utils';
 import { loadState, saveState } from './store';
 import type { SettingsValidationResult } from '../shared/types';
@@ -24,7 +23,9 @@ function getExpectedHookEvents(): string[] {
 }
 
 function readClaudeSettings(): Record<string, unknown> {
-  return readJsonSafe(path.join(homedir(), '.claude', 'settings.json')) ?? {};
+  // Match claude-cli hook/statusLine install paths: WSL mode uses the distro
+  // home (UNC), not the Windows profile — otherwise validation reads the wrong file.
+  return readJsonSafe(path.join(getEffectiveCliUserHome(), '.claude', 'settings.json')) ?? {};
 }
 
 export function isVibeyardStatusLine(statusLine: unknown): boolean {

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import type { PersistedState } from '../shared/types';
+import { isWin, isWslMode } from './platform';
+import { getEffectiveDistro, normalizeProjectPathForWslStorage } from './wsl';
 
 export type { SessionRecord, ProjectRecord, Preferences, PersistedState } from '../shared/types';
 
@@ -27,6 +29,7 @@ export function loadState(): PersistedState {
       const parsed = JSON.parse(raw) as PersistedState;
       if (parsed.version !== 1) continue;
       migrateSessionIds(parsed);
+      normalizeWslProjectPaths(parsed);
       if (file !== STATE_FILE) {
         console.warn('Recovered state from temp file');
       }
@@ -37,6 +40,20 @@ export function loadState(): PersistedState {
   }
   console.warn('No valid state file found, using defaults');
   return defaultState();
+}
+
+/** When WSL mode is on, persist project paths as Linux paths (`/home/...`), not `\\wsl$\...`. */
+export function normalizeWslProjectPaths(state: PersistedState): void {
+  if (!isWin || !isWslMode(state.preferences)) return;
+  const distro = getEffectiveDistro(state.preferences.wslDistro) ?? undefined;
+  for (const p of state.projects) {
+    p.path = normalizeProjectPathForWslStorage(p.path, distro);
+    for (const s of p.sessions) {
+      if (s.worktreePath) {
+        s.worktreePath = normalizeProjectPathForWslStorage(s.worktreePath, distro);
+      }
+    }
+  }
 }
 
 /** Migrate legacy claudeSessionId fields to cliSessionId */

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -52,6 +52,14 @@ export function normalizeWslProjectPaths(state: PersistedState): void {
       if (s.worktreePath) {
         s.worktreePath = normalizeProjectPathForWslStorage(s.worktreePath, distro);
       }
+      if (s.gitWorktreePath) {
+        s.gitWorktreePath = normalizeProjectPathForWslStorage(s.gitWorktreePath, distro);
+      }
+    }
+    for (const h of p.sessionHistory ?? []) {
+      if (h.gitWorktreePath) {
+        h.gitWorktreePath = normalizeProjectPathForWslStorage(h.gitWorktreePath, distro);
+      }
     }
   }
 }

--- a/src/main/wsl.test.ts
+++ b/src/main/wsl.test.ts
@@ -78,72 +78,61 @@ describe('getDefaultWslDistro', () => {
 });
 
 describe('winPathToWsl', () => {
-  it('converts via wslpath when available', () => {
-    // isWslAvailable
-    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
-    // getDefaultWslDistro → --list --verbose
-    mockExecFileSync.mockReturnValueOnce('* Ubuntu  Running  2\r\n' as any);
-    // wslpath call
-    mockExecFileSync.mockReturnValueOnce('/mnt/c/Users/test/project\n' as any);
-
+  it('converts drive-letter paths via heuristic without calling wsl', () => {
     expect(wsl.winPathToWsl('C:\\Users\\test\\project')).toBe('/mnt/c/Users/test/project');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
   });
 
-  it('falls back to heuristic when wslpath fails', () => {
-    // isWslAvailable
-    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
-    // getDefaultWslDistro
-    mockExecFileSync.mockReturnValueOnce('* Ubuntu  Running  2\r\n' as any);
-    // wslpath throws
-    mockExecFileSync.mockImplementationOnce(() => { throw new Error('wslpath fail'); });
-
-    expect(wsl.winPathToWsl('D:\\code\\repo')).toBe('/mnt/d/code/repo');
+  it('normalizes \\\\wsl$\\ UNC to a Linux path without calling wslpath', () => {
+    expect(wsl.winPathToWsl('\\\\wsl$\\Ubuntu\\home\\u\\proj')).toBe('/home/u/proj');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
   });
 
-  it('uses -e for wslpath -u so the default shell does not mangle backslashes or special chars', () => {
-    mockExecFileSync.mockReturnValueOnce('/mnt/c/Users/test/(parens)/x\n' as any);
-    wsl.winPathToWsl('C:\\Users\\test\\(parens)\\x', 'Ubuntu');
+  it('converts paths with parentheses via heuristic without calling wsl', () => {
+    expect(wsl.winPathToWsl('C:\\Users\\test\\(parens)\\x')).toBe('/mnt/c/Users/test/(parens)/x');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('uses wslpath -u when the path is not a drive-letter path or wsl$ UNC', () => {
+    mockExecFileSync.mockReturnValueOnce('/mnt/c/from-wslpath\n' as any);
+    expect(wsl.winPathToWsl('\\\\?\\Volume{abc}\\x', 'Ubuntu')).toBe('/mnt/c/from-wslpath');
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'wsl.exe',
-      ['-d', 'Ubuntu', '-e', 'wslpath', '-u', 'C:\\Users\\test\\(parens)\\x'],
-      expect.objectContaining({ timeout: 3000, encoding: 'utf8' }),
+      ['-d', 'Ubuntu', '-e', 'wslpath', '-u', '\\\\?\\Volume{abc}\\x'],
+      expect.objectContaining({ timeout: 3000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }),
     );
+  });
+
+  it('falls back to forward slashes when wslpath fails for non-drive paths', () => {
+    mockExecFileSync.mockImplementationOnce(() => { throw new Error('wslpath fail'); });
+    mockExecFileSync.mockImplementationOnce(() => { throw new Error('wslpath fail'); });
+    mockExecFileSync.mockImplementationOnce(() => { throw new Error('wslpath fail'); });
+    // Heuristic skipped; wslpath fails; final replace only flips backslashes (no /mnt mapping)
+    expect(wsl.winPathToWsl('\\\\?\\Z:\\odd\\path', 'Ubuntu')).toBe('//?/Z:/odd/path');
   });
 });
 
 describe('wslPathToWin', () => {
-  it('converts via wslpath when available', () => {
-    // isWslAvailable
-    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
-    // getDefaultWslDistro
-    mockExecFileSync.mockReturnValueOnce('* Ubuntu  Running  2\r\n' as any);
-    // wslpath -w
-    mockExecFileSync.mockReturnValueOnce('\\\\wsl$\\Ubuntu\\home\\user\n' as any);
-
-    expect(wsl.wslPathToWin('/home/user')).toBe('\\\\wsl$\\Ubuntu\\home\\user');
+  it('maps Linux home paths to \\\\wsl$\\ UNC without calling wsl', () => {
+    expect(wsl.wslPathToWin('/home/user', 'Ubuntu')).toBe('\\\\wsl$\\Ubuntu\\home\\user');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
   });
 
-  it('falls back to UNC construction for pure Linux paths', () => {
-    // wslpath throws (distro passed explicitly, no isWslAvailable needed for the path itself)
-    mockExecFileSync.mockImplementationOnce(() => { throw new Error('fail'); });
-
+  it('maps pure Linux project paths to UNC', () => {
     expect(wsl.wslPathToWin('/home/user/project', 'Ubuntu')).toBe('\\\\wsl$\\Ubuntu\\home\\user\\project');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
   });
 
-  it('falls back to drive letter for /mnt/ paths', () => {
-    mockExecFileSync.mockImplementationOnce(() => { throw new Error('fail'); });
-
+  it('maps /mnt/ paths back to a Windows drive letter', () => {
     expect(wsl.wslPathToWin('/mnt/c/Users/test', 'Ubuntu')).toBe('C:\\Users\\test');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
   });
 
-  it('uses -e for wslpath -w so paths with parentheses are not parsed by bash', () => {
-    mockExecFileSync.mockReturnValueOnce('\\\\wsl$\\Ubuntu\\home\\user\\(app)\\page.tsx\n' as any);
-    wsl.wslPathToWin('/home/user/(app)/page.tsx', 'Ubuntu');
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'wsl.exe',
-      ['-d', 'Ubuntu', '-e', 'wslpath', '-w', '/home/user/(app)/page.tsx'],
-      expect.objectContaining({ timeout: 3000, encoding: 'utf8' }),
+  it('maps paths with parentheses to UNC without subprocesses', () => {
+    expect(wsl.wslPathToWin('/home/user/(app)/page.tsx', 'Ubuntu')).toBe(
+      '\\\\wsl$\\Ubuntu\\home\\user\\(app)\\page.tsx',
     );
+    expect(mockExecFileSync).not.toHaveBeenCalled();
   });
 });
 
@@ -186,15 +175,9 @@ describe('getWslHome', () => {
 });
 
 describe('getSharedTempDir', () => {
-  it('converts Windows temp to WSL path', () => {
-    // isWslAvailable
-    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
-    // getDefaultWslDistro
-    mockExecFileSync.mockReturnValueOnce('* Ubuntu  Running  2\r\n' as any);
-    // wslpath -u for temp dir
-    mockExecFileSync.mockReturnValueOnce('/mnt/c/Users/test/AppData/Local/Temp\n' as any);
-
+  it('converts Windows temp to WSL path via heuristic', () => {
     expect(wsl.getSharedTempDir()).toBe('/mnt/c/Users/test/AppData/Local/Temp');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
   });
 });
 

--- a/src/main/wsl.test.ts
+++ b/src/main/wsl.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('os', () => ({
+  tmpdir: () => 'C:\\Users\\test\\AppData\\Local\\Temp',
+  homedir: () => 'C:\\Users\\test',
+}));
+
+vi.mock('./platform', () => ({
+  isWin: true,
+}));
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+}));
+
+import { execFileSync } from 'child_process';
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+type WslModule = typeof import('./wsl');
+let wsl: WslModule;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  wsl = await import('./wsl');
+});
+
+describe('isWslAvailable', () => {
+  it('returns true when wsl --status succeeds', () => {
+    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
+    expect(wsl.isWslAvailable()).toBe(true);
+  });
+
+  it('returns false when wsl --status throws', () => {
+    mockExecFileSync.mockImplementationOnce(() => { throw new Error('not found'); });
+    expect(wsl.isWslAvailable()).toBe(false);
+  });
+
+  it('caches the result', () => {
+    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
+    wsl.isWslAvailable();
+    wsl.isWslAvailable();
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getWslDistros', () => {
+  it('parses distro names from wsl --list --quiet output', () => {
+    // isWslAvailable probe
+    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
+    // --list --quiet
+    mockExecFileSync.mockReturnValueOnce('Ubuntu\r\nDebian\r\n' as any);
+
+    const distros = wsl.getWslDistros();
+    expect(distros).toEqual(['Ubuntu', 'Debian']);
+  });
+
+  it('returns empty array when WSL is not available', () => {
+    mockExecFileSync.mockImplementationOnce(() => { throw new Error('no wsl'); });
+    expect(wsl.getWslDistros()).toEqual([]);
+  });
+});
+
+describe('getDefaultWslDistro', () => {
+  it('identifies the default distro from verbose listing', () => {
+    // isWslAvailable
+    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
+    // --list --verbose
+    mockExecFileSync.mockReturnValueOnce(
+      '  NAME      STATE    VERSION\r\n* Ubuntu    Running  2\r\n  Debian    Stopped  2\r\n' as any
+    );
+
+    expect(wsl.getDefaultWslDistro()).toBe('Ubuntu');
+  });
+});
+
+describe('winPathToWsl', () => {
+  it('converts via wslpath when available', () => {
+    // isWslAvailable
+    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
+    // getDefaultWslDistro → --list --verbose
+    mockExecFileSync.mockReturnValueOnce('* Ubuntu  Running  2\r\n' as any);
+    // wslpath call
+    mockExecFileSync.mockReturnValueOnce('/mnt/c/Users/test/project\n' as any);
+
+    expect(wsl.winPathToWsl('C:\\Users\\test\\project')).toBe('/mnt/c/Users/test/project');
+  });
+
+  it('falls back to heuristic when wslpath fails', () => {
+    // isWslAvailable
+    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
+    // getDefaultWslDistro
+    mockExecFileSync.mockReturnValueOnce('* Ubuntu  Running  2\r\n' as any);
+    // wslpath throws
+    mockExecFileSync.mockImplementationOnce(() => { throw new Error('wslpath fail'); });
+
+    expect(wsl.winPathToWsl('D:\\code\\repo')).toBe('/mnt/d/code/repo');
+  });
+
+  it('uses -e for wslpath -u so the default shell does not mangle backslashes or special chars', () => {
+    mockExecFileSync.mockReturnValueOnce('/mnt/c/Users/test/(parens)/x\n' as any);
+    wsl.winPathToWsl('C:\\Users\\test\\(parens)\\x', 'Ubuntu');
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'wsl.exe',
+      ['-d', 'Ubuntu', '-e', 'wslpath', '-u', 'C:\\Users\\test\\(parens)\\x'],
+      expect.objectContaining({ timeout: 3000, encoding: 'utf8' }),
+    );
+  });
+});
+
+describe('wslPathToWin', () => {
+  it('converts via wslpath when available', () => {
+    // isWslAvailable
+    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
+    // getDefaultWslDistro
+    mockExecFileSync.mockReturnValueOnce('* Ubuntu  Running  2\r\n' as any);
+    // wslpath -w
+    mockExecFileSync.mockReturnValueOnce('\\\\wsl$\\Ubuntu\\home\\user\n' as any);
+
+    expect(wsl.wslPathToWin('/home/user')).toBe('\\\\wsl$\\Ubuntu\\home\\user');
+  });
+
+  it('falls back to UNC construction for pure Linux paths', () => {
+    // wslpath throws (distro passed explicitly, no isWslAvailable needed for the path itself)
+    mockExecFileSync.mockImplementationOnce(() => { throw new Error('fail'); });
+
+    expect(wsl.wslPathToWin('/home/user/project', 'Ubuntu')).toBe('\\\\wsl$\\Ubuntu\\home\\user\\project');
+  });
+
+  it('falls back to drive letter for /mnt/ paths', () => {
+    mockExecFileSync.mockImplementationOnce(() => { throw new Error('fail'); });
+
+    expect(wsl.wslPathToWin('/mnt/c/Users/test', 'Ubuntu')).toBe('C:\\Users\\test');
+  });
+
+  it('uses -e for wslpath -w so paths with parentheses are not parsed by bash', () => {
+    mockExecFileSync.mockReturnValueOnce('\\\\wsl$\\Ubuntu\\home\\user\\(app)\\page.tsx\n' as any);
+    wsl.wslPathToWin('/home/user/(app)/page.tsx', 'Ubuntu');
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'wsl.exe',
+      ['-d', 'Ubuntu', '-e', 'wslpath', '-w', '/home/user/(app)/page.tsx'],
+      expect.objectContaining({ timeout: 3000, encoding: 'utf8' }),
+    );
+  });
+});
+
+describe('uncWslPathToLinuxPath', () => {
+  it('strips \\\\wsl$\\ distro prefix', () => {
+    expect(wsl.uncWslPathToLinuxPath('\\\\wsl$\\Ubuntu\\home\\user\\repo')).toBe('/home/user/repo');
+  });
+
+  it('strips \\\\wsl.localhost\\ prefix', () => {
+    expect(wsl.uncWslPathToLinuxPath('\\\\wsl.localhost\\Ubuntu\\home\\user')).toBe('/home/user');
+  });
+
+  it('returns null for non-UNC paths', () => {
+    expect(wsl.uncWslPathToLinuxPath('C:\\foo')).toBeNull();
+  });
+});
+
+describe('normalizeProjectPathForWslStorage', () => {
+  it('normalizes UNC to Linux path', () => {
+    expect(wsl.normalizeProjectPathForWslStorage('\\\\wsl$\\Ubuntu\\home\\scrot\\code')).toBe('/home/scrot/code');
+  });
+
+  it('passes through and collapses POSIX paths', () => {
+    expect(wsl.normalizeProjectPathForWslStorage('/home/scrot/code//')).toBe('/home/scrot/code');
+  });
+});
+
+describe('getWslHome', () => {
+  it('returns home directory from WSL', () => {
+    mockExecFileSync.mockReturnValueOnce('/home/testuser\n');
+
+    expect(wsl.getWslHome('Ubuntu')).toBe('/home/testuser');
+  });
+
+  it('falls back to /root on error', () => {
+    mockExecFileSync.mockImplementationOnce(() => { throw new Error('fail'); });
+
+    expect(wsl.getWslHome('Ubuntu')).toBe('/root');
+  });
+});
+
+describe('getSharedTempDir', () => {
+  it('converts Windows temp to WSL path', () => {
+    // isWslAvailable
+    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
+    // getDefaultWslDistro
+    mockExecFileSync.mockReturnValueOnce('* Ubuntu  Running  2\r\n' as any);
+    // wslpath -u for temp dir
+    mockExecFileSync.mockReturnValueOnce('/mnt/c/Users/test/AppData/Local/Temp\n' as any);
+
+    expect(wsl.getSharedTempDir()).toBe('/mnt/c/Users/test/AppData/Local/Temp');
+  });
+});
+
+describe('getEffectiveDistro', () => {
+  it('uses preference when valid', () => {
+    // isWslAvailable
+    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
+    // getWslDistros → --list --quiet
+    mockExecFileSync.mockReturnValueOnce('Ubuntu\r\nDebian\r\n' as any);
+
+    expect(wsl.getEffectiveDistro('Debian')).toBe('Debian');
+  });
+
+  it('falls back to default when preference not in list', () => {
+    // isWslAvailable
+    mockExecFileSync.mockReturnValueOnce(Buffer.from('') as any);
+    // getWslDistros → --list --quiet
+    mockExecFileSync.mockReturnValueOnce('Ubuntu\r\n' as any);
+    // getDefaultWslDistro → --list --verbose
+    mockExecFileSync.mockReturnValueOnce('* Ubuntu  Running  2\r\n' as any);
+
+    expect(wsl.getEffectiveDistro('NonExistent')).toBe('Ubuntu');
+  });
+});

--- a/src/main/wsl.ts
+++ b/src/main/wsl.ts
@@ -1,0 +1,328 @@
+/**
+ * WSL2 integration utilities for the Windows Electron build.
+ *
+ * Provides detection, distro enumeration, path translation, and command
+ * execution helpers so the app can spawn CLI tools inside WSL2 while
+ * running as a native Windows process.
+ */
+
+import { execSync, execFileSync } from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
+import { isWin } from './platform';
+
+const WSL_EXE = 'wsl.exe';
+
+// ── Caches ──────────────────────────────────────────────────────────
+
+let cachedAvailable: boolean | null = null;
+let cachedDistros: string[] | null = null;
+let cachedDefaultDistro: string | null = null;
+let cachedWslHome = new Map<string, string>();
+const pathCache = new Map<string, string>();
+
+export function clearCaches(): void {
+  cachedAvailable = null;
+  cachedDistros = null;
+  cachedDefaultDistro = null;
+  cachedWslHome.clear();
+  pathCache.clear();
+}
+
+// ── Detection ───────────────────────────────────────────────────────
+
+/**
+ * Returns true when running on Windows and WSL2 is installed and functional.
+ * Result is cached after the first probe.
+ */
+export function isWslAvailable(): boolean {
+  if (!isWin) return false;
+  if (cachedAvailable !== null) return cachedAvailable;
+
+  try {
+    // `wsl --status` exits 0 when WSL2 is healthy
+    execFileSync(WSL_EXE, ['--status'], { timeout: 5000, stdio: 'pipe' });
+    cachedAvailable = true;
+  } catch {
+    cachedAvailable = false;
+  }
+  return cachedAvailable;
+}
+
+// ── Distro listing ──────────────────────────────────────────────────
+
+/**
+ * Returns the list of installed WSL distro names.
+ * `wsl --list --quiet` outputs one distro per line (UTF-16LE on Windows).
+ */
+export function getWslDistros(): string[] {
+  if (!isWslAvailable()) return [];
+  if (cachedDistros) return cachedDistros;
+
+  try {
+    const raw = execFileSync(WSL_EXE, ['--list', '--quiet'], {
+      timeout: 5000,
+      encoding: 'utf16le' as BufferEncoding,
+    });
+    cachedDistros = raw
+      .split(/\r?\n/)
+      .map((line) => line.replace(/\0/g, '').trim())
+      .filter(Boolean);
+  } catch {
+    cachedDistros = [];
+  }
+  return cachedDistros;
+}
+
+/**
+ * Returns the default WSL distro (marked with `*` in `wsl --list --verbose`).
+ * Falls back to the first distro if parsing fails.
+ */
+export function getDefaultWslDistro(): string | null {
+  if (!isWslAvailable()) return null;
+  if (cachedDefaultDistro !== null) return cachedDefaultDistro;
+
+  try {
+    const raw = execFileSync(WSL_EXE, ['--list', '--verbose'], {
+      timeout: 5000,
+      encoding: 'utf16le' as BufferEncoding,
+    });
+    const lines = raw.split(/\r?\n/).map((l) => l.replace(/\0/g, ''));
+    for (const line of lines) {
+      const match = line.match(/^\s*\*\s+(\S+)/);
+      if (match) {
+        cachedDefaultDistro = match[1];
+        return cachedDefaultDistro;
+      }
+    }
+  } catch {
+    // fall through
+  }
+
+  const distros = getWslDistros();
+  cachedDefaultDistro = distros[0] ?? null;
+  return cachedDefaultDistro;
+}
+
+// ── Path translation ────────────────────────────────────────────────
+
+/**
+ * If `winPath` is a `\\wsl$\...` or `\\wsl.localhost\...` UNC path, return the
+ * Linux absolute path (forward slashes). Otherwise return null.
+ */
+export function uncWslPathToLinuxPath(winPath: string): string | null {
+  const norm = winPath.trim().replace(/\//g, '\\');
+  let m = norm.match(/^\\\\wsl\$\\([^\\]+)\\(.*)$/i);
+  if (!m) m = norm.match(/^\\\\wsl\.localhost\\([^\\]+)\\(.*)$/i);
+  if (!m) return null;
+  const tail = m[2].replace(/\\/g, '/');
+  if (!tail) return '/';
+  return '/' + tail.replace(/^\/+/, '');
+}
+
+function collapsePosixPath(p: string): string {
+  let s = p.replace(/\/+/g, '/');
+  if (s.length > 1) s = s.replace(/\/$/, '');
+  return s;
+}
+
+/**
+ * Normalize a project/root path for persistence when WSL mode is on: store as a
+ * single Linux absolute path (`/home/...` or `/mnt/c/...`), never `\\wsl$\...`.
+ */
+export function normalizeProjectPathForWslStorage(raw: string, distro?: string): string {
+  const t = raw.trim();
+  if (!t) return t;
+  const fromUnc = uncWslPathToLinuxPath(t);
+  if (fromUnc !== null) return collapsePosixPath(fromUnc);
+  const slash = t.replace(/\\/g, '/');
+  if (slash.startsWith('/') && !/^[A-Za-z]:\//.test(slash)) {
+    return collapsePosixPath(slash);
+  }
+  if (t.includes('\\') || /^[A-Za-z]:/.test(t)) {
+    return collapsePosixPath(winPathToWsl(t, distro));
+  }
+  return collapsePosixPath(slash);
+}
+
+/**
+ * Convert a Windows path to a Linux path inside WSL.
+ * e.g. `C:\Users\foo\project` → `/mnt/c/Users/foo/project`
+ */
+export function winPathToWsl(winPath: string, distro?: string): string {
+  const key = `w2l:${distro || ''}:${winPath}`;
+  const cached = pathCache.get(key);
+  if (cached) return cached;
+
+  const d = distro || getDefaultWslDistro();
+  if (!d) return winPath;
+
+  try {
+    // `-e` runs wslpath directly; `--` runs via the default shell and breaks on
+    // Windows paths with backslash escapes and on Linux paths with `(` `)`.
+    const args = ['-d', d, '-e', 'wslpath', '-u', winPath];
+    const result = execFileSync(WSL_EXE, args, {
+      timeout: 3000,
+      encoding: 'utf8',
+    }).trim();
+    if (result) {
+      pathCache.set(key, result);
+      return result;
+    }
+  } catch {
+    // Fallback: simple heuristic for common drive letter paths
+  }
+
+  const fallback = winPath
+    .replace(/^([A-Za-z]):\\/, (_, drive: string) => `/mnt/${drive.toLowerCase()}/`)
+    .replace(/\\/g, '/');
+  pathCache.set(key, fallback);
+  return fallback;
+}
+
+/**
+ * Convert a Linux path inside WSL to a Windows UNC path.
+ * e.g. `/home/foo` → `\\wsl$\Ubuntu\home\foo`
+ */
+export function wslPathToWin(linuxPath: string, distro?: string): string {
+  const key = `l2w:${distro || ''}:${linuxPath}`;
+  const cached = pathCache.get(key);
+  if (cached) return cached;
+
+  const d = distro || getDefaultWslDistro();
+  if (!d) return linuxPath;
+
+  try {
+    const args = ['-d', d, '-e', 'wslpath', '-w', linuxPath];
+    const result = execFileSync(WSL_EXE, args, {
+      timeout: 3000,
+      encoding: 'utf8',
+    }).trim();
+    if (result) {
+      pathCache.set(key, result);
+      return result;
+    }
+  } catch {
+    // Fallback: manual UNC construction
+  }
+
+  // For paths starting with /mnt/<drive>/, convert back to drive letter
+  const mntMatch = linuxPath.match(/^\/mnt\/([a-z])\/(.*)/);
+  if (mntMatch) {
+    const result = `${mntMatch[1].toUpperCase()}:\\${mntMatch[2].replace(/\//g, '\\')}`;
+    pathCache.set(key, result);
+    return result;
+  }
+
+  // For pure Linux paths, use UNC
+  const result = `\\\\wsl$\\${d}${linuxPath.replace(/\//g, '\\')}`;
+  pathCache.set(key, result);
+  return result;
+}
+
+// ── WSL home directory ──────────────────────────────────────────────
+
+/**
+ * Returns the Linux home directory for the default user in the given distro.
+ * Cached per distro.
+ */
+export function getWslHome(distro?: string): string {
+  const d = distro || getDefaultWslDistro() || 'Ubuntu';
+  const cached = cachedWslHome.get(d);
+  if (cached) return cached;
+
+  try {
+    const result = execFileSync(WSL_EXE, ['-d', d, '--', 'sh', '-c', 'echo $HOME'], {
+      timeout: 3000,
+      encoding: 'utf8',
+    }).trim();
+    if (result) {
+      cachedWslHome.set(d, result);
+      return result;
+    }
+  } catch {
+    // fallback
+  }
+
+  const fallback = '/root';
+  cachedWslHome.set(d, fallback);
+  return fallback;
+}
+
+/**
+ * Returns the Windows UNC path to a file under the WSL user's home.
+ * e.g. `getWslHomePath('.claude/settings.json', 'Ubuntu')` →
+ *      `\\wsl$\Ubuntu\home\user\.claude\settings.json`
+ */
+export function getWslHomePath(relativePath: string, distro?: string): string {
+  const home = getWslHome(distro);
+  const linuxPath = `${home}/${relativePath}`;
+  return wslPathToWin(linuxPath, distro);
+}
+
+// ── Command execution ───────────────────────────────────────────────
+
+/**
+ * Execute a command inside WSL and return its stdout.
+ */
+export function wslExec(
+  command: string,
+  args: string[] = [],
+  distro?: string,
+  options?: { timeout?: number; cwd?: string },
+): string {
+  const d = distro || getDefaultWslDistro();
+  if (!d) throw new Error('No WSL distro available');
+
+  const wslArgs = ['-d', d, '--', command, ...args];
+  return execFileSync(WSL_EXE, wslArgs, {
+    timeout: options?.timeout ?? 10000,
+    encoding: 'utf8',
+    cwd: options?.cwd,
+  }).trim();
+}
+
+/**
+ * List directories inside WSL at the given path, optionally filtered by prefix.
+ * Used for path autocomplete in the project browser.
+ */
+export function wslListDirs(dirPath: string, prefix?: string, distro?: string): string[] {
+  const d = distro || getDefaultWslDistro();
+  if (!d) return [];
+
+  try {
+    const pattern = prefix ? `${dirPath}${prefix}*/` : `${dirPath}*/`;
+    const raw = wslExec('sh', ['-c', `ls -1d ${pattern} 2>/dev/null || true`], d, { timeout: 3000 });
+    return raw
+      .split('\n')
+      .map((l) => l.trim().replace(/\/$/, ''))
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+// ── WSL mode helpers ────────────────────────────────────────────────
+
+/**
+ * Get the effective WSL distro from preferences, falling back to default.
+ */
+export function getEffectiveDistro(prefDistro?: string): string | null {
+  if (prefDistro) {
+    const distros = getWslDistros();
+    if (distros.includes(prefDistro)) return prefDistro;
+  }
+  return getDefaultWslDistro();
+}
+
+/**
+ * Returns the Windows temp dir as a WSL-accessible path.
+ * e.g. `C:\Users\foo\AppData\Local\Temp` → `/mnt/c/Users/foo/AppData/Local/Temp`
+ *
+ * Used so hook scripts inside WSL write to a location the Windows-side
+ * `fs.watch` can observe.
+ */
+export function getSharedTempDir(distro?: string): string {
+  const winTemp = os.tmpdir();
+  return winPathToWsl(winTemp, distro);
+}

--- a/src/main/wsl.ts
+++ b/src/main/wsl.ts
@@ -13,6 +13,73 @@ import { isWin } from './platform';
 
 const WSL_EXE = 'wsl.exe';
 
+/** Options for wslpath probes: avoid spamming stderr when a method fails and we retry. */
+const wslExecFileWslpathOpts: Parameters<typeof execFileSync>[2] = {
+  timeout: 3000,
+  encoding: 'utf8',
+  stdio: ['ignore', 'pipe', 'pipe'],
+};
+
+/**
+ * `C:\` / `C:/` → `/mnt/c/...` without calling into WSL (avoids wslpath/shell entirely).
+ */
+function winPathToWslHeuristic(winPath: string): string | null {
+  const t = winPath.trim();
+  if (!/^[A-Za-z]:[\\/]/.test(t)) return null;
+  return t
+    .replace(/^([A-Za-z]):\\/, (_, drive: string) => `/mnt/${drive.toLowerCase()}/`)
+    .replace(/^([A-Za-z]):\//, (_, drive: string) => `/mnt/${drive.toLowerCase()}/`)
+    .replace(/\\/g, '/');
+}
+
+/**
+ * Linux absolute path → Windows path for `fs` / UNC access, without `wslpath -w`.
+ * Matches what `wslpath -w` does for normal WSL2 layouts; avoids subprocesses and
+ * shell parsing issues on paths with `(`, spaces, etc.
+ */
+function linuxPathToWinHeuristic(linuxPath: string, distro: string): string {
+  const mntMatch = linuxPath.match(/^\/mnt\/([a-z])\/(.*)/);
+  if (mntMatch) {
+    return `${mntMatch[1].toUpperCase()}:\\${mntMatch[2].replace(/\//g, '\\')}`;
+  }
+  if (linuxPath.startsWith('/')) {
+    return `\\\\wsl$\\${distro}${linuxPath.replace(/\//g, '\\')}`;
+  }
+  return linuxPath;
+}
+
+/**
+ * Run `wslpath -u` inside WSL for Windows paths that are not plain `X:\` (e.g. `\\?\`, odd UNC).
+ * Uses `-e` and a `sh -c` fallback so the path is not parsed by the login shell.
+ */
+function execWslpathUnix(distro: string, winPath: string): string | null {
+  const direct: string[][] = [
+    ['-d', distro, '-e', 'wslpath', '-u', winPath],
+    ['-d', distro, '--exec', 'wslpath', '-u', winPath],
+  ];
+  for (const args of direct) {
+    try {
+      const out = String(execFileSync(WSL_EXE, args, wslExecFileWslpathOpts)).trim();
+      if (out) return out;
+    } catch {
+      // try next
+    }
+  }
+  try {
+    const out = String(
+      execFileSync(
+        WSL_EXE,
+        ['-d', distro, '--', 'sh', '-c', 'exec wslpath -u "$1"', '_', winPath],
+        wslExecFileWslpathOpts,
+      ),
+    ).trim();
+    if (out) return out;
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
 // ── Caches ──────────────────────────────────────────────────────────
 
 let cachedAvailable: boolean | null = null;
@@ -154,23 +221,27 @@ export function winPathToWsl(winPath: string, distro?: string): string {
   const cached = pathCache.get(key);
   if (cached) return cached;
 
+  const t = winPath.trim();
+  const fromUnc = uncWslPathToLinuxPath(t);
+  if (fromUnc !== null) {
+    const r = collapsePosixPath(fromUnc);
+    pathCache.set(key, r);
+    return r;
+  }
+
+  const heuristic = winPathToWslHeuristic(t);
+  if (heuristic) {
+    pathCache.set(key, heuristic);
+    return heuristic;
+  }
+
   const d = distro || getDefaultWslDistro();
   if (!d) return winPath;
 
-  try {
-    // `-e` runs wslpath directly; `--` runs via the default shell and breaks on
-    // Windows paths with backslash escapes and on Linux paths with `(` `)`.
-    const args = ['-d', d, '-e', 'wslpath', '-u', winPath];
-    const result = execFileSync(WSL_EXE, args, {
-      timeout: 3000,
-      encoding: 'utf8',
-    }).trim();
-    if (result) {
-      pathCache.set(key, result);
-      return result;
-    }
-  } catch {
-    // Fallback: simple heuristic for common drive letter paths
+  const converted = execWslpathUnix(d, winPath);
+  if (converted) {
+    pathCache.set(key, converted);
+    return converted;
   }
 
   const fallback = winPath
@@ -192,30 +263,7 @@ export function wslPathToWin(linuxPath: string, distro?: string): string {
   const d = distro || getDefaultWslDistro();
   if (!d) return linuxPath;
 
-  try {
-    const args = ['-d', d, '-e', 'wslpath', '-w', linuxPath];
-    const result = execFileSync(WSL_EXE, args, {
-      timeout: 3000,
-      encoding: 'utf8',
-    }).trim();
-    if (result) {
-      pathCache.set(key, result);
-      return result;
-    }
-  } catch {
-    // Fallback: manual UNC construction
-  }
-
-  // For paths starting with /mnt/<drive>/, convert back to drive letter
-  const mntMatch = linuxPath.match(/^\/mnt\/([a-z])\/(.*)/);
-  if (mntMatch) {
-    const result = `${mntMatch[1].toUpperCase()}:\\${mntMatch[2].replace(/\//g, '\\')}`;
-    pathCache.set(key, result);
-    return result;
-  }
-
-  // For pure Linux paths, use UNC
-  const result = `\\\\wsl$\\${d}${linuxPath.replace(/\//g, '\\')}`;
+  const result = linuxPathToWinHeuristic(linuxPath, d);
   pathCache.set(key, result);
   return result;
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -103,6 +103,12 @@ export interface VibeyardApi {
   stats: {
     getCache(): Promise<StatsCache | null>;
   };
+  wsl: {
+    isAvailable(): Promise<boolean>;
+    getDistros(): Promise<string[]>;
+    getDefaultDistro(): Promise<string | null>;
+    browseDirs(dirPath: string, prefix?: string): Promise<string[]>;
+  };
   settings: {
     onWarning(callback: (data: SettingsWarningData) => void): () => void;
     onConflictDialog(callback: (data: StatusLineConflictData) => void): () => void;
@@ -251,6 +257,12 @@ const api: VibeyardApi = {
   },
   stats: {
     getCache: () => ipcRenderer.invoke('stats:getCache'),
+  },
+  wsl: {
+    isAvailable: () => ipcRenderer.invoke('wsl:isAvailable'),
+    getDistros: () => ipcRenderer.invoke('wsl:getDistros'),
+    getDefaultDistro: () => ipcRenderer.invoke('wsl:getDefaultDistro'),
+    browseDirs: (dirPath: string, prefix?: string) => ipcRenderer.invoke('wsl:browseDirs', dirPath, prefix),
   },
   settings: {
     onWarning: (cb) => onChannel('settings:warning', (data) => cb(data as SettingsWarningData)),

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -83,6 +83,9 @@ export interface VibeyardApi {
     getBrowserPreloadPath(): Promise<string>;
     /** Chromium page zoom (1 = 100%). Replaces CSS `zoom` for reliable layout on all platforms. */
     setZoomFactor(factor: number): Promise<void>;
+    browseImageFile(): Promise<string | null>;
+    /** Binary image for terminal backdrop (renderer builds a Blob URL). */
+    readBackgroundImage(filePath: string): Promise<{ mime: string; data: ArrayBuffer } | null>;
     onQuitting(callback: () => void): () => void;
   };
   browser: {
@@ -240,6 +243,8 @@ const api: VibeyardApi = {
     openExternal: (url: string) => ipcRenderer.invoke('app:openExternal', url),
     getBrowserPreloadPath: () => ipcRenderer.invoke('app:getBrowserPreloadPath'),
     setZoomFactor: (factor: number) => ipcRenderer.invoke('app:setZoomFactor', factor),
+    browseImageFile: () => ipcRenderer.invoke('app:browseImageFile'),
+    readBackgroundImage: (filePath: string) => ipcRenderer.invoke('app:readBackgroundImage', filePath),
     onQuitting: (cb: () => void) => onChannel('app:quitting', cb),
   },
   browser: {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -64,6 +64,7 @@ export interface VibeyardApi {
     listBranches(path: string): Promise<{ name: string; current: boolean }[]>;
     checkoutBranch(path: string, branch: string): Promise<void>;
     createBranch(path: string, branch: string): Promise<void>;
+    createWorktree(path: string, worktreePath: string, newBranch?: string): Promise<void>;
     watchProject(path: string): void;
     onChanged(callback: () => void): () => void;
   };
@@ -80,6 +81,8 @@ export interface VibeyardApi {
     getVersion(): Promise<string>;
     openExternal(url: string): Promise<void>;
     getBrowserPreloadPath(): Promise<string>;
+    /** Chromium page zoom (1 = 100%). Replaces CSS `zoom` for reliable layout on all platforms. */
+    setZoomFactor(factor: number): Promise<void>;
     onQuitting(callback: () => void): () => void;
   };
   browser: {
@@ -218,6 +221,8 @@ const api: VibeyardApi = {
     listBranches: (path: string) => ipcRenderer.invoke('git:listBranches', path),
     checkoutBranch: (path: string, branch: string) => ipcRenderer.invoke('git:checkoutBranch', path, branch),
     createBranch: (path: string, branch: string) => ipcRenderer.invoke('git:createBranch', path, branch),
+    createWorktree: (path: string, worktreePath: string, newBranch?: string) =>
+      ipcRenderer.invoke('git:createWorktree', path, worktreePath, newBranch),
     watchProject: (path: string) => ipcRenderer.send('git:watchProject', path),
     onChanged: (callback: () => void) => onChannel('git:changed', callback),
   },
@@ -234,6 +239,7 @@ const api: VibeyardApi = {
     getVersion: () => ipcRenderer.invoke('app:getVersion'),
     openExternal: (url: string) => ipcRenderer.invoke('app:openExternal', url),
     getBrowserPreloadPath: () => ipcRenderer.invoke('app:getBrowserPreloadPath'),
+    setZoomFactor: (factor: number) => ipcRenderer.invoke('app:setZoomFactor', factor),
     onQuitting: (cb: () => void) => onChannel('app:quitting', cb),
   },
   browser: {

--- a/src/renderer/components/custom-select.ts
+++ b/src/renderer/components/custom-select.ts
@@ -7,6 +7,7 @@ export interface SelectOption {
 export interface CustomSelectInstance {
   element: HTMLElement;
   getValue(): string;
+  setValue(value: string): void;
   destroy(): void;
 }
 
@@ -14,6 +15,7 @@ export function createCustomSelect(
   id: string,
   options: SelectOption[],
   defaultValue?: string,
+  onChange?: (value: string) => void,
 ): CustomSelectInstance {
   const defaultOpt = options.find(o => o.value === defaultValue) ?? options.find(o => !o.disabled) ?? options[0];
 
@@ -68,6 +70,7 @@ export function createCustomSelect(
     items.forEach(el => el.classList.remove('selected'));
     items[index].classList.add('selected');
     closeDropdown();
+    onChange?.(opt.value);
   }
 
   function updateActive(): void {
@@ -142,6 +145,11 @@ export function createCustomSelect(
   return {
     element: wrapper,
     getValue() { return hidden.value; },
+    setValue(value: string) {
+      const idx = options.findIndex((o) => o.value === value && !o.disabled);
+      if (idx < 0) return;
+      selectOption(idx);
+    },
     destroy() { document.removeEventListener('mousedown', onOutsideClick); },
   };
 }

--- a/src/renderer/components/git-panel.ts
+++ b/src/renderer/components/git-panel.ts
@@ -1,5 +1,6 @@
 import { appState } from '../state.js';
-import { onChange as onGitStatusChange, getGitStatus, getActiveGitPath, getWorktrees, setActiveWorktree, onWorktreeChange } from '../git-status.js';
+import { onChange as onGitStatusChange, getGitStatus, getActiveGitPath, getWorktrees, onWorktreeChange, sessionSupportsGitWorktreePin } from '../git-status.js';
+import { applyWorktreeSelection } from '../worktree-actions.js';
 import { onChange as onStatusChange } from '../session-activity.js';
 import { showFileViewer } from './file-viewer.js';
 import { areaLabel } from '../dom-utils.js';
@@ -137,13 +138,18 @@ function renderWorktreeSelector(container: HTMLElement, project: { id: string; p
 
   if (!worktrees || worktrees.length <= 1) return;
 
-  const activeGitPath = getActiveGitPath(project.id);
-
   const wrapper = document.createElement('div');
   wrapper.className = 'git-worktree-selector';
 
   const select = document.createElement('select');
   select.className = 'git-worktree-select';
+
+  const session = appState.activeSession;
+  const autoOpt = document.createElement('option');
+  autoOpt.value = '';
+  autoOpt.textContent = 'Auto (shell CWD)';
+  autoOpt.selected = !session?.gitWorktreeUserPinned;
+  select.appendChild(autoOpt);
 
   for (const wt of worktrees) {
     if (wt.isBare) continue;
@@ -152,12 +158,12 @@ function renderWorktreeSelector(container: HTMLElement, project: { id: string; p
     const label = wt.branch || `detached (${wt.head.slice(0, 7)})`;
     const pathHint = wt.path === project.path ? '' : ` — ${shortPath(wt.path)}`;
     option.textContent = label + pathHint;
-    option.selected = wt.path === activeGitPath;
+    option.selected = Boolean(session?.gitWorktreeUserPinned && session.gitWorktreePath === wt.path);
     select.appendChild(option);
   }
 
   select.addEventListener('change', () => {
-    setActiveWorktree(project.id, select.value);
+    applyWorktreeSelection(project.id, select.value || null);
   });
 
   wrapper.appendChild(select);
@@ -211,7 +217,8 @@ async function refresh(): Promise<void> {
 
   const activeGitPath = getActiveGitPath(project.id);
   const worktrees = getWorktrees(project.id);
-  const hasMultipleWorktrees = worktrees && worktrees.length > 1;
+  const pinWorktreeUi = sessionSupportsGitWorktreePin(appState.activeSession);
+  const hasMultipleWorktrees = pinWorktreeUi && worktrees && worktrees.length > 1;
 
   // Find active worktree branch for header
   let headerSuffix = '';

--- a/src/renderer/components/git-panel.ts
+++ b/src/renderer/components/git-panel.ts
@@ -1,6 +1,6 @@
 import { appState } from '../state.js';
 import { onChange as onGitStatusChange, getGitStatus, getActiveGitPath, getWorktrees, onWorktreeChange, sessionSupportsGitWorktreePin } from '../git-status.js';
-import { applyWorktreeSelection } from '../worktree-actions.js';
+import { applyWorktreeSelection, promptCreateWorktree } from '../worktree-actions.js';
 import { onChange as onStatusChange } from '../session-activity.js';
 import { showFileViewer } from './file-viewer.js';
 import { areaLabel } from '../dom-utils.js';
@@ -136,7 +136,8 @@ function renderWorktreeSelector(container: HTMLElement, project: { id: string; p
   const existing = container.querySelector('.git-worktree-selector');
   if (existing) existing.remove();
 
-  if (!worktrees || worktrees.length <= 1) return;
+  const pickable = worktrees?.filter((w) => !w.isBare) ?? [];
+  if (pickable.length < 1) return;
 
   const wrapper = document.createElement('div');
   wrapper.className = 'git-worktree-selector';
@@ -151,8 +152,7 @@ function renderWorktreeSelector(container: HTMLElement, project: { id: string; p
   autoOpt.selected = !session?.gitWorktreeUserPinned;
   select.appendChild(autoOpt);
 
-  for (const wt of worktrees) {
-    if (wt.isBare) continue;
+  for (const wt of pickable) {
     const option = document.createElement('option');
     option.value = wt.path;
     const label = wt.branch || `detached (${wt.head.slice(0, 7)})`;
@@ -167,6 +167,17 @@ function renderWorktreeSelector(container: HTMLElement, project: { id: string; p
   });
 
   wrapper.appendChild(select);
+
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.className = 'config-section-add-btn';
+  addBtn.title = 'Create new worktree';
+  addBtn.textContent = '+';
+  addBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    promptCreateWorktree(project);
+  });
+  wrapper.appendChild(addBtn);
 
   // Insert after header
   const header = container.querySelector('.config-section-header');
@@ -218,7 +229,9 @@ async function refresh(): Promise<void> {
   const activeGitPath = getActiveGitPath(project.id);
   const worktrees = getWorktrees(project.id);
   const pinWorktreeUi = sessionSupportsGitWorktreePin(appState.activeSession);
-  const hasMultipleWorktrees = pinWorktreeUi && worktrees && worktrees.length > 1;
+  const pickableWtCount = worktrees?.filter((w) => !w.isBare).length ?? 0;
+  const showWorktreeSelector = pinWorktreeUi && pickableWtCount >= 1;
+  const hasMultipleWorktrees = pinWorktreeUi && pickableWtCount > 1;
 
   // Find active worktree branch for header
   let headerSuffix = '';
@@ -241,7 +254,7 @@ async function refresh(): Promise<void> {
     }
 
     // Update worktree selector
-    if (hasMultipleWorktrees) {
+    if (showWorktreeSelector) {
       renderWorktreeSelector(container, project);
     } else {
       const selector = container.querySelector('.git-worktree-selector');
@@ -282,8 +295,8 @@ async function refresh(): Promise<void> {
   container.innerHTML = '';
   container.appendChild(section);
 
-  // Add worktree selector if multiple worktrees
-  if (hasMultipleWorktrees) {
+  // Worktree pin + create (shown whenever the session can pin and the repo has at least one checkout)
+  if (showWorktreeSelector) {
     renderWorktreeSelector(container, project);
   }
 

--- a/src/renderer/components/preferences-modal.ts
+++ b/src/renderer/components/preferences-modal.ts
@@ -63,6 +63,8 @@ export function showPreferencesModal(): void {
   let autoTitleCheckbox: HTMLInputElement | null = null;
   let defaultProviderSelect: CustomSelectInstance | null = null;
   let debugModeCheckbox: HTMLInputElement | null = null;
+  let wslCheckbox: HTMLInputElement | null = null;
+  let wslDistroSelect: CustomSelectInstance | null = null;
   let sidebarCheckboxes: { configSections: HTMLInputElement; gitPanel: HTMLInputElement; sessionHistory: HTMLInputElement; costFooter: HTMLInputElement; readinessSection: HTMLInputElement } | null = null;
   let activeRecorder: { cleanup: () => void } | null = null;
 
@@ -196,6 +198,68 @@ export function showPreferencesModal(): void {
       autoTitleRow.appendChild(autoTitleLabel);
       autoTitleRow.appendChild(autoTitleCheckbox);
       content.appendChild(autoTitleRow);
+
+      // WSL2 section (only relevant on Windows builds)
+      const wslSection = document.createElement('div');
+      wslSection.className = 'preferences-wsl-section';
+      wslSection.style.display = 'none'; // hidden until we confirm WSL is available
+
+      const wslHeader = document.createElement('div');
+      wslHeader.className = 'pref-section-header';
+      wslHeader.textContent = 'WSL2 Integration';
+      wslSection.appendChild(wslHeader);
+
+      const wslRow = document.createElement('div');
+      wslRow.className = 'modal-toggle-field';
+      const wslLabel = document.createElement('label');
+      wslLabel.htmlFor = 'pref-wsl-enabled';
+      wslLabel.textContent = 'Run CLI tools inside WSL2';
+      wslCheckbox = document.createElement('input');
+      wslCheckbox.type = 'checkbox';
+      wslCheckbox.id = 'pref-wsl-enabled';
+      wslCheckbox.checked = appState.preferences.wslEnabled ?? false;
+      wslRow.appendChild(wslLabel);
+      wslRow.appendChild(wslCheckbox);
+      wslSection.appendChild(wslRow);
+
+      const wslDistroRow = document.createElement('div');
+      wslDistroRow.className = 'modal-toggle-field';
+      const wslDistroLabel = document.createElement('label');
+      wslDistroLabel.textContent = 'WSL Distro';
+      wslDistroRow.appendChild(wslDistroLabel);
+
+      const distroPlaceholder = document.createElement('span');
+      distroPlaceholder.textContent = 'Detecting…';
+      distroPlaceholder.className = 'pref-wsl-detecting';
+      wslDistroRow.appendChild(distroPlaceholder);
+      wslSection.appendChild(wslDistroRow);
+
+      content.appendChild(wslSection);
+
+      // Async: check WSL availability and populate distro dropdown
+      window.vibeyard.wsl.isAvailable().then(async (available) => {
+        if (!available || currentSection !== 'general') return;
+        wslSection.style.display = '';
+
+        const distros = await window.vibeyard.wsl.getDistros();
+        const defaultDistro = await window.vibeyard.wsl.getDefaultDistro();
+        const current = appState.preferences.wslDistro ?? defaultDistro ?? distros[0] ?? '';
+
+        distroPlaceholder.remove();
+        if (distros.length > 0) {
+          wslDistroSelect = createCustomSelect(
+            'pref-wsl-distro',
+            distros.map(d => ({ value: d, label: d === defaultDistro ? `${d} (default)` : d })),
+            current,
+          );
+          wslDistroRow.appendChild(wslDistroSelect.element);
+        } else {
+          const noDistro = document.createElement('span');
+          noDistro.textContent = 'No WSL distros found';
+          noDistro.style.color = 'var(--text-muted)';
+          wslDistroRow.appendChild(noDistro);
+        }
+      }).catch(() => {});
 
     } else if (section === 'sidebar') {
       const views = appState.preferences.sidebarViews ?? { configSections: true, gitPanel: true, sessionHistory: true, costFooter: true, readinessSection: true };
@@ -697,6 +761,12 @@ export function showPreferencesModal(): void {
         costFooter: sidebarCheckboxes.costFooter.checked,
         readinessSection: sidebarCheckboxes.readinessSection.checked,
       });
+    }
+    if (wslCheckbox) {
+      appState.setPreference('wslEnabled', wslCheckbox.checked);
+    }
+    if (wslDistroSelect) {
+      appState.setPreference('wslDistro', wslDistroSelect.getValue());
     }
   };
 

--- a/src/renderer/components/preferences-modal.ts
+++ b/src/renderer/components/preferences-modal.ts
@@ -4,6 +4,8 @@ import { createCustomSelect, type CustomSelectInstance } from './custom-select.j
 import { shortcutManager, displayKeys, eventToAccelerator } from '../shortcuts.js';
 import { loadProviderAvailability, getProviderAvailabilitySnapshot } from '../provider-availability.js';
 import type { CliProviderMeta, ProviderId, SettingsValidationResult } from '../../shared/types.js';
+import { UI_ZOOM_SIZE_OPTIONS } from '../display-preferences.js';
+import { TERMINAL_FONT_SIZE_OPTIONS } from '../terminal-font-size.js';
 
 
 const overlay = document.getElementById('modal-overlay')!;
@@ -62,6 +64,8 @@ export function showPreferencesModal(): void {
   let insightsCheckbox: HTMLInputElement | null = null;
   let autoTitleCheckbox: HTMLInputElement | null = null;
   let defaultProviderSelect: CustomSelectInstance | null = null;
+  let uiZoomSelect: CustomSelectInstance | null = null;
+  let terminalFontSelect: CustomSelectInstance | null = null;
   let debugModeCheckbox: HTMLInputElement | null = null;
   let wslCheckbox: HTMLInputElement | null = null;
   let wslDistroSelect: CustomSelectInstance | null = null;
@@ -118,6 +122,52 @@ export function showPreferencesModal(): void {
       providerRow.appendChild(providerLabel);
       providerRow.appendChild(defaultProviderSelect.element);
       content.appendChild(providerRow);
+
+      uiZoomSelect?.destroy();
+      terminalFontSelect?.destroy();
+      uiZoomSelect = null;
+      terminalFontSelect = null;
+
+      const displayHeader = document.createElement('div');
+      displayHeader.className = 'pref-section-header';
+      displayHeader.textContent = 'Display';
+      content.appendChild(displayHeader);
+
+      const uiZoomRow = document.createElement('div');
+      uiZoomRow.className = 'modal-toggle-field';
+      const uiZoomLabel = document.createElement('label');
+      uiZoomLabel.textContent = 'Interface scale';
+      const zoomRaw = appState.preferences.uiZoom ?? 1;
+      const zoomSnapped = UI_ZOOM_SIZE_OPTIONS.reduce((best, z) =>
+        Math.abs(z - zoomRaw) < Math.abs(best - zoomRaw) ? z : best,
+        UI_ZOOM_SIZE_OPTIONS[0],
+      );
+      const zoomVal = zoomSnapped.toFixed(2);
+      uiZoomSelect = createCustomSelect(
+        'pref-ui-zoom',
+        UI_ZOOM_SIZE_OPTIONS.map((z) => ({
+          value: z.toFixed(2),
+          label: z === 1 ? '100% (default)' : `${Math.round(z * 100)}%`,
+        })),
+        zoomVal,
+      );
+      uiZoomRow.appendChild(uiZoomLabel);
+      uiZoomRow.appendChild(uiZoomSelect.element);
+      content.appendChild(uiZoomRow);
+
+      const termFontRow = document.createElement('div');
+      termFontRow.className = 'modal-toggle-field';
+      const termFontLabel = document.createElement('label');
+      termFontLabel.textContent = 'Terminal font size';
+      const fontVal = String(appState.preferences.terminalFontSize ?? 14);
+      terminalFontSelect = createCustomSelect(
+        'pref-terminal-font',
+        TERMINAL_FONT_SIZE_OPTIONS.map((n) => ({ value: String(n), label: `${n}px` })),
+        fontVal,
+      );
+      termFontRow.appendChild(termFontLabel);
+      termFontRow.appendChild(terminalFontSelect.element);
+      content.appendChild(termFontRow);
 
       const row = document.createElement('div');
       row.className = 'modal-toggle-field';
@@ -749,6 +799,18 @@ export function showPreferencesModal(): void {
     if (defaultProviderSelect) {
       appState.setPreference('defaultProvider', defaultProviderSelect.getValue() as ProviderId);
     }
+    if (uiZoomSelect) {
+      const z = Number.parseFloat(uiZoomSelect.getValue());
+      if (Number.isFinite(z) && z >= 0.5 && z <= 4) {
+        appState.setPreference('uiZoom', z);
+      }
+    }
+    if (terminalFontSelect) {
+      const fs = Number.parseInt(terminalFontSelect.getValue(), 10);
+      if (Number.isFinite(fs)) {
+        appState.setPreference('terminalFontSize', Math.min(32, Math.max(10, fs)));
+      }
+    }
     if (debugModeCheckbox && debugModeCheckbox.checked !== appState.preferences.debugMode) {
       appState.setPreference('debugMode', debugModeCheckbox.checked);
       window.vibeyard.menu.rebuild(debugModeCheckbox.checked);
@@ -804,6 +866,8 @@ export function showPreferencesModal(): void {
   (overlay as any)._cleanup = () => {
     cleanupRecorder();
     if (defaultProviderSelect) defaultProviderSelect.destroy();
+    if (uiZoomSelect) uiZoomSelect.destroy();
+    if (terminalFontSelect) terminalFontSelect.destroy();
     btnConfirm.removeEventListener('click', handleConfirm);
     btnCancel.removeEventListener('click', handleCancel);
     document.removeEventListener('keydown', handleKeydown);

--- a/src/renderer/components/preferences-modal.ts
+++ b/src/renderer/components/preferences-modal.ts
@@ -3,9 +3,13 @@ import { closeModal } from './modal.js';
 import { createCustomSelect, type CustomSelectInstance } from './custom-select.js';
 import { shortcutManager, displayKeys, eventToAccelerator } from '../shortcuts.js';
 import { loadProviderAvailability, getProviderAvailabilitySnapshot } from '../provider-availability.js';
-import type { CliProviderMeta, ProviderId, SettingsValidationResult } from '../../shared/types.js';
+import type { CliProviderMeta, Preferences, ProviderId, SettingsValidationResult, TerminalBackgroundMode } from '../../shared/types.js';
 import { UI_ZOOM_SIZE_OPTIONS } from '../display-preferences.js';
 import { TERMINAL_FONT_SIZE_OPTIONS } from '../terminal-font-size.js';
+import { TERMINAL_BG_PRESETS } from '../terminal-background-helpers.js';
+import { refreshTerminalBackdropFromPreferences } from '../terminal-backdrop.js';
+import { refreshTerminalSurfacesFromPreferences } from '../refresh-terminal-surfaces.js';
+import { applyDisplayPreferences } from '../display-preferences.js';
 
 
 const overlay = document.getElementById('modal-overlay')!;
@@ -15,7 +19,7 @@ const bodyEl = document.getElementById('modal-body')!;
 const btnCancel = document.getElementById('modal-cancel')!;
 const btnConfirm = document.getElementById('modal-confirm')!;
 
-type Section = 'general' | 'sidebar' | 'shortcuts' | 'setup' | 'about';
+type Section = 'general' | 'appearance' | 'sidebar' | 'shortcuts' | 'setup' | 'about';
 
 export function showPreferencesModal(): void {
   titleEl.textContent = 'Preferences';
@@ -32,6 +36,7 @@ export function showPreferencesModal(): void {
 
   const sections: { id: Section; label: string }[] = [
     { id: 'general', label: 'General' },
+    { id: 'appearance', label: 'Appearance' },
     { id: 'sidebar', label: 'Sidebar' },
     { id: 'shortcuts', label: 'Shortcuts' },
     { id: 'setup', label: 'Setup' },
@@ -71,6 +76,46 @@ export function showPreferencesModal(): void {
   let wslDistroSelect: CustomSelectInstance | null = null;
   let sidebarCheckboxes: { configSections: HTMLInputElement; gitPanel: HTMLInputElement; sessionHistory: HTMLInputElement; costFooter: HTMLInputElement; readinessSection: HTMLInputElement } | null = null;
   let activeRecorder: { cleanup: () => void } | null = null;
+  let appearanceModeSelect: CustomSelectInstance | null = null;
+  let appearancePresetSelect: CustomSelectInstance | null = null;
+  let appearanceDimSlider: HTMLInputElement | null = null;
+  let appearanceSurfaceSlider: HTMLInputElement | null = null;
+  let appearanceImagePathLabel: HTMLDivElement | null = null;
+  let appearanceDraftImagePath: string | null = null;
+  /** Captured when leaving the Appearance section so Done saves from any tab. */
+  let pendingAppearancePatch: Partial<Preferences> | null = null;
+
+  /** Push current Appearance controls into the main column (does not mutate `appState`). */
+  function applyAppearanceBackdropPreview(): void {
+    if (!appearanceModeSelect || !appearancePresetSelect || !appearanceDimSlider || !appearanceSurfaceSlider) return;
+    const dim = Math.min(100, Math.max(0, Number.parseInt(appearanceDimSlider.value, 10))) / 100;
+    const surf = Math.min(100, Math.max(0, Number.parseInt(appearanceSurfaceSlider.value, 10))) / 100;
+    const mode = appearanceModeSelect.getValue() as TerminalBackgroundMode;
+    const merged: Preferences = {
+      ...appState.preferences,
+      terminalBackgroundMode: mode,
+      terminalBackgroundPresetId: appearancePresetSelect.getValue(),
+      terminalBackgroundImagePath: mode === 'custom' ? appearanceDraftImagePath : null,
+      terminalBackgroundDim: dim,
+      terminalBackgroundSurfaceAlpha: surf,
+    };
+    void refreshTerminalBackdropFromPreferences(merged);
+    refreshTerminalSurfacesFromPreferences(merged);
+  }
+
+  function snapshotAppearanceFromControls(): void {
+    if (!appearanceModeSelect || !appearancePresetSelect || !appearanceDimSlider || !appearanceSurfaceSlider) return;
+    const mode = appearanceModeSelect.getValue() as TerminalBackgroundMode;
+    const dim = Math.min(100, Math.max(0, Number.parseInt(appearanceDimSlider.value, 10))) / 100;
+    const surf = Math.min(100, Math.max(0, Number.parseInt(appearanceSurfaceSlider.value, 10))) / 100;
+    pendingAppearancePatch = {
+      terminalBackgroundMode: mode,
+      terminalBackgroundPresetId: appearancePresetSelect.getValue(),
+      terminalBackgroundImagePath: mode === 'custom' ? appearanceDraftImagePath : null,
+      terminalBackgroundDim: dim,
+      terminalBackgroundSurfaceAlpha: surf,
+    };
+  }
 
   function cleanupRecorder() {
     if (activeRecorder) {
@@ -81,6 +126,18 @@ export function showPreferencesModal(): void {
 
   function renderSection(section: Section) {
     cleanupRecorder();
+    snapshotAppearanceFromControls();
+    if (appearanceModeSelect) {
+      appearanceModeSelect.destroy();
+      appearanceModeSelect = null;
+    }
+    if (appearancePresetSelect) {
+      appearancePresetSelect.destroy();
+      appearancePresetSelect = null;
+    }
+    appearanceDimSlider = null;
+    appearanceSurfaceSlider = null;
+    appearanceImagePathLabel = null;
     currentSection = section;
     content.innerHTML = '';
 
@@ -249,67 +306,231 @@ export function showPreferencesModal(): void {
       autoTitleRow.appendChild(autoTitleCheckbox);
       content.appendChild(autoTitleRow);
 
-      // WSL2 section (only relevant on Windows builds)
-      const wslSection = document.createElement('div');
-      wslSection.className = 'preferences-wsl-section';
-      wslSection.style.display = 'none'; // hidden until we confirm WSL is available
+      // WSL2 section: Windows only (no IPC / DOM on macOS or Linux builds)
+      const rendererIsWin = navigator.platform.toUpperCase().includes('WIN');
+      if (rendererIsWin) {
+        const wslSection = document.createElement('div');
+        wslSection.className = 'preferences-wsl-section';
+        wslSection.style.display = 'none'; // hidden until we confirm WSL is available
 
-      const wslHeader = document.createElement('div');
-      wslHeader.className = 'pref-section-header';
-      wslHeader.textContent = 'WSL2 Integration';
-      wslSection.appendChild(wslHeader);
+        const wslHeader = document.createElement('div');
+        wslHeader.className = 'pref-section-header';
+        wslHeader.textContent = 'WSL2 mode';
+        wslSection.appendChild(wslHeader);
 
-      const wslRow = document.createElement('div');
-      wslRow.className = 'modal-toggle-field';
-      const wslLabel = document.createElement('label');
-      wslLabel.htmlFor = 'pref-wsl-enabled';
-      wslLabel.textContent = 'Run CLI tools inside WSL2';
-      wslCheckbox = document.createElement('input');
-      wslCheckbox.type = 'checkbox';
-      wslCheckbox.id = 'pref-wsl-enabled';
-      wslCheckbox.checked = appState.preferences.wslEnabled ?? false;
-      wslRow.appendChild(wslLabel);
-      wslRow.appendChild(wslCheckbox);
-      wslSection.appendChild(wslRow);
+        const wslIntro = document.createElement('p');
+        wslIntro.className = 'preferences-wsl-intro';
+        wslIntro.textContent =
+          'Optional. When off, Vibeyard runs CLI tools on Windows natively and ignores Linux-style project paths from other machines. Turn on only on this PC if you want sessions inside WSL2.';
+        wslSection.appendChild(wslIntro);
 
-      const wslDistroRow = document.createElement('div');
-      wslDistroRow.className = 'modal-toggle-field';
-      const wslDistroLabel = document.createElement('label');
-      wslDistroLabel.textContent = 'WSL Distro';
-      wslDistroRow.appendChild(wslDistroLabel);
+        const wslRow = document.createElement('div');
+        wslRow.className = 'modal-toggle-field';
+        const wslLabel = document.createElement('label');
+        wslLabel.htmlFor = 'pref-wsl-enabled';
+        wslLabel.textContent = 'Run CLI tools inside WSL2';
+        wslCheckbox = document.createElement('input');
+        wslCheckbox.type = 'checkbox';
+        wslCheckbox.id = 'pref-wsl-enabled';
+        wslCheckbox.checked = appState.preferences.wslEnabled ?? false;
+        wslRow.appendChild(wslLabel);
+        wslRow.appendChild(wslCheckbox);
+        wslSection.appendChild(wslRow);
 
-      const distroPlaceholder = document.createElement('span');
-      distroPlaceholder.textContent = 'Detecting…';
-      distroPlaceholder.className = 'pref-wsl-detecting';
-      wslDistroRow.appendChild(distroPlaceholder);
-      wslSection.appendChild(wslDistroRow);
+        const wslDistroRow = document.createElement('div');
+        wslDistroRow.className = 'modal-toggle-field';
+        const wslDistroLabel = document.createElement('label');
+        wslDistroLabel.textContent = 'WSL distro';
+        wslDistroRow.appendChild(wslDistroLabel);
 
-      content.appendChild(wslSection);
+        const distroPlaceholder = document.createElement('span');
+        distroPlaceholder.textContent = 'Detecting…';
+        distroPlaceholder.className = 'pref-wsl-detecting';
+        wslDistroRow.appendChild(distroPlaceholder);
+        wslSection.appendChild(wslDistroRow);
 
-      // Async: check WSL availability and populate distro dropdown
-      window.vibeyard.wsl.isAvailable().then(async (available) => {
-        if (!available || currentSection !== 'general') return;
-        wslSection.style.display = '';
+        content.appendChild(wslSection);
 
-        const distros = await window.vibeyard.wsl.getDistros();
-        const defaultDistro = await window.vibeyard.wsl.getDefaultDistro();
-        const current = appState.preferences.wslDistro ?? defaultDistro ?? distros[0] ?? '';
+        // Async: check WSL availability and populate distro dropdown
+        window.vibeyard.wsl.isAvailable().then(async (available) => {
+          if (!available || currentSection !== 'general') return;
+          wslSection.style.display = '';
 
-        distroPlaceholder.remove();
-        if (distros.length > 0) {
-          wslDistroSelect = createCustomSelect(
-            'pref-wsl-distro',
-            distros.map(d => ({ value: d, label: d === defaultDistro ? `${d} (default)` : d })),
-            current,
-          );
-          wslDistroRow.appendChild(wslDistroSelect.element);
-        } else {
-          const noDistro = document.createElement('span');
-          noDistro.textContent = 'No WSL distros found';
-          noDistro.style.color = 'var(--text-muted)';
-          wslDistroRow.appendChild(noDistro);
+          const distros = await window.vibeyard.wsl.getDistros();
+          const defaultDistro = await window.vibeyard.wsl.getDefaultDistro();
+          const current = appState.preferences.wslDistro ?? defaultDistro ?? distros[0] ?? '';
+
+          distroPlaceholder.remove();
+          if (distros.length > 0) {
+            wslDistroSelect = createCustomSelect(
+              'pref-wsl-distro',
+              distros.map(d => ({ value: d, label: d === defaultDistro ? `${d} (default)` : d })),
+              current,
+            );
+            wslDistroRow.appendChild(wslDistroSelect.element);
+          } else {
+            const noDistro = document.createElement('span');
+            noDistro.textContent = 'No WSL distros found';
+            noDistro.style.color = 'var(--text-muted)';
+            wslDistroRow.appendChild(noDistro);
+          }
+        }).catch(() => {});
+      }
+
+    } else if (section === 'appearance') {
+      const pref: Preferences = { ...appState.preferences, ...(pendingAppearancePatch ?? {}) };
+      appearanceDraftImagePath = pref.terminalBackgroundImagePath ?? null;
+
+      const mode = (pref.terminalBackgroundMode ?? 'none') as TerminalBackgroundMode;
+      const presetId = pref.terminalBackgroundPresetId ?? 'metro';
+      const dimPct = Math.round((pref.terminalBackgroundDim ?? 0.28) * 100);
+      const surfPct = Math.round((pref.terminalBackgroundSurfaceAlpha ?? 0.88) * 100);
+
+      const modeRow = document.createElement('div');
+      modeRow.className = 'modal-toggle-field';
+      const modeLabel = document.createElement('label');
+      modeLabel.textContent = 'Terminal backdrop';
+
+      const presetRow = document.createElement('div');
+      presetRow.className = 'modal-toggle-field';
+      const presetLabel = document.createElement('label');
+      presetLabel.textContent = 'Built-in preset';
+
+      /** Image path + browse — only when mode is Custom image */
+      const imageSectionEl = document.createElement('div');
+      imageSectionEl.className = 'pref-appearance-image-section';
+
+      /** Dim + terminal surface — same controls for preset gradients and custom images */
+      const tuningSectionEl = document.createElement('div');
+      tuningSectionEl.className = 'pref-appearance-tuning-section';
+
+      function syncAppearanceRows(): void {
+        const m = (appearanceModeSelect?.getValue() ?? 'none') as TerminalBackgroundMode;
+        presetRow.style.display = m === 'preset' ? '' : 'none';
+        imageSectionEl.style.display = m === 'custom' ? '' : 'none';
+        tuningSectionEl.style.display = m === 'preset' || m === 'custom' ? '' : 'none';
+      }
+
+      appearanceModeSelect = createCustomSelect(
+        'pref-terminal-bg-mode',
+        [
+          { value: 'none', label: 'Solid (no backdrop)' },
+          { value: 'preset', label: 'Built-in gradient' },
+          { value: 'custom', label: 'Custom image' },
+        ],
+        mode,
+        () => {
+          syncAppearanceRows();
+          applyAppearanceBackdropPreview();
+        },
+      );
+
+      modeRow.appendChild(modeLabel);
+      modeRow.appendChild(appearanceModeSelect.element);
+      content.appendChild(modeRow);
+
+      appearancePresetSelect = createCustomSelect(
+        'pref-terminal-bg-preset',
+        TERMINAL_BG_PRESETS.map((p) => ({ value: p.id, label: p.label })),
+        presetId,
+        () => {
+          applyAppearanceBackdropPreview();
+        },
+      );
+      presetRow.appendChild(presetLabel);
+      presetRow.appendChild(appearancePresetSelect.element);
+      content.appendChild(presetRow);
+
+      const browseRow = document.createElement('div');
+      browseRow.className = 'modal-toggle-field';
+      browseRow.style.alignItems = 'flex-start';
+      const browseLabelCol = document.createElement('div');
+      browseLabelCol.style.display = 'flex';
+      browseLabelCol.style.flexDirection = 'column';
+      browseLabelCol.style.gap = '6px';
+      browseLabelCol.style.flex = '1';
+      browseLabelCol.style.minWidth = '0';
+      const browseLabel = document.createElement('label');
+      browseLabel.textContent = 'Custom image';
+      appearanceImagePathLabel = document.createElement('div');
+      appearanceImagePathLabel.className = 'pref-image-path';
+      appearanceImagePathLabel.textContent = appearanceDraftImagePath ?? '(none)';
+      browseLabelCol.appendChild(browseLabel);
+      browseLabelCol.appendChild(appearanceImagePathLabel);
+
+      const browseActions = document.createElement('div');
+      browseActions.style.display = 'flex';
+      browseActions.style.flexShrink = '0';
+      browseActions.style.gap = '8px';
+      const browseBtn = document.createElement('button');
+      browseBtn.type = 'button';
+      browseBtn.className = 'modal-field-btn';
+      browseBtn.textContent = 'Choose\u2026';
+      const clearBtn = document.createElement('button');
+      clearBtn.type = 'button';
+      clearBtn.className = 'modal-field-btn';
+      clearBtn.textContent = 'Clear';
+      browseBtn.addEventListener('click', async () => {
+        const p = await window.vibeyard.app.browseImageFile();
+        if (p) {
+          appearanceDraftImagePath = p;
+          appearanceImagePathLabel!.textContent = p;
+          appearanceModeSelect?.setValue('custom');
+          syncAppearanceRows();
+          applyAppearanceBackdropPreview();
         }
-      }).catch(() => {});
+      });
+      clearBtn.addEventListener('click', () => {
+        appearanceDraftImagePath = null;
+        appearanceImagePathLabel!.textContent = '(none)';
+        applyAppearanceBackdropPreview();
+      });
+      browseActions.appendChild(browseBtn);
+      browseActions.appendChild(clearBtn);
+      browseRow.appendChild(browseLabelCol);
+      browseRow.appendChild(browseActions);
+      imageSectionEl.appendChild(browseRow);
+
+      const dimWrap = document.createElement('div');
+      dimWrap.className = 'pref-slider-field';
+      const dimLab = document.createElement('label');
+      dimLab.htmlFor = 'pref-terminal-bg-dim';
+      dimLab.textContent = 'Dim overlay (darkening on top of backdrop)';
+      appearanceDimSlider = document.createElement('input');
+      appearanceDimSlider.type = 'range';
+      appearanceDimSlider.id = 'pref-terminal-bg-dim';
+      appearanceDimSlider.min = '0';
+      appearanceDimSlider.max = '100';
+      appearanceDimSlider.value = String(dimPct);
+      appearanceDimSlider.addEventListener('input', () => {
+        applyAppearanceBackdropPreview();
+      });
+      dimWrap.appendChild(dimLab);
+      dimWrap.appendChild(appearanceDimSlider);
+      tuningSectionEl.appendChild(dimWrap);
+
+      const surfWrap = document.createElement('div');
+      surfWrap.className = 'pref-slider-field';
+      const surfLab = document.createElement('label');
+      surfLab.htmlFor = 'pref-terminal-bg-surface';
+      surfLab.textContent = 'Terminal surface opacity (higher = easier to read)';
+      appearanceSurfaceSlider = document.createElement('input');
+      appearanceSurfaceSlider.type = 'range';
+      appearanceSurfaceSlider.id = 'pref-terminal-bg-surface';
+      appearanceSurfaceSlider.min = '0';
+      appearanceSurfaceSlider.max = '100';
+      appearanceSurfaceSlider.value = String(surfPct);
+      appearanceSurfaceSlider.addEventListener('input', () => {
+        applyAppearanceBackdropPreview();
+      });
+      surfWrap.appendChild(surfLab);
+      surfWrap.appendChild(appearanceSurfaceSlider);
+      tuningSectionEl.appendChild(surfWrap);
+
+      content.appendChild(imageSectionEl);
+      content.appendChild(tuningSectionEl);
+      syncAppearanceRows();
+      applyAppearanceBackdropPreview();
 
     } else if (section === 'sidebar') {
       const views = appState.preferences.sidebarViews ?? { configSections: true, gitPanel: true, sessionHistory: true, costFooter: true, readinessSection: true };
@@ -830,10 +1051,15 @@ export function showPreferencesModal(): void {
     if (wslDistroSelect) {
       appState.setPreference('wslDistro', wslDistroSelect.getValue());
     }
+    if (pendingAppearancePatch) {
+      appState.patchPreferences(pendingAppearancePatch);
+      pendingAppearancePatch = null;
+    }
   };
 
   const handleConfirm = () => {
     cleanupRecorder();
+    snapshotAppearanceFromControls();
     save();
     closeModal();
     modal.classList.remove('modal-wide');
@@ -842,6 +1068,8 @@ export function showPreferencesModal(): void {
 
   const handleCancel = () => {
     cleanupRecorder();
+    pendingAppearancePatch = null;
+    void applyDisplayPreferences();
     closeModal();
     modal.classList.remove('modal-wide');
     btnConfirm.textContent = 'Create';
@@ -865,6 +1093,15 @@ export function showPreferencesModal(): void {
 
   (overlay as any)._cleanup = () => {
     cleanupRecorder();
+    snapshotAppearanceFromControls();
+    if (appearanceModeSelect) {
+      appearanceModeSelect.destroy();
+      appearanceModeSelect = null;
+    }
+    if (appearancePresetSelect) {
+      appearancePresetSelect.destroy();
+      appearancePresetSelect = null;
+    }
     if (defaultProviderSelect) defaultProviderSelect.destroy();
     if (uiZoomSelect) uiZoomSelect.destroy();
     if (terminalFontSelect) terminalFontSelect.destroy();

--- a/src/renderer/components/project-terminal.ts
+++ b/src/renderer/components/project-terminal.ts
@@ -7,6 +7,7 @@ import { fitAllVisible } from './terminal-pane.js';
 import { destroySearchBar, hideSearchBar } from './search-bar.js';
 import { shortcutManager, displayKeys } from '../shortcuts.js';
 import { attachClipboardCopyHandler } from './terminal-utils.js';
+import { getEffectiveTerminalFontSize, applyXtermFontSize } from '../terminal-font-size.js';
 
 interface ShellTerminalInstance {
   terminal: Terminal;
@@ -55,7 +56,7 @@ function ensureShell(projectId: string, projectPath: string): ShellTerminalInsta
       cyan: '#00acc1',
       white: '#e0e0e0',
     },
-    fontSize: 14,
+    fontSize: getEffectiveTerminalFontSize(),
     fontFamily: "'JetBrains Mono', 'Fira Code', 'SF Mono', Menlo, monospace",
     cursorBlink: true,
     allowProposedApi: true,
@@ -166,6 +167,15 @@ function fitShellTerminal(projectId: string): void {
     window.vibeyard.pty.resize(instance.sessionId, cols, rows);
   } catch {
     // not visible yet
+  }
+}
+
+export function applyShellTerminalsFontSize(fontSize: number): void {
+  for (const [, inst] of shells) {
+    applyXtermFontSize(inst.terminal, fontSize);
+    if (!panelEl.classList.contains('hidden') && inst.projectId === currentProjectId) {
+      fitShellTerminal(inst.projectId);
+    }
   }
 }
 

--- a/src/renderer/components/project-terminal.ts
+++ b/src/renderer/components/project-terminal.ts
@@ -8,9 +8,12 @@ import { destroySearchBar, hideSearchBar } from './search-bar.js';
 import { shortcutManager, displayKeys } from '../shortcuts.js';
 import { attachClipboardCopyHandler } from './terminal-utils.js';
 import { getEffectiveTerminalFontSize, applyXtermFontSize } from '../terminal-font-size.js';
+import type { Preferences } from '../../shared/types.js';
+import { backdropIsActive, getTerminalSurfaceBackgroundColor } from '../terminal-background-helpers.js';
 
 interface ShellTerminalInstance {
   terminal: Terminal;
+  webglAddon: WebglAddon | null;
   fitAddon: FitAddon;
   searchAddon: SearchAddon;
   element: HTMLDivElement;
@@ -41,9 +44,10 @@ function ensureShell(projectId: string, projectPath: string): ShellTerminalInsta
   element.style.height = '100%';
   element.style.position = 'relative';
 
+  const surfaceBg = getTerminalSurfaceBackgroundColor(appState.preferences);
   const terminal = new Terminal({
     theme: {
-      background: '#000000',
+      background: surfaceBg,
       foreground: '#e0e0e0',
       cursor: '#e94560',
       selectionBackground: '#ff6b85a6',
@@ -59,6 +63,7 @@ function ensureShell(projectId: string, projectPath: string): ShellTerminalInsta
     fontSize: getEffectiveTerminalFontSize(),
     fontFamily: "'JetBrains Mono', 'Fira Code', 'SF Mono', Menlo, monospace",
     cursorBlink: true,
+    allowTransparency: true,
     allowProposedApi: true,
   });
 
@@ -74,6 +79,7 @@ function ensureShell(projectId: string, projectPath: string): ShellTerminalInsta
 
   const instance: ShellTerminalInstance = {
     terminal,
+    webglAddon: null,
     fitAddon,
     searchAddon,
     element,
@@ -118,10 +124,13 @@ function showPanel(projectId: string): void {
   if (!containerEl.contains(instance.element)) {
     containerEl.appendChild(instance.element);
     instance.terminal.open(instance.element);
-    try {
-      instance.terminal.loadAddon(new WebglAddon());
-    } catch {
-      // Software fallback
+    if (!backdropIsActive(appState.preferences)) {
+      try {
+        instance.webglAddon = new WebglAddon();
+        instance.terminal.loadAddon(instance.webglAddon);
+      } catch {
+        instance.webglAddon = null;
+      }
     }
   }
   instance.element.style.display = '';
@@ -238,6 +247,8 @@ function destroyShell(projectId: string): void {
   if (!instance) return;
   destroySearchBar(instance.sessionId);
   window.vibeyard.pty.kill(instance.sessionId);
+  instance.webglAddon?.dispose();
+  instance.webglAddon = null;
   instance.terminal.dispose();
   instance.element.remove();
   shells.delete(projectId);
@@ -353,6 +364,32 @@ export function getActiveShellSessionId(): string | null {
   if (!currentProjectId || panelEl.classList.contains('hidden')) return null;
   const instance = shells.get(currentProjectId);
   return instance?.sessionId ?? null;
+}
+
+export function applyShellTerminalsSurface(background: string): void {
+  for (const [, inst] of shells) {
+    inst.terminal.options.theme = { ...inst.terminal.options.theme, background };
+  }
+}
+
+export function syncShellTerminalsWebglFromPreferences(prefs: Preferences): void {
+  const useWebgl = !backdropIsActive(prefs);
+  for (const [, instance] of shells) {
+    if (!instance.terminal.element) continue;
+    if (useWebgl) {
+      if (!instance.webglAddon) {
+        try {
+          instance.webglAddon = new WebglAddon();
+          instance.terminal.loadAddon(instance.webglAddon);
+        } catch {
+          instance.webglAddon = null;
+        }
+      }
+    } else if (instance.webglAddon) {
+      instance.webglAddon.dispose();
+      instance.webglAddon = null;
+    }
+  }
 }
 
 export { isShellSessionId };

--- a/src/renderer/components/remote-terminal-pane.ts
+++ b/src/renderer/components/remote-terminal-pane.ts
@@ -5,10 +5,14 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebglAddon } from '@xterm/addon-webgl';
 import type { ShareMode } from '../../shared/sharing-types.js';
+import type { Preferences } from '../../shared/types.js';
 import { getEffectiveTerminalFontSize, applyXtermFontSize } from '../terminal-font-size.js';
+import { appState } from '../state.js';
+import { backdropIsActive, getTerminalSurfaceBackgroundColor } from '../terminal-background-helpers.js';
 
 interface RemoteTerminalInstance {
   terminal: Terminal;
+  webglAddon: WebglAddon | null;
   fitAddon: FitAddon;
   element: HTMLDivElement;
   sessionId: string;
@@ -55,9 +59,10 @@ export function createRemoteTerminalPane(
   statusBar.appendChild(disconnectBtn);
   element.appendChild(statusBar);
 
+  const surfaceBg = getTerminalSurfaceBackgroundColor(appState.preferences);
   const terminal = new Terminal({
     theme: {
-      background: '#000000',
+      background: surfaceBg,
       foreground: '#e0e0e0',
       cursor: '#e94560',
       selectionBackground: '#ff6b85a6',
@@ -73,6 +78,7 @@ export function createRemoteTerminalPane(
     fontSize: getEffectiveTerminalFontSize(),
     fontFamily: "'JetBrains Mono', 'Fira Code', 'SF Mono', Menlo, monospace",
     cursorBlink: mode === 'readwrite',
+    allowTransparency: true,
     allowProposedApi: true,
     disableStdin: mode === 'readonly',
     cols,
@@ -91,6 +97,7 @@ export function createRemoteTerminalPane(
 
   const instance: RemoteTerminalInstance = {
     terminal,
+    webglAddon: null,
     fitAddon,
     element,
     sessionId,
@@ -114,11 +121,13 @@ export function attachRemoteToContainer(sessionId: string, container: HTMLElemen
     container.appendChild(instance.element);
     instance.terminal.open(xtermWrap as HTMLElement);
 
-    try {
-      const webglAddon = new WebglAddon();
-      instance.terminal.loadAddon(webglAddon);
-    } catch {
-      // Software renderer fallback
+    if (!backdropIsActive(appState.preferences)) {
+      try {
+        instance.webglAddon = new WebglAddon();
+        instance.terminal.loadAddon(instance.webglAddon);
+      } catch {
+        instance.webglAddon = null;
+      }
     }
   } else {
     container.appendChild(instance.element);
@@ -197,9 +206,37 @@ export function destroyRemoteTerminal(sessionId: string): void {
   const instance = instances.get(sessionId);
   if (!instance) return;
 
+  instance.webglAddon?.dispose();
+  instance.webglAddon = null;
   instance.terminal.dispose();
   instance.element.remove();
   instances.delete(sessionId);
+}
+
+export function applyRemoteTerminalsSurface(background: string): void {
+  for (const [, inst] of instances) {
+    inst.terminal.options.theme = { ...inst.terminal.options.theme, background };
+  }
+}
+
+export function syncRemoteTerminalsWebglFromPreferences(prefs: Preferences): void {
+  const useWebgl = !backdropIsActive(prefs);
+  for (const [, instance] of instances) {
+    if (!instance.terminal.element) continue;
+    if (useWebgl) {
+      if (!instance.webglAddon) {
+        try {
+          instance.webglAddon = new WebglAddon();
+          instance.terminal.loadAddon(instance.webglAddon);
+        } catch {
+          instance.webglAddon = null;
+        }
+      }
+    } else if (instance.webglAddon) {
+      instance.webglAddon.dispose();
+      instance.webglAddon = null;
+    }
+  }
 }
 
 export function _resetForTesting(): void {

--- a/src/renderer/components/remote-terminal-pane.ts
+++ b/src/renderer/components/remote-terminal-pane.ts
@@ -5,6 +5,7 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebglAddon } from '@xterm/addon-webgl';
 import type { ShareMode } from '../../shared/sharing-types.js';
+import { getEffectiveTerminalFontSize, applyXtermFontSize } from '../terminal-font-size.js';
 
 interface RemoteTerminalInstance {
   terminal: Terminal;
@@ -69,7 +70,7 @@ export function createRemoteTerminalPane(
       cyan: '#00acc1',
       white: '#e0e0e0',
     },
-    fontSize: 14,
+    fontSize: getEffectiveTerminalFontSize(),
     fontFamily: "'JetBrains Mono', 'Fira Code', 'SF Mono', Menlo, monospace",
     cursorBlink: mode === 'readwrite',
     allowProposedApi: true,
@@ -156,6 +157,15 @@ export function fitRemoteTerminal(sessionId: string): void {
     instance.fitAddon.fit();
   } catch {
     // Element not yet visible
+  }
+}
+
+export function applyRemoteTerminalsFontSize(fontSize: number): void {
+  for (const [sessionId, inst] of instances) {
+    applyXtermFontSize(inst.terminal, fontSize);
+    if (!inst.element.classList.contains('hidden')) {
+      fitRemoteTerminal(sessionId);
+    }
   }
 }
 

--- a/src/renderer/components/split-layout.ts
+++ b/src/renderer/components/split-layout.ts
@@ -1,4 +1,5 @@
-import { appState, ProjectRecord } from '../state.js';
+import { appState, ProjectRecord, type SessionRecord } from '../state.js';
+import { resolveCliSessionPtyCwd } from '../session-pty-cwd.js';
 import { isUnread, onChange as onUnreadChange } from '../session-unread.js';
 import {
   createTerminalPane,
@@ -120,7 +121,8 @@ function onSessionAdded(data: unknown): void {
     renderLayout();
   } else {
     // Create and spawn immediately
-    createTerminalPane(session.id, project.path, session.cliSessionId, !!session.cliSessionId, session.args || '', (session.providerId as import('../../shared/types').ProviderId) || 'claude', project.id);
+    const cwd = resolveCliSessionPtyCwd(project.path, session as SessionRecord);
+    createTerminalPane(session.id, cwd, session.cliSessionId, !!session.cliSessionId, session.args || '', (session.providerId as import('../../shared/types').ProviderId) || 'claude', project.id);
     const pending = appState.consumePendingInitialPrompt(project.id, session.id);
     if (pending) {
       setPendingPrompt(session.id, pending);
@@ -195,7 +197,8 @@ export function renderLayout(): void {
       }
     } else {
       if (!getTerminalInstance(session.id)) {
-        createTerminalPane(session.id, project.path, session.cliSessionId, !!session.cliSessionId, session.args || '', session.providerId || 'claude', project.id);
+        const cwd = resolveCliSessionPtyCwd(project.path, session);
+        createTerminalPane(session.id, cwd, session.cliSessionId, !!session.cliSessionId, session.args || '', session.providerId || 'claude', project.id);
       }
     }
   }

--- a/src/renderer/components/tab-bar.ts
+++ b/src/renderer/components/tab-bar.ts
@@ -15,6 +15,7 @@ import { endShare, onShareChange } from '../sharing/share-manager.js';
 import { openInspector, isInspectorOpen, getInspectedSessionId, closeInspector } from './session-inspector.js';
 import { loadProviderAvailability, hasMultipleAvailableProviders, getProviderAvailabilitySnapshot, getProviderCapabilities } from '../provider-availability.js';
 import { buildResumeWithProviderItems } from './resume-with-provider-menu.js';
+import { restartCliWithoutSavedConversation } from './terminal-pane.js';
 
 const tabListEl = document.getElementById('tab-list')!;
 const gitStatusEl = document.getElementById('git-status')!;
@@ -372,6 +373,19 @@ function showTabContextMenu(x: number, y: number, project: ProjectRecord, sessio
       },
     );
     for (const el of items) menu.appendChild(el);
+
+    const canForgetResume = !!session.cliSessionId && providerCapabilities?.sessionResume !== false;
+    const forgetResumeItem = document.createElement('div');
+    forgetResumeItem.className = 'tab-context-menu-item' + (!canForgetResume ? ' disabled' : '');
+    forgetResumeItem.textContent = 'Start fresh (forget saved CLI session)';
+    if (canForgetResume) {
+      forgetResumeItem.addEventListener('click', (e) => {
+        e.stopPropagation();
+        hideTabContextMenu();
+        void restartCliWithoutSavedConversation(project.id, session.id);
+      });
+    }
+    menu.appendChild(forgetResumeItem);
   }
 
   menu.appendChild(closeItem);
@@ -733,7 +747,7 @@ async function showBranchContextMenu(e: MouseEvent): Promise<void> {
     });
     menu.appendChild(createItem);
 
-    if (activeSession && sessionSupportsGitWorktreePin(activeSession) && pickableWt.length > 1) {
+    if (activeSession && sessionSupportsGitWorktreePin(activeSession) && pickableWt.length >= 1) {
       const wtSepBefore = document.createElement('div');
       wtSepBefore.className = 'tab-context-menu-separator';
       menu.appendChild(wtSepBefore);
@@ -982,7 +996,7 @@ export async function promptNewSession(onCreated?: (session: SessionRecord) => v
       } else if (wtChoice && wtChoice !== '__inherit__') {
         gitWt = { path: wtChoice, userPinned: true };
       }
-      const session = appState.addSession(project.id, name, args, providerId, gitWt);
+      const session = appState.addSession(project.id, name, args, providerId, gitWt, { userChoseDisplayName: true });
       if (session && onCreated) onCreated(session);
     }
   });

--- a/src/renderer/components/tab-bar.ts
+++ b/src/renderer/components/tab-bar.ts
@@ -2,7 +2,9 @@ import { appState, MAX_SESSION_NAME_LENGTH, type ProjectRecord, type SessionReco
 import type { ProviderId } from '../../shared/types.js';
 import { showModal, closeModal, setModalError, FieldDef } from './modal.js';
 import { onChange as onStatusChange, getStatus, type SessionStatus } from '../session-activity.js';
-import { onChange as onGitStatusChange, getGitStatus, getActiveGitPath, refreshGitStatus } from '../git-status.js';
+import { onChange as onGitStatusChange, onWorktreeChange, getGitStatus, getActiveGitPath, refreshGitStatus, sessionSupportsGitWorktreePin, getSessionWorktree, getWorktrees } from '../git-status.js';
+import type { GitWorktree } from '../types.js';
+import { applyWorktreeSelection, promptCreateWorktree } from '../worktree-actions.js';
 
 import { isUnread, onChange as onUnreadChange } from '../session-unread.js';
 import { showHelpDialog } from './help-dialog.js';
@@ -23,6 +25,32 @@ const btnHelp = document.getElementById('btn-help')!;
 
 let activeContextMenu: HTMLElement | null = null;
 const prevStatus = new Map<string, SessionStatus>();
+
+function shortWtLabelPath(fullPath: string): string {
+  const parts = fullPath.split('/');
+  return parts.length > 2 ? '.../' + parts.slice(-2).join('/') : fullPath;
+}
+
+/** True when the path is the project root (main checkout), not a linked `git worktree add` path. */
+function isMainWorktreePath(worktreePath: string, projectPath: string): boolean {
+  const norm = (s: string) => s.replace(/\\/g, '/').replace(/\/+$/, '');
+  return norm(worktreePath) === norm(projectPath);
+}
+
+function worktreeSelectLabel(wt: GitWorktree, projectPath: string): string {
+  const labelBase = wt.branch || `detached (${wt.head.slice(0, 7)})`;
+  return wt.path === projectPath ? labelBase : `${labelBase} \u2014 ${shortWtLabelPath(wt.path)}`;
+}
+
+/** Branch-style label for tab pill; tooltip carries full path. */
+function worktreeTabPillLabel(effPath: string, wts: GitWorktree[]): { label: string; title: string } {
+  const wt = wts.find((w) => !w.isBare && w.path === effPath);
+  if (wt) {
+    const label = wt.branch || `detached (${wt.head.slice(0, 7)})`;
+    return { label, title: `${label} — ${effPath}` };
+  }
+  return { label: shortWtLabelPath(effPath), title: effPath };
+}
 
 function buildTooltip(status: SessionStatus, cliSessionId?: string): string {
   const statusLine = `Status: ${status}`;
@@ -45,7 +73,10 @@ export function initTabBar(): void {
     if (hasMultipleAvailableProviders()) render();
   }).catch(() => {});
 
-  appState.on('state-loaded', render);
+  appState.on('state-loaded', () => {
+    render();
+    void refreshGitStatus().then(() => renderGitStatus());
+  });
   appState.on('project-changed', render);
   appState.on('session-added', render);
   appState.on('session-removed', (data?: unknown) => {
@@ -80,7 +111,15 @@ export function initTabBar(): void {
   onGitStatusChange((projectId) => {
     if (projectId === appState.activeProjectId) renderGitStatus();
   });
-  appState.on('project-changed', renderGitStatus);
+  onWorktreeChange(() => {
+    if (appState.activeProjectId) {
+      renderGitStatus();
+      render();
+    }
+  });
+  appState.on('project-changed', () => {
+    void refreshGitStatus().then(() => renderGitStatus());
+  });
 
   document.addEventListener('click', hideTabContextMenu);
   document.addEventListener('keydown', (e) => { if (e.key === 'Escape') hideTabContextMenu(); });
@@ -383,9 +422,21 @@ function render(): void {
     const namePrefix = isDiff ? '<span class="tab-diff-badge">DIFF</span> ' : isMcp ? '<span class="tab-mcp-badge">MCP</span> ' : isFileReader ? '<span class="tab-file-badge">FILE</span> ' : isRemoteTab ? '<span class="tab-remote-badge">P2P</span> ' : isBrowserTab ? '<span class="tab-browser-badge">WEB</span> ' : !isSpecial ? providerIcon : '';
     const shareIndicator = sharing ? '<span class="tab-share-indicator" title="Sharing"></span>' : '';
     const statusDot = isSpecial ? '' : `<span class="tab-status ${getStatus(session.id)}"></span>`;
+    const wts = getWorktrees(project.id);
+    const barePickable = wts?.filter((w) => !w.isBare) ?? [];
+    const effWt = !isSpecial ? getSessionWorktree(session.id) : null;
+    let wtPill = '';
+    if (
+      effWt &&
+      barePickable.length > 1 &&
+      !isMainWorktreePath(effWt, project.path)
+    ) {
+      const { label, title } = worktreeTabPillLabel(effWt, barePickable);
+      wtPill = ` <span class="tab-worktree-pill" title="${escAttr(title)}">${esc(label)}</span>`;
+    }
     tab.innerHTML = `
       ${statusDot}
-      <span class="tab-name">${namePrefix}${esc(session.name)}</span>
+      <span class="tab-name">${namePrefix}${esc(session.name)}${wtPill}</span>
       ${shareIndicator}
       <span class="tab-close" title="Close session">&times;</span>
     `;
@@ -519,6 +570,8 @@ async function showBranchContextMenu(e: MouseEvent): Promise<void> {
   const project = appState.activeProject;
   if (!project) return;
 
+  // Warm cache for the current worktree path (path can change before the next interval poll).
+  await refreshGitStatus();
   const status = getGitStatus(project.id);
   if (!status || !status.isGitRepo) return;
 
@@ -542,13 +595,25 @@ async function showBranchContextMenu(e: MouseEvent): Promise<void> {
   activeContextMenu = menu;
 
   try {
-    const branches = await window.vibeyard.git.listBranches(gitPath);
+    const activeSession = appState.activeSession;
+    const [branches, worktreesRaw] = await Promise.all([
+      window.vibeyard.git.listBranches(gitPath),
+      window.vibeyard.git.getWorktrees(project.path),
+    ]);
 
     // Menu was dismissed during loading
     if (activeContextMenu !== menu) return;
 
     menu.innerHTML = '';
     menu.addEventListener('click', (ev) => ev.stopPropagation());
+
+    const worktrees = worktreesRaw as GitWorktree[];
+    const pickableWt = worktrees.filter((w) => !w.isBare);
+
+    const branchesHeader = document.createElement('div');
+    branchesHeader.className = 'tab-context-menu-header';
+    branchesHeader.textContent = 'Branches';
+    menu.appendChild(branchesHeader);
 
     const searchInput = document.createElement('input');
     searchInput.className = 'branch-search-input';
@@ -667,6 +732,50 @@ async function showBranchContextMenu(e: MouseEvent): Promise<void> {
       promptCreateBranch(gitPath);
     });
     menu.appendChild(createItem);
+
+    if (activeSession && sessionSupportsGitWorktreePin(activeSession) && pickableWt.length > 1) {
+      const wtSepBefore = document.createElement('div');
+      wtSepBefore.className = 'tab-context-menu-separator';
+      menu.appendChild(wtSepBefore);
+
+      const wtHeader = document.createElement('div');
+      wtHeader.className = 'tab-context-menu-header';
+      wtHeader.textContent = 'Worktrees';
+      menu.appendChild(wtHeader);
+
+      const autoItem = document.createElement('div');
+      const autoSelected = !activeSession.gitWorktreeUserPinned;
+      autoItem.className = 'tab-context-menu-item' + (autoSelected ? ' active' : '');
+      autoItem.textContent = (autoSelected ? '\u2713 ' : '  ') + 'Auto (shell CWD)';
+      autoItem.addEventListener('click', () => {
+        hideTabContextMenu();
+        applyWorktreeSelection(project.id, null);
+      });
+      menu.appendChild(autoItem);
+
+      for (const wt of pickableWt) {
+        const labelBase = wt.branch || `detached (${wt.head.slice(0, 7)})`;
+        const label = wt.path === project.path ? labelBase : `${labelBase} \u2014 ${shortWtLabelPath(wt.path)}`;
+        const rowSelected = Boolean(activeSession.gitWorktreeUserPinned && activeSession.gitWorktreePath === wt.path);
+        const item = document.createElement('div');
+        item.className = 'tab-context-menu-item' + (rowSelected ? ' active' : '');
+        item.textContent = (rowSelected ? '\u2713 ' : '  ') + label;
+        item.addEventListener('click', () => {
+          hideTabContextMenu();
+          applyWorktreeSelection(project.id, wt.path);
+        });
+        menu.appendChild(item);
+      }
+
+      const createWtItem = document.createElement('div');
+      createWtItem.className = 'tab-context-menu-item';
+      createWtItem.textContent = 'Create New Worktree\u2026';
+      createWtItem.addEventListener('click', () => {
+        hideTabContextMenu();
+        promptCreateWorktree(project);
+      });
+      menu.appendChild(createWtItem);
+    }
 
     // Adjust if off-screen
     const rect = menu.getBoundingClientRect();
@@ -833,6 +942,31 @@ export async function promptNewSession(onCreated?: (session: SessionRecord) => v
     });
   }
 
+  let pickableWt: GitWorktree[] = [];
+  try {
+    const raw = (await window.vibeyard.git.getWorktrees(project.path)) as GitWorktree[];
+    pickableWt = raw.filter((w) => !w.isBare);
+  } catch {
+    // Ignore — no worktree selector
+  }
+
+  if (pickableWt.length > 1) {
+    fields.push({
+      label: 'Git worktree',
+      id: 'session-worktree',
+      type: 'select',
+      defaultValue: '__inherit__',
+      options: [
+        { value: '__inherit__', label: 'Same as active tab' },
+        { value: '__auto__', label: 'Auto (shell CWD)' },
+        ...pickableWt.map((w) => ({
+          value: w.path,
+          label: worktreeSelectLabel(w, project.path),
+        })),
+      ],
+    });
+  }
+
   showModal('New Session', fields, (values) => {
     const name = values['session-name']?.trim();
     if (name) {
@@ -841,7 +975,14 @@ export async function promptNewSession(onCreated?: (session: SessionRecord) => v
       const keepArgs = values['keep-args'] === 'true';
       project.defaultArgs = keepArgs ? (args || undefined) : undefined;
       const providerId = (values['provider'] || 'claude') as ProviderId;
-      const session = appState.addSession(project.id, name, args, providerId);
+      const wtChoice = values['session-worktree'];
+      let gitWt: { path: string | null; userPinned: boolean } | undefined;
+      if (wtChoice === '__auto__') {
+        gitWt = { path: null, userPinned: false };
+      } else if (wtChoice && wtChoice !== '__inherit__') {
+        gitWt = { path: wtChoice, userPinned: true };
+      }
+      const session = appState.addSession(project.id, name, args, providerId, gitWt);
       if (session && onCreated) onCreated(session);
     }
   });
@@ -867,4 +1008,8 @@ function esc(s: string): string {
   const el = document.createElement('span');
   el.textContent = s;
   return el.innerHTML;
+}
+
+function escAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }

--- a/src/renderer/components/terminal-pane.test.ts
+++ b/src/renderer/components/terminal-pane.test.ts
@@ -41,7 +41,9 @@ vi.mock('@xterm/addon-fit', () => ({
 }));
 
 vi.mock('@xterm/addon-webgl', () => ({
-  WebglAddon: class FakeWebglAddon {},
+  WebglAddon: class FakeWebglAddon {
+    dispose(): void {}
+  },
 }));
 
 vi.mock('@xterm/addon-search', () => ({

--- a/src/renderer/components/terminal-pane.ts
+++ b/src/renderer/components/terminal-pane.ts
@@ -7,14 +7,19 @@ import { initSession, removeSession } from '../session-activity.js';
 import { markFreshSession } from '../session-insights.js';
 import { removeSession as removeCostSession, type CostInfo } from '../session-cost.js';
 import { removeSession as removeContextSession, type ContextWindowInfo } from '../session-context.js';
+import { clearSession as clearTitleSession } from '../session-title.js';
 import type { ProviderId } from '../types.js';
+import type { Preferences } from '../../shared/types.js';
 import { getProviderCapabilities } from '../provider-availability.js';
 import { FilePathLinkProvider, GithubLinkProvider } from './terminal-link-provider.js';
 import { attachClipboardCopyHandler } from './terminal-utils.js';
 import { getEffectiveTerminalFontSize } from '../terminal-font-size.js';
+import { appState } from '../state.js';
+import { backdropIsActive, getTerminalSurfaceBackgroundColor } from '../terminal-background-helpers.js';
 
 interface TerminalInstance {
   terminal: Terminal;
+  webglAddon: WebglAddon | null;
   fitAddon: FitAddon;
   searchAddon: SearchAddon;
   element: HTMLDivElement;
@@ -72,9 +77,10 @@ export function createTerminalPane(
   statusBar.appendChild(costDisplay);
   element.appendChild(statusBar);
 
+  const surfaceBg = getTerminalSurfaceBackgroundColor(appState.preferences);
   const terminal = new Terminal({
     theme: {
-      background: '#000000',
+      background: surfaceBg,
       foreground: '#e0e0e0',
       cursor: '#e94560',
       selectionBackground: '#ff6b85a6',
@@ -90,6 +96,7 @@ export function createTerminalPane(
     fontSize: getEffectiveTerminalFontSize(),
     fontFamily: "'JetBrains Mono', 'Fira Code', 'SF Mono', Menlo, monospace",
     cursorBlink: true,
+    allowTransparency: true,
     allowProposedApi: true,
     linkHandler: {
       activate: (event, uri) => {
@@ -123,6 +130,7 @@ export function createTerminalPane(
 
   const instance: TerminalInstance = {
     terminal,
+    webglAddon: null,
     fitAddon,
     searchAddon,
     element,
@@ -179,6 +187,30 @@ export function getAllInstances(): Map<string, TerminalInstance> {
   return instances;
 }
 
+/**
+ * Enable WebGL when no backdrop (performance), disable when backdrop is on (transparency).
+ * Safe to call after theme / backdrop prefs change.
+ */
+export function syncSessionTerminalsWebglFromPreferences(prefs: Preferences): void {
+  const useWebgl = !backdropIsActive(prefs);
+  for (const [, instance] of instances) {
+    if (!instance.terminal.element) continue;
+    if (useWebgl) {
+      if (!instance.webglAddon) {
+        try {
+          instance.webglAddon = new WebglAddon();
+          instance.terminal.loadAddon(instance.webglAddon);
+        } catch {
+          instance.webglAddon = null;
+        }
+      }
+    } else if (instance.webglAddon) {
+      instance.webglAddon.dispose();
+      instance.webglAddon = null;
+    }
+  }
+}
+
 export function setPendingPrompt(sessionId: string, prompt: string): void {
   const instance = instances.get(sessionId);
   if (instance) {
@@ -193,6 +225,29 @@ function clearPendingPromptTimer(instance: TerminalInstance): void {
   }
 }
 
+
+/**
+ * Drop the saved CLI conversation id and spawn a new PTY in the same tab.
+ * Uses `pty.create` (main replaces an existing PTY with a silenced exit) — do not call `pty.kill` from here.
+ */
+export async function restartCliWithoutSavedConversation(projectId: string, sessionId: string): Promise<void> {
+  appState.clearSessionCliResumeId(projectId, sessionId);
+  const instance = instances.get(sessionId);
+  if (!instance) return;
+  clearPendingPromptTimer(instance);
+  clearTitleSession(sessionId);
+  instance.cliSessionId = null;
+  instance.isResume = false;
+  instance.spawned = false;
+  instance.exited = false;
+  try {
+    instance.terminal.clear();
+  } catch {
+    // xterm may not be open yet
+  }
+  await spawnTerminal(sessionId);
+  fitAllVisible();
+}
 
 export async function spawnTerminal(sessionId: string): Promise<void> {
   const instance = instances.get(sessionId);
@@ -227,12 +282,15 @@ export function attachToContainer(sessionId: string, container: HTMLElement): vo
     container.appendChild(instance.element);
     instance.terminal.open(xtermWrap as HTMLElement);
 
-    // Try WebGL, fall back silently
-    try {
-      const webglAddon = new WebglAddon();
-      instance.terminal.loadAddon(webglAddon);
-    } catch {
-      // WebGL not available, software renderer works fine
+    // WebGL paints opaque cell backgrounds (alpha forced to 1), which hides the backdrop.
+    // With a backdrop we use the default DOM/canvas renderer so translucent theme.background works.
+    if (!backdropIsActive(appState.preferences)) {
+      try {
+        instance.webglAddon = new WebglAddon();
+        instance.terminal.loadAddon(instance.webglAddon);
+      } catch {
+        instance.webglAddon = null;
+      }
     }
   } else {
     // Always re-append to ensure correct DOM order (appendChild moves existing children)
@@ -329,6 +387,8 @@ export function destroyTerminal(sessionId: string): void {
 
   clearPendingPromptTimer(instance);
   window.vibeyard.pty.kill(sessionId);
+  instance.webglAddon?.dispose();
+  instance.webglAddon = null;
   instance.terminal.dispose();
   instance.element.remove();
   instances.delete(sessionId);

--- a/src/renderer/components/terminal-pane.ts
+++ b/src/renderer/components/terminal-pane.ts
@@ -11,6 +11,7 @@ import type { ProviderId } from '../types.js';
 import { getProviderCapabilities } from '../provider-availability.js';
 import { FilePathLinkProvider, GithubLinkProvider } from './terminal-link-provider.js';
 import { attachClipboardCopyHandler } from './terminal-utils.js';
+import { getEffectiveTerminalFontSize } from '../terminal-font-size.js';
 
 interface TerminalInstance {
   terminal: Terminal;
@@ -86,7 +87,7 @@ export function createTerminalPane(
       cyan: '#00acc1',
       white: '#e0e0e0',
     },
-    fontSize: 14,
+    fontSize: getEffectiveTerminalFontSize(),
     fontFamily: "'JetBrains Mono', 'Fira Code', 'SF Mono', Menlo, monospace",
     cursorBlink: true,
     allowProposedApi: true,

--- a/src/renderer/display-preferences.ts
+++ b/src/renderer/display-preferences.ts
@@ -8,6 +8,7 @@ import {
 import { getAllInstances, fitAllVisible } from './components/terminal-pane.js';
 import { applyShellTerminalsFontSize } from './components/project-terminal.js';
 import { applyRemoteTerminalsFontSize } from './components/remote-terminal-pane.js';
+import { refreshTerminalBackdropFromPreferences } from './terminal-backdrop.js';
 
 export const DEFAULT_UI_ZOOM = 1;
 
@@ -83,6 +84,7 @@ export function applyAllTerminalFontSizes(): void {
 export async function applyDisplayPreferences(): Promise<void> {
   await applyUiZoom();
   applyAllTerminalFontSizes();
+  void refreshTerminalBackdropFromPreferences(appState.preferences);
   window.dispatchEvent(new Event('resize'));
   requestAnimationFrame(() => {
     window.dispatchEvent(new Event('resize'));

--- a/src/renderer/display-preferences.ts
+++ b/src/renderer/display-preferences.ts
@@ -1,0 +1,90 @@
+import { appState } from './state.js';
+import {
+  getEffectiveTerminalFontSize,
+  applyXtermFontSize,
+  TERMINAL_FONT_MIN,
+  TERMINAL_FONT_MAX,
+} from './terminal-font-size.js';
+import { getAllInstances, fitAllVisible } from './components/terminal-pane.js';
+import { applyShellTerminalsFontSize } from './components/project-terminal.js';
+import { applyRemoteTerminalsFontSize } from './components/remote-terminal-pane.js';
+
+export const DEFAULT_UI_ZOOM = 1;
+
+/** Interface scale range for prefs + keyboard (Chromium zoom factor). */
+export const UI_ZOOM_MIN = 1;
+export const UI_ZOOM_MAX = 2;
+export const UI_ZOOM_STEP = 0.05;
+
+/** Every step for Preferences (same grid as Ctrl+/Ctrl-). */
+export const UI_ZOOM_SIZE_OPTIONS: readonly number[] = Array.from(
+  { length: Math.floor((UI_ZOOM_MAX - UI_ZOOM_MIN) / UI_ZOOM_STEP) + 1 },
+  (_, i) => Math.round((UI_ZOOM_MIN + i * UI_ZOOM_STEP) * 100) / 100,
+);
+
+function snapUiZoom(z: number): number {
+  return Math.round(Math.min(UI_ZOOM_MAX, Math.max(UI_ZOOM_MIN, z)) * 100) / 100;
+}
+
+/** One keyboard step: interface zoom (+/- 5%) + terminal font (+/- 1px), both persist. */
+export function stepUiAndTerminalZoom(direction: 1 | -1): void {
+  const z = snapUiZoom(effectiveUiZoom());
+  const nz = snapUiZoom(z + direction * UI_ZOOM_STEP);
+
+  const curF = getEffectiveTerminalFontSize();
+  const nf = Math.min(TERMINAL_FONT_MAX, Math.max(TERMINAL_FONT_MIN, curF + direction));
+
+  appState.patchPreferences({
+    uiZoom: nz,
+    terminalFontSize: nf,
+  });
+}
+export { DEFAULT_TERMINAL_FONT_SIZE } from './terminal-font-size.js';
+
+function effectiveUiZoom(): number {
+  const z = appState.preferences?.uiZoom;
+  if (typeof z !== 'number' || !Number.isFinite(z) || z < 0.5 || z > 4) return DEFAULT_UI_ZOOM;
+  return z;
+}
+
+/**
+ * Whole-app scale via Electron `webContents.setZoomFactor` (Chromium page zoom).
+ * Avoids CSS `zoom`, which breaks flex layout (terminal gutter / clipped chrome) on Windows.
+ */
+export async function applyUiZoom(): Promise<void> {
+  const appEl = document.getElementById('app');
+  if (appEl) {
+    appEl.style.removeProperty('zoom');
+    appEl.style.removeProperty('width');
+    appEl.style.removeProperty('height');
+  }
+  document.documentElement.classList.remove('ui-zoom-active');
+  document.documentElement.style.removeProperty('--app-ui-zoom');
+
+  const zoom = effectiveUiZoom();
+  try {
+    await window.vibeyard.app.setZoomFactor(zoom);
+  } catch {
+    // Tests or environments without the IPC bridge
+  }
+}
+
+/** Update xterm font size on every terminal instance and refit visible panes. */
+export function applyAllTerminalFontSizes(): void {
+  const fontSize = getEffectiveTerminalFontSize();
+  for (const [, inst] of getAllInstances()) {
+    applyXtermFontSize(inst.terminal, fontSize);
+  }
+  applyShellTerminalsFontSize(fontSize);
+  applyRemoteTerminalsFontSize(fontSize);
+  fitAllVisible();
+}
+
+export async function applyDisplayPreferences(): Promise<void> {
+  await applyUiZoom();
+  applyAllTerminalFontSizes();
+  window.dispatchEvent(new Event('resize'));
+  requestAnimationFrame(() => {
+    window.dispatchEvent(new Event('resize'));
+  });
+}

--- a/src/renderer/git-status.ts
+++ b/src/renderer/git-status.ts
@@ -1,6 +1,6 @@
 import { appState } from './state.js';
 import { onChange as onStatusChange } from './session-activity.js';
-import type { GitWorktree } from './types.js';
+import type { GitWorktree, SessionRecord } from './types.js';
 
 export interface GitStatus {
   isGitRepo: boolean;
@@ -21,15 +21,28 @@ const listeners: GitStatusCallback[] = [];
 const worktreeChangeListeners: WorktreeChangeCallback[] = [];
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 let polling = false;
+/** When true, run another poll as soon as the current one finishes (coalesced). */
+let pollPending = false;
 
 // Worktree cache: projectId → GitWorktree[]
 const worktreeCache = new Map<string, GitWorktree[]>();
-// Session → worktree path mapping
+// Session → worktree path mapping (from shell cwd; used when gitWorktreePath is unset)
 const sessionWorktreeMap = new Map<string, string>();
-// Manual override: projectId → worktree path
-const manualOverride = new Map<string, string>();
-let worktreePollCounter = 0;
+/** Last PTY cwd per session (in-memory; Windows may not report cwd). */
+const sessionShellCwd = new Map<string, string>();
+/** Last git root we polled per project — used to re-notify UI when the path changes but counts match. */
+const lastPolledGitPathByProject = new Map<string, string>();
+
+/** Terminal-style tabs (unset `type`) can pin a git worktree per tab. */
+export function sessionSupportsGitWorktreePin(session: SessionRecord | undefined): boolean {
+  return session != null && !session.type;
+}
 let unwatchGitChanged: (() => void) | null = null;
+
+/** Compare worktree roots across Windows/Linux and trailing slash differences. */
+function normWorktreePath(p: string): string {
+  return p.replace(/\\/g, '/').replace(/\/+$/, '');
+}
 
 async function refreshWorktrees(projectId: string, projectPath: string): Promise<void> {
   try {
@@ -37,10 +50,9 @@ async function refreshWorktrees(projectId: string, projectPath: string): Promise
     const prev = worktreeCache.get(projectId);
     worktreeCache.set(projectId, worktrees);
 
-    // Clean up manual overrides pointing to deleted worktrees
-    const override = manualOverride.get(projectId);
-    if (override && !worktrees.some(w => w.path === override)) {
-      manualOverride.delete(projectId);
+    // Empty list usually means git failed — do not prune persisted pins (would wipe all worktree tabs).
+    if (worktrees.length > 0) {
+      appState.pruneStaleSessionGitWorktrees(projectId, new Set(worktrees.map((w) => w.path)));
     }
 
     if (!prev || JSON.stringify(prev) !== JSON.stringify(worktrees)) {
@@ -55,72 +67,126 @@ async function detectSessionWorktree(sessionId: string): Promise<void> {
   const project = appState.activeProject;
   if (!project) return;
 
+  const session = project.sessions.find((s) => s.id === sessionId);
+  if (!session || !sessionSupportsGitWorktreePin(session)) return;
+
+  let cwd: string | null = null;
   try {
-    const cwd = await window.vibeyard.pty.getCwd(sessionId);
-    if (!cwd) return;
+    cwd = await window.vibeyard.pty.getCwd(sessionId);
+  } catch {
+    // Ignore errors
+  }
 
-    const worktrees = worktreeCache.get(project.id);
-    if (!worktrees || worktrees.length <= 1) return;
+  const nextShell = cwd?.trim() ?? '';
+  const prevShell = sessionShellCwd.get(sessionId) ?? '';
+  let shellChanged = false;
+  if (prevShell !== nextShell) {
+    if (nextShell) sessionShellCwd.set(sessionId, nextShell);
+    else sessionShellCwd.delete(sessionId);
+    shellChanged = true;
+  }
 
-    // Find which worktree the cwd falls under (longest path match)
-    let bestMatch = '';
+  if (session.gitWorktreeUserPinned) {
+    if (shellChanged) {
+      for (const cb of worktreeChangeListeners) cb();
+    }
+    return;
+  }
+
+  const worktrees = worktreeCache.get(project.id);
+  if (!worktrees || worktrees.length <= 1) {
+    if (shellChanged) {
+      for (const cb of worktreeChangeListeners) cb();
+    }
+    return;
+  }
+
+  let bestMatch = '';
+  if (nextShell) {
+    const shellN = normWorktreePath(nextShell);
     for (const wt of worktrees) {
-      if ((cwd === wt.path || cwd.startsWith(wt.path + '/')) && wt.path.length > bestMatch.length) {
+      if (wt.isBare) continue;
+      const wtN = normWorktreePath(wt.path);
+      const under = shellN === wtN || shellN.startsWith(wtN + '/');
+      if (under && wtN.length > normWorktreePath(bestMatch).length) {
         bestMatch = wt.path;
       }
     }
+  }
 
-    if (bestMatch) {
-      const prev = sessionWorktreeMap.get(sessionId);
-      sessionWorktreeMap.set(sessionId, bestMatch);
-      if (prev !== bestMatch) {
-        for (const cb of worktreeChangeListeners) cb();
-      }
+  const prevMap = sessionWorktreeMap.get(sessionId) ?? '';
+  let mapChanged = false;
+  if (bestMatch) {
+    sessionWorktreeMap.set(sessionId, bestMatch);
+    if (prevMap !== bestMatch) mapChanged = true;
+  } else {
+    sessionWorktreeMap.delete(sessionId);
+    if (prevMap !== '') mapChanged = true;
+  }
+
+  const prevPersisted = session.gitWorktreePath ?? '';
+  if (bestMatch) {
+    if (normWorktreePath(bestMatch) !== normWorktreePath(prevPersisted)) {
+      appState.syncSessionGitWorktreeFromDetect(project.id, sessionId, bestMatch);
     }
-  } catch {
-    // Ignore errors
+  } else if (prevPersisted !== '' && nextShell !== '') {
+    // PTY cwd unknown (session not spawned yet): keep restored gitWorktreePath until we can see cwd.
+    appState.syncSessionGitWorktreeFromDetect(project.id, sessionId, null);
+  }
+
+  if (shellChanged || mapChanged) {
+    for (const cb of worktreeChangeListeners) cb();
   }
 }
 
 async function poll(): Promise<void> {
   const project = appState.activeProject;
-  if (!project || polling) return;
+  if (!project) return;
+
+  if (polling) {
+    pollPending = true;
+    return;
+  }
 
   polling = true;
   try {
-    // Refresh worktree list every 3rd poll (~30s)
-    worktreePollCounter++;
-    if (worktreePollCounter % 3 === 1) {
+    for (;;) {
       await refreshWorktrees(project.id, project.path);
-    }
 
-    // Detect active session's worktree
-    const activeSession = appState.activeSession;
-    if (activeSession && activeSession.type !== 'diff-viewer' && activeSession.type !== 'file-reader' && activeSession.type !== 'mcp-inspector') {
-      await detectSessionWorktree(activeSession.id);
-    }
+      const activeSession = appState.activeSession;
+      if (activeSession && sessionSupportsGitWorktreePin(activeSession)) {
+        await detectSessionWorktree(activeSession.id);
+      }
 
-    // Query git status using the resolved worktree path
-    const gitPath = getActiveGitPath(project.id);
-    const status = await window.vibeyard.git.getStatus(gitPath) as GitStatus;
-    const cacheKey = `${project.id}:${gitPath}`;
-    const prev = cache.get(cacheKey);
-    cache.set(cacheKey, status);
-    // Also set by projectId for backward compatibility
-    cache.set(project.id, status);
+      const gitPath = getActiveGitPath(project.id);
+      const status = await window.vibeyard.git.getStatus(gitPath) as GitStatus;
+      const cacheKey = `${project.id}:${gitPath}`;
+      const prev = cache.get(cacheKey);
+      cache.set(cacheKey, status);
 
-    if (!prev || JSON.stringify(prev) !== JSON.stringify(status)) {
-      for (const cb of listeners) cb(project.id, status);
+      const prevPath = lastPolledGitPathByProject.get(project.id);
+      const pathChanged = prevPath !== gitPath;
+      lastPolledGitPathByProject.set(project.id, gitPath);
+
+      if (!prev || JSON.stringify(prev) !== JSON.stringify(status) || pathChanged) {
+        for (const cb of listeners) cb(project.id, status);
+      }
+
+      if (!pollPending) break;
+      pollPending = false;
     }
   } catch {
     // Ignore errors
   } finally {
     polling = false;
+    pollPending = false;
   }
 }
 
 export function getGitStatus(projectId: string): GitStatus | null {
-  return cache.get(projectId) ?? null;
+  const gitPath = getActiveGitPath(projectId);
+  const key = `${projectId}:${gitPath}`;
+  return cache.get(key) ?? null;
 }
 
 export function getWorktrees(projectId: string): GitWorktree[] | null {
@@ -128,34 +194,56 @@ export function getWorktrees(projectId: string): GitWorktree[] | null {
 }
 
 export function getActiveGitPath(projectId: string): string {
-  // Manual override takes precedence
-  const override = manualOverride.get(projectId);
-  if (override) return override;
+  const project = appState.projects.find((p) => p.id === projectId);
+  if (!project?.activeSessionId) return project?.path ?? '';
 
-  // Check active session's worktree
-  const project = appState.projects.find(p => p.id === projectId);
-  if (project?.activeSessionId) {
-    const sessionWt = sessionWorktreeMap.get(project.activeSessionId);
-    if (sessionWt) return sessionWt;
+  const session = project.sessions.find((s) => s.id === project.activeSessionId);
+  const worktrees = worktreeCache.get(project.id);
+  const path = session?.gitWorktreePath;
+
+  if (session?.gitWorktreeUserPinned && path) {
+    if (!worktrees || worktrees.length === 0) {
+      return path;
+    }
+    const known = worktrees.some((w) => w.path === path && !w.isBare);
+    if (known) return path;
   }
 
-  // Fallback to project path
-  return project?.path ?? '';
+  if (path) {
+    if (!worktrees || worktrees.length === 0) {
+      return path;
+    }
+    const known = worktrees.some((w) => w.path === path && !w.isBare);
+    if (known) return path;
+  }
+
+  const sessionWt = sessionWorktreeMap.get(project.activeSessionId);
+  if (sessionWt) return sessionWt;
+
+  return project.path;
 }
 
 export function getSessionWorktree(sessionId: string): string | null {
+  const project = appState.activeProject;
+  const session = project?.sessions.find((s) => s.id === sessionId);
+  if (session?.gitWorktreePath) {
+    return session.gitWorktreePath;
+  }
   return sessionWorktreeMap.get(sessionId) ?? null;
 }
 
+export function getSessionShellCwd(sessionId: string): string | null {
+  const v = sessionShellCwd.get(sessionId);
+  return v ?? null;
+}
+
+/** Set git worktree for the active terminal tab only (sidebar selector). */
 export function setActiveWorktree(projectId: string, path: string | null): void {
-  if (path) {
-    manualOverride.set(projectId, path);
-  } else {
-    manualOverride.delete(projectId);
-  }
-  // Trigger refresh
-  poll();
-  for (const cb of worktreeChangeListeners) cb();
+  const project = appState.projects.find((p) => p.id === projectId);
+  if (!project?.activeSessionId) return;
+  const pin = path != null && path !== '';
+  appState.setSessionGitWorktree(projectId, project.activeSessionId, path, { userPinned: pin });
+  void refreshGitStatus();
 }
 
 export { poll as refreshGitStatus };
@@ -206,7 +294,6 @@ export function startPolling(): void {
 
   // Immediate poll on project/session changes; manage interval lifecycle
   appState.on('project-changed', () => {
-    worktreePollCounter = 0; // Force worktree refresh on project switch
     if (!appState.activeProject) {
       stopInterval();
     } else {
@@ -214,28 +301,35 @@ export function startPolling(): void {
       startInterval();
     }
   });
+
+  // `startPolling()` runs before `appState.load()` in index.ts; initial state has no project,
+  // so the first `startInterval()` no-ops. Persisted projects only fire `state-loaded`, not
+  // `project-changed` — without this, git never polls and the branch menu stays dead.
+  appState.on('state-loaded', () => {
+    if (appState.activeProject) {
+      window.vibeyard.git.watchProject(appState.activeProject.path);
+    }
+    startInterval();
+  });
+
   appState.on('session-added', () => poll());
 
   // Detect worktree on session change
   appState.on('session-changed', () => {
-    const activeSession = appState.activeSession;
-    if (activeSession && activeSession.type !== 'diff-viewer' && activeSession.type !== 'file-reader' && activeSession.type !== 'mcp-inspector') {
-      detectSessionWorktree(activeSession.id);
-    }
-    // Clear manual override on session switch so auto-detection takes effect
-    const project = appState.activeProject;
-    if (project) {
-      manualOverride.delete(project.id);
-    }
-    poll();
+    void poll();
+    for (const cb of worktreeChangeListeners) cb();
   });
 
   // Poll when a session transitions from working → waiting/completed
   onStatusChange((_sessionId, status) => {
     if (status === 'waiting' || status === 'completed') {
-      // Also re-detect worktree on status transition
-      detectSessionWorktree(_sessionId);
-      poll();
+      void (async () => {
+        const session = appState.activeProject?.sessions.find((s) => s.id === _sessionId);
+        if (session && sessionSupportsGitWorktreePin(session)) {
+          await detectSessionWorktree(_sessionId);
+        }
+        await poll();
+      })();
     }
   });
 }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; font-src 'self'; connect-src 'self' http: https:; frame-src *;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; font-src 'self'; img-src 'self' data: blob:; connect-src 'self' http: https:; frame-src *;">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Vibeyard</title>
   <link rel="icon" type="image/png" href="icon.png">

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -3,7 +3,14 @@ import { initSidebar, promptNewProject } from './components/sidebar.js';
 import { initTabBar } from './components/tab-bar.js';
 import { initSplitLayout } from './components/split-layout.js';
 import { initKeybindings } from './keybindings.js';
-import { handlePtyData, destroyTerminal, updateCostDisplay, updateContextDisplay } from './components/terminal-pane.js';
+import {
+  handlePtyData,
+  destroyTerminal,
+  updateCostDisplay,
+  updateContextDisplay,
+  restartCliWithoutSavedConversation,
+} from './components/terminal-pane.js';
+import { showAlertBanner, removeAlertBanner } from './components/alert-banner.js';
 import { setIdle, setHookStatus, notifyInterrupt } from './session-activity.js';
 import { parseCost, setCostData, onChange as onCostChange } from './session-cost.js';
 import { parseTitle, clearSession as clearTitleSession } from './session-title.js';
@@ -46,6 +53,8 @@ window.vibeyard.app.onQuitting(() => {
 });
 
 async function main(): Promise<void> {
+  const staleResumeErrorBannerShown = new Set<string>();
+
   // Wire PTY data/exit events from main process
   window.vibeyard.pty.onData((sessionId, data) => {
     if (isShellSessionId(sessionId)) {
@@ -54,6 +63,29 @@ async function main(): Promise<void> {
       handlePtyData(sessionId, data);
       parseCost(sessionId, data);
       parseTitle(sessionId, data);
+      if (
+        data.includes('No conversation found with session ID') &&
+        !staleResumeErrorBannerShown.has(sessionId)
+      ) {
+        staleResumeErrorBannerShown.add(sessionId);
+        const project = appState.projects.find((p) => p.sessions.some((s) => s.id === sessionId));
+        const session = project?.sessions.find((s) => s.id === sessionId);
+        if (project && session?.cliSessionId && appState.activeSession?.id === sessionId) {
+          showAlertBanner({
+            icon: '\u26A0\uFE0F',
+            message:
+              'Saved Claude session no longer exists (cleared data, different account, or it was removed). Start fresh to open a new conversation in this tab.',
+            cta: {
+              label: 'Start fresh',
+              onClick: async () => {
+                removeAlertBanner();
+                await restartCliWithoutSavedConversation(project.id, sessionId);
+                staleResumeErrorBannerShown.delete(sessionId);
+              },
+            },
+          });
+        }
+      }
       if (data.includes('Interrupted')) {
         notifyInterrupt(sessionId);
       }

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -37,6 +37,7 @@ import type { InspectorEvent } from '../shared/types.js';
 import { getContext } from './session-context.js';
 import { initSessionInspector } from './components/session-inspector.js';
 import { loadProviderMetas } from './provider-availability.js';
+import { applyDisplayPreferences } from './display-preferences.js';
 
 let isQuitting = false;
 window.vibeyard.app.onQuitting(() => {
@@ -197,6 +198,10 @@ async function main(): Promise<void> {
 
   // Load persisted state
   await appState.load();
+  void applyDisplayPreferences();
+  appState.on('preferences-changed', () => {
+    void applyDisplayPreferences();
+  });
 
   // Auto-open new project modal when no projects exist
   if (appState.projects.length === 0) {

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -10,6 +10,7 @@ import { getActiveShellSessionId } from './components/project-terminal.js';
 import { toggleGitPanel } from './components/git-panel.js';
 import { showQuickOpen } from './components/quick-open.js';
 import { shortcutManager } from './shortcuts.js';
+import { stepUiAndTerminalZoom } from './display-preferences.js';
 import { getFileReaderInstance, getFileReaderTextSelector, showGoToLineBar } from './components/file-reader.js';
 import { getFileViewerInstance } from './components/file-viewer.js';
 import { DomSearchBackend } from './components/dom-search-backend.js';
@@ -88,6 +89,8 @@ export function initKeybindings(): void {
     }
   });
   shortcutManager.registerHandler('help', () => showHelpDialog());
+  shortcutManager.registerHandler('ui-zoom-in', () => stepUiAndTerminalZoom(1));
+  shortcutManager.registerHandler('ui-zoom-out', () => stepUiAndTerminalZoom(-1));
 
   document.addEventListener('keydown', (e) => {
     shortcutManager.matchEvent(e);

--- a/src/renderer/refresh-terminal-surfaces.test.ts
+++ b/src/renderer/refresh-terminal-surfaces.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Preferences } from '../shared/types.js';
+
+const {
+  sessionTerminal,
+  getAllInstances,
+  applyShellTerminalsSurface,
+  applyRemoteTerminalsSurface,
+  syncSessionTerminalsWebglFromPreferences,
+  syncShellTerminalsWebglFromPreferences,
+  syncRemoteTerminalsWebglFromPreferences,
+} = vi.hoisted(() => {
+  const sessionTerminal: { options: { theme: Record<string, string> } } = {
+    options: { theme: { foreground: '#e0e0e0' } },
+  };
+  return {
+    sessionTerminal,
+    getAllInstances: vi.fn(() => new Map([['s1', { terminal: sessionTerminal }]])),
+    applyShellTerminalsSurface: vi.fn(),
+    applyRemoteTerminalsSurface: vi.fn(),
+    syncSessionTerminalsWebglFromPreferences: vi.fn(),
+    syncShellTerminalsWebglFromPreferences: vi.fn(),
+    syncRemoteTerminalsWebglFromPreferences: vi.fn(),
+  };
+});
+
+vi.mock('./components/terminal-pane.js', () => ({
+  getAllInstances,
+  syncSessionTerminalsWebglFromPreferences,
+}));
+vi.mock('./components/project-terminal.js', () => ({
+  applyShellTerminalsSurface,
+  syncShellTerminalsWebglFromPreferences,
+}));
+vi.mock('./components/remote-terminal-pane.js', () => ({
+  applyRemoteTerminalsSurface,
+  syncRemoteTerminalsWebglFromPreferences,
+}));
+
+import { refreshTerminalSurfacesFromPreferences } from './refresh-terminal-surfaces.js';
+
+function prefs(p: Partial<Preferences>): Preferences {
+  return {
+    soundOnSessionWaiting: true,
+    notificationsDesktop: true,
+    debugMode: false,
+    sessionHistoryEnabled: true,
+    insightsEnabled: true,
+    autoTitleEnabled: true,
+    ...p,
+  } as Preferences;
+}
+
+describe('refreshTerminalSurfacesFromPreferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionTerminal.options.theme = { foreground: '#e0e0e0' };
+  });
+
+  it('sets opaque cell background when backdrop is off', () => {
+    const p = prefs({ terminalBackgroundMode: 'none' });
+    refreshTerminalSurfacesFromPreferences(p);
+    expect(sessionTerminal.options.theme.background).toBe('#000000');
+    expect(applyShellTerminalsSurface).toHaveBeenCalledWith('#000000');
+    expect(applyRemoteTerminalsSurface).toHaveBeenCalledWith('#000000');
+    expect(getAllInstances).toHaveBeenCalled();
+    expect(syncSessionTerminalsWebglFromPreferences).toHaveBeenCalledWith(p);
+    expect(syncShellTerminalsWebglFromPreferences).toHaveBeenCalledWith(p);
+    expect(syncRemoteTerminalsWebglFromPreferences).toHaveBeenCalledWith(p);
+  });
+
+  it('sets translucent cell background when preset backdrop is active', () => {
+    const p = prefs({ terminalBackgroundMode: 'preset', terminalBackgroundSurfaceAlpha: 0.5 });
+    refreshTerminalSurfacesFromPreferences(p);
+    expect(sessionTerminal.options.theme.background).toBe('rgba(0,0,0,0.5)');
+    expect(applyShellTerminalsSurface).toHaveBeenCalledWith('rgba(0,0,0,0.5)');
+    expect(syncSessionTerminalsWebglFromPreferences).toHaveBeenCalledWith(p);
+  });
+});

--- a/src/renderer/refresh-terminal-surfaces.ts
+++ b/src/renderer/refresh-terminal-surfaces.ts
@@ -1,0 +1,18 @@
+import type { Preferences } from '../shared/types.js';
+import { getTerminalSurfaceBackgroundColor } from './terminal-background-helpers.js';
+import { getAllInstances, syncSessionTerminalsWebglFromPreferences } from './components/terminal-pane.js';
+import { applyShellTerminalsSurface, syncShellTerminalsWebglFromPreferences } from './components/project-terminal.js';
+import { applyRemoteTerminalsSurface, syncRemoteTerminalsWebglFromPreferences } from './components/remote-terminal-pane.js';
+
+/** Push current preferences into every live xterm instance. */
+export function refreshTerminalSurfacesFromPreferences(prefs: Preferences): void {
+  const bg = getTerminalSurfaceBackgroundColor(prefs);
+  for (const [, inst] of getAllInstances()) {
+    inst.terminal.options.theme = { ...inst.terminal.options.theme, background: bg };
+  }
+  applyShellTerminalsSurface(bg);
+  applyRemoteTerminalsSurface(bg);
+  syncSessionTerminalsWebglFromPreferences(prefs);
+  syncShellTerminalsWebglFromPreferences(prefs);
+  syncRemoteTerminalsWebglFromPreferences(prefs);
+}

--- a/src/renderer/session-pty-cwd.test.ts
+++ b/src/renderer/session-pty-cwd.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCliSessionPtyCwd } from './session-pty-cwd.js';
+
+describe('resolveCliSessionPtyCwd', () => {
+  const root = '/repo/main';
+
+  it('uses project path for CLI session without gitWorktreePath', () => {
+    expect(resolveCliSessionPtyCwd(root, {})).toBe(root);
+  });
+
+  it('uses trimmed gitWorktreePath for CLI session', () => {
+    expect(resolveCliSessionPtyCwd(root, { gitWorktreePath: '  /repo/wt-feature  ' })).toBe('/repo/wt-feature');
+  });
+
+  it('falls back to project path when gitWorktreePath is only whitespace', () => {
+    expect(resolveCliSessionPtyCwd(root, { gitWorktreePath: '   ' })).toBe(root);
+  });
+
+  it('ignores gitWorktreePath when session has a special type', () => {
+    expect(resolveCliSessionPtyCwd(root, { type: 'mcp-inspector', gitWorktreePath: '/repo/wt' })).toBe(root);
+    expect(resolveCliSessionPtyCwd(root, { type: 'diff-viewer', gitWorktreePath: '/repo/wt' })).toBe(root);
+  });
+});

--- a/src/renderer/session-pty-cwd.ts
+++ b/src/renderer/session-pty-cwd.ts
@@ -1,0 +1,15 @@
+import type { SessionRecord } from '../shared/types.js';
+
+/**
+ * Directory passed to `pty.create` for CLI sessions: linked worktree when set, else project root.
+ * Non-CLI session kinds keep `projectPath` (they do not use this for spawning in split-layout).
+ */
+export function resolveCliSessionPtyCwd(
+  projectPath: string,
+  session: Pick<SessionRecord, 'type' | 'gitWorktreePath'>,
+): string {
+  if (session.type) return projectPath;
+  const wt = session.gitWorktreePath?.trim();
+  if (wt) return wt;
+  return projectPath;
+}

--- a/src/renderer/session-title.test.ts
+++ b/src/renderer/session-title.test.ts
@@ -108,6 +108,31 @@ describe('parseTitle', () => {
     const updated = project.sessions.find((s) => s.id === session.id)!;
     expect(updated.name).toBe('Session 1');
   });
+
+  it('ignores Claude Code version splash as auto-title', () => {
+    const { project, session } = addProjectAndSession('upload');
+    parseTitle(session.id, '───────────── Claude Code v2.1.108 ──');
+    expect(project.sessions.find((s) => s.id === session.id)!.name).toBe('upload');
+  });
+
+  it('ignores Claude Code version splash without a v prefix', () => {
+    const { project, session } = addProjectAndSession('Session 5');
+    parseTitle(session.id, '───────────── Claude Code 2.1.108 ──');
+    expect(project.sessions.find((s) => s.id === session.id)!.name).toBe('Session 5');
+  });
+
+  it('ignores Claude Code splash wrapped in markdown emphasis', () => {
+    const { project, session } = addProjectAndSession('login');
+    parseTitle(session.id, '───────────── *Claude Code v2.1.108* ──');
+    expect(project.sessions.find((s) => s.id === session.id)!.name).toBe('login');
+  });
+
+  it('still applies a real title after skipping the Claude Code splash', () => {
+    const { project, session } = addProjectAndSession();
+    parseTitle(session.id, '───────────── Claude Code v2.1.108 ──');
+    parseTitle(session.id, '───────────── mp3-upload-feature ──');
+    expect(project.sessions.find((s) => s.id === session.id)!.name).toBe('mp3-upload-feature');
+  });
 });
 
 describe('clearSession', () => {

--- a/src/renderer/session-title.ts
+++ b/src/renderer/session-title.ts
@@ -4,6 +4,37 @@ import { appState } from './state.js';
 /** Matches a Claude Code separator line containing the conversation title */
 const TITLE_RE = /─{3,}\s+(\S[^─]*\S)\s+─{2,}/;
 
+function foldCliBannerText(title: string): string {
+  return title
+    .normalize('NFKC')
+    .replace(/[\u200B-\u200D\uFEFF]/g, '')
+    .replace(/^[\s"'`*_~()[\]{}“”‘’]+|[\s"'`*_~()[\]{}“”‘’]+$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Separator text for the CLI welcome header (e.g. "Claude Code v2.1.108"), not a
+ * user conversation topic — must not replace tab names via auto-title.
+ */
+function looksLikeCliProductBanner(title: string): boolean {
+  const t = foldCliBannerText(title);
+  if (!t.startsWith('claude code')) return false;
+  const rest = t.slice('claude code'.length).trim();
+  if (!rest) return true;
+  return /^v?[\d.]+(?:[a-z0-9.-]*)$/i.test(rest);
+}
+
+function titleFromSeparatorLine(line: string): string | null {
+  const m = TITLE_RE.exec(line);
+  if (!m) return null;
+  const raw = m[1].trim();
+  if (!raw) return null;
+  if (looksLikeCliProductBanner(raw)) return null;
+  return raw;
+}
+
 /** Sessions that have already been titled (skip future parsing for performance) */
 const titled = new Set<string>();
 
@@ -16,10 +47,7 @@ export function parseTitle(sessionId: string, rawData: string): void {
 
   // Process line-by-line to avoid matching text spanning across separate separator lines
   for (const line of clean.split(/\r?\n|\r/)) {
-    const match = TITLE_RE.exec(line);
-    if (!match) continue;
-
-    const title = match[1].trim();
+    const title = titleFromSeparatorLine(line);
     if (!title) continue;
 
     titled.add(sessionId);

--- a/src/renderer/shortcuts.test.ts
+++ b/src/renderer/shortcuts.test.ts
@@ -16,9 +16,11 @@ function makeKeyEvent(opts: {
   metaKey?: boolean;
   shiftKey?: boolean;
   altKey?: boolean;
+  code?: string;
 }): KeyboardEvent {
   return {
     key: opts.key,
+    code: opts.code ?? '',
     ctrlKey: opts.ctrlKey ?? false,
     metaKey: opts.metaKey ?? false,
     shiftKey: opts.shiftKey ?? false,
@@ -262,6 +264,7 @@ describe('ShortcutManager', () => {
     expect(all.has('Sessions')).toBe(true);
     expect(all.has('Panels')).toBe(true);
     expect(all.has('Search & Help')).toBe(true);
+    expect(all.has('Display')).toBe(true);
   });
 
   it('getAll entries have resolvedKeys property', async () => {
@@ -360,6 +363,58 @@ describe('ShortcutManager', () => {
     const e = makeKeyEvent({ key: '1', metaKey: true });
     expect(mgr.matchEvent(e)).toBe(true);
     expect(handler).toHaveBeenCalled();
+  });
+
+  it('matchEvent handles CmdOrCtrl+Plus as meta + equals (Mac)', async () => {
+    const { ShortcutManager } = await import('./shortcuts');
+    const mgr = new ShortcutManager();
+    const handler = vi.fn();
+    mgr.registerHandler('ui-zoom-in', handler);
+    const e = makeKeyEvent({ key: '=', metaKey: true });
+    expect(mgr.matchEvent(e)).toBe(true);
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('matchEvent handles CmdOrCtrl+Plus as ctrl + equals (Windows)', async () => {
+    vi.resetModules();
+    vi.stubGlobal('navigator', { platform: 'Win32' });
+    mockAppState.preferences.keybindings = {};
+    const { ShortcutManager } = await import('./shortcuts');
+    const mgr = new ShortcutManager();
+    const handler = vi.fn();
+    mgr.registerHandler('ui-zoom-in', handler);
+    const e = makeKeyEvent({ key: '=', ctrlKey: true });
+    expect(mgr.matchEvent(e)).toBe(true);
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('matchEvent handles CmdOrCtrl+Minus (Mac)', async () => {
+    vi.resetModules();
+    vi.stubGlobal('navigator', { platform: 'MacIntel' });
+    mockAppState.preferences.keybindings = {};
+    const { ShortcutManager } = await import('./shortcuts');
+    const mgr = new ShortcutManager();
+    const handler = vi.fn();
+    mgr.registerHandler('ui-zoom-out', handler);
+    const e = makeKeyEvent({ key: '-', metaKey: true });
+    expect(mgr.matchEvent(e)).toBe(true);
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('displayKeys shows Ctrl++ for CmdOrCtrl+Plus on Windows', async () => {
+    vi.resetModules();
+    vi.stubGlobal('navigator', { platform: 'Win32' });
+    const { displayKeys } = await import('./shortcuts');
+    expect(displayKeys('CmdOrCtrl+Plus')).toBe('Ctrl++');
+    expect(displayKeys('CmdOrCtrl+Minus')).toBe('Ctrl+-');
+  });
+
+  it('displayKeys shows zoom chords on Mac', async () => {
+    vi.resetModules();
+    vi.stubGlobal('navigator', { platform: 'MacIntel' });
+    const { displayKeys } = await import('./shortcuts');
+    expect(displayKeys('CmdOrCtrl+Plus')).toBe('\u2318+');
+    expect(displayKeys('CmdOrCtrl+Minus')).toBe('\u2318\u2212');
   });
 });
 

--- a/src/renderer/shortcuts.ts
+++ b/src/renderer/shortcuts.ts
@@ -42,13 +42,22 @@ export const SHORTCUT_DEFAULTS: ShortcutDefault[] = [
   { id: 'find-in-terminal', label: 'Find', category: 'Search & Help', defaultKeys: 'CmdOrCtrl+F' },
   { id: 'goto-line', label: 'Go to Line', category: 'Search & Help', defaultKeys: 'CmdOrCtrl+L' },
   { id: 'help', label: 'Help', category: 'Search & Help', defaultKeys: 'F1' },
+  { id: 'ui-zoom-in', label: 'Increase Scale (+5% UI, +1px terminal)', category: 'Display', defaultKeys: 'CmdOrCtrl+Plus' },
+  { id: 'ui-zoom-out', label: 'Decrease Scale (−5% UI, −1px terminal)', category: 'Display', defaultKeys: 'CmdOrCtrl+Minus' },
 ];
 
 const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 
 /** Convert accelerator string to platform-specific display string */
 export function displayKeys(accelerator: string): string {
-  let display = accelerator;
+  if (accelerator === 'CmdOrCtrl+Plus') {
+    return isMac ? '\u2318+' : 'Ctrl++';
+  }
+  if (accelerator === 'CmdOrCtrl+Minus') {
+    return isMac ? '\u2318\u2212' : 'Ctrl+-';
+  }
+
+  let display = accelerator.replace(/\+Plus$/g, '++').replace(/\+Minus$/g, '+-');
   if (isMac) {
     display = display.replace(/CmdOrCtrl/g, 'Cmd');
     display = display.replace(/Ctrl\+/g, 'Ctrl+');
@@ -68,28 +77,30 @@ export function displayKeys(accelerator: string): string {
 
 /** Parse an accelerator string into modifier flags and a key */
 function parseAccelerator(accelerator: string): { ctrl: boolean; meta: boolean; shift: boolean; alt: boolean; key: string } {
-  const parts = accelerator.split('+');
+  const lastPlus = accelerator.lastIndexOf('+');
+  const key = lastPlus === -1 ? accelerator : accelerator.slice(lastPlus + 1);
+  const modPart = lastPlus === -1 ? '' : accelerator.slice(0, lastPlus);
+
   let ctrl = false;
   let meta = false;
   let shift = false;
   let alt = false;
-  let key = '';
 
-  for (const part of parts) {
-    const lower = part.toLowerCase();
-    if (lower === 'cmdorctrl') {
-      if (isMac) meta = true;
-      else ctrl = true;
-    } else if (lower === 'ctrl') {
-      ctrl = true;
-    } else if (lower === 'cmd') {
-      meta = true;
-    } else if (lower === 'shift') {
-      shift = true;
-    } else if (lower === 'alt') {
-      alt = true;
-    } else {
-      key = part;
+  if (modPart) {
+    for (const part of modPart.split('+')) {
+      const lower = part.toLowerCase();
+      if (lower === 'cmdorctrl') {
+        if (isMac) meta = true;
+        else ctrl = true;
+      } else if (lower === 'ctrl') {
+        ctrl = true;
+      } else if (lower === 'cmd') {
+        meta = true;
+      } else if (lower === 'shift') {
+        shift = true;
+      } else if (lower === 'alt') {
+        alt = true;
+      }
     }
   }
 
@@ -107,12 +118,30 @@ function matchesAccelerator(e: KeyboardEvent, accelerator: string): boolean {
 
   if (parsed.ctrl !== eventCtrl) return false;
   if (parsed.meta !== eventMeta) return false;
-  if (parsed.shift !== eventShift) return false;
   if (parsed.alt !== eventAlt) return false;
+
+  const parsedKey = parsed.key;
+  const isZoomChord =
+    parsedKey === 'Plus' || parsedKey === '+' || parsedKey === 'Minus' || parsedKey === '-';
+  if (parsed.shift !== eventShift) {
+    const allowShiftMismatch = isZoomChord && !parsed.shift;
+    if (!allowShiftMismatch) return false;
+  }
 
   // Compare key - handle special cases
   const eventKey = e.key;
-  const parsedKey = parsed.key;
+
+  if (parsedKey === 'Plus' || parsedKey === '+') {
+    if (eventKey === '+') return true;
+    if (eventKey === '=') return true;
+    if (e.code === 'NumpadAdd') return true;
+    return false;
+  }
+  if (parsedKey === 'Minus' || parsedKey === '-') {
+    if (eventKey === '-') return true;
+    if (e.code === 'NumpadSubtract') return true;
+    return false;
+  }
 
   // Direct match
   if (eventKey === parsedKey) return true;
@@ -220,7 +249,15 @@ export class ShortcutManager {
   matchEvent(e: KeyboardEvent): boolean {
     const overrides = appState.preferences.keybindings ?? {};
 
-    for (const shortcut of this.shortcuts) {
+    // Display / zoom chords first so they win over session shortcuts that share Ctrl+= etc.
+    const priorityIds = new Set(['ui-zoom-in', 'ui-zoom-out']);
+    const ordered = [...this.shortcuts].sort((a, b) => {
+      const ap = priorityIds.has(a.id) ? 0 : 1;
+      const bp = priorityIds.has(b.id) ? 0 : 1;
+      return ap - bp;
+    });
+
+    for (const shortcut of ordered) {
       const keys = overrides[shortcut.id] ?? shortcut.defaultKeys;
       if (matchesAccelerator(e, keys) && shortcut.handler) {
         e.preventDefault();

--- a/src/renderer/state.test.ts
+++ b/src/renderer/state.test.ts
@@ -404,6 +404,14 @@ describe('addSession()', () => {
     expect(s1.gitWorktreePath).toBe('/wt/shared');
     expect(s1.gitWorktreeUserPinned).toBe(true);
   });
+
+  it('sets userRenamed when userChoseDisplayName is true', () => {
+    const project = addProject();
+    const s = appState.addSession(project.id, 'Custom', undefined, undefined, undefined, {
+      userChoseDisplayName: true,
+    })!;
+    expect(s.userRenamed).toBe(true);
+  });
 });
 
 describe('addDiffViewerSession()', () => {
@@ -553,6 +561,27 @@ describe('updateSessionCliId()', () => {
     // Simulate /clear: new cliSessionId
     appState.updateSessionCliId(project.id, session.id, 'claude-xyz');
     expect(appState.activeSession!.userRenamed).toBe(false);
+  });
+});
+
+describe('clearSessionCliResumeId()', () => {
+  it('clears cliSessionId for a CLI tab and persists', () => {
+    const project = addProject();
+    const session = appState.addSession(project.id, 'S1')!;
+    appState.updateSessionCliId(project.id, session.id, 'stale-id');
+    mockSave.mockClear();
+    appState.clearSessionCliResumeId(project.id, session.id);
+    expect(appState.activeSession!.cliSessionId).toBeNull();
+    expect(mockSave).toHaveBeenCalled();
+  });
+
+  it('no-ops for sessions without a cliSessionId', () => {
+    const project = addProject();
+    const session = appState.addSession(project.id, 'S1')!;
+    mockSave.mockClear();
+    appState.clearSessionCliResumeId(project.id, session.id);
+    expect(appState.activeSession!.cliSessionId).toBeNull();
+    expect(mockSave).not.toHaveBeenCalled();
   });
 });
 

--- a/src/renderer/state.test.ts
+++ b/src/renderer/state.test.ts
@@ -372,6 +372,38 @@ describe('addSession()', () => {
     const session = appState.addSession(project.id, 'S1')!;
     expect(session.args).toBeUndefined();
   });
+
+  it('applies gitWorktreeOverride before session-added (PTY path + menu see same state)', () => {
+    const addedCb = vi.fn();
+    const project = addProject();
+    appState.on('session-added', addedCb);
+    appState.addSession(project.id, 'S1', undefined, undefined, {
+      path: '/wt/feature',
+      userPinned: true,
+    });
+    expect(addedCb).toHaveBeenCalledTimes(1);
+    const payload = addedCb.mock.calls[0][0] as { session: { gitWorktreePath?: string; gitWorktreeUserPinned?: boolean } };
+    expect(payload.session.gitWorktreePath).toBe('/wt/feature');
+    expect(payload.session.gitWorktreeUserPinned).toBe(true);
+  });
+
+  it('gitWorktreeOverride with null path clears worktree (Auto) and does not inherit active tab', () => {
+    const project = addProject();
+    const s0 = appState.addSession(project.id, 'S0')!;
+    appState.setSessionGitWorktree(project.id, s0.id, '/wt/pinned', { userPinned: true });
+    const s1 = appState.addSession(project.id, 'S1', undefined, undefined, { path: null, userPinned: false })!;
+    expect(s1.gitWorktreePath).toBeUndefined();
+    expect(s1.gitWorktreeUserPinned).toBeUndefined();
+  });
+
+  it('inherits git worktree from active CLI tab when override omitted', () => {
+    const project = addProject();
+    const s0 = appState.addSession(project.id, 'S0')!;
+    appState.setSessionGitWorktree(project.id, s0.id, '/wt/shared', { userPinned: true });
+    const s1 = appState.addSession(project.id, 'S1')!;
+    expect(s1.gitWorktreePath).toBe('/wt/shared');
+    expect(s1.gitWorktreeUserPinned).toBe(true);
+  });
 });
 
 describe('addDiffViewerSession()', () => {
@@ -1297,6 +1329,22 @@ describe('resumeFromHistory()', () => {
     expect(resumed.providerId).toBe('claude');
     expect(resumed.id).not.toBe(session.id); // new id
     expect(resumed.createdAt).toBeDefined(); // has its own createdAt
+  });
+
+  it('restores git worktree path when resuming from history', () => {
+    const project = addProject();
+    const session = appState.addSession(project.id, 'Wt tab')!;
+    appState.updateSessionCliId(project.id, session.id, 'cli-wt');
+    appState.setSessionGitWorktree(project.id, session.id, '/repo/feature-wt', { userPinned: true });
+    appState.removeSession(project.id, session.id);
+
+    const archived = appState.getSessionHistory(project.id)[0];
+    expect(archived.gitWorktreePath).toBe('/repo/feature-wt');
+    expect(archived.gitWorktreeUserPinned).toBe(true);
+
+    const resumed = appState.resumeFromHistory(project.id, archived.id)!;
+    expect(resumed.gitWorktreePath).toBe('/repo/feature-wt');
+    expect(resumed.gitWorktreeUserPinned).toBe(true);
   });
 
   it('sets resumed session as active', () => {

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -42,6 +42,8 @@ const defaultPreferences: Preferences = {
   autoTitleEnabled: true,
   readinessExcludedProviders: [],
   sidebarViews: { configSections: true, gitPanel: true, sessionHistory: true, costFooter: true, readinessSection: true },
+  uiZoom: 1,
+  terminalFontSize: 14,
 };
 
 const NAV_HISTORY_MAX = 50;
@@ -261,6 +263,13 @@ class AppState {
     this.emit('preferences-changed');
   }
 
+  /** Apply several preference fields in one persist/emit (e.g. keyboard zoom in/out). */
+  patchPreferences(patch: Partial<Preferences>): void {
+    Object.assign(this.state.preferences, patch);
+    this.persist();
+    this.emit('preferences-changed');
+  }
+
   setActiveProject(id: string | null): void {
     this.state.activeProjectId = id;
     const project = this.state.projects.find((p) => p.id === id);
@@ -314,10 +323,21 @@ class AppState {
     return this.addSession(projectId, name, args, providerId);
   }
 
-  addSession(projectId: string, name: string, args?: string, providerId?: ProviderId): SessionRecord | undefined {
+  /**
+   * @param gitWorktreeOverride Set when creating from "New Session" (etc.) so `session-added` sees
+   * the final worktree before the PTY is created. `path: null` clears inherited path (Auto mode).
+   */
+  addSession(
+    projectId: string,
+    name: string,
+    args?: string,
+    providerId?: ProviderId,
+    gitWorktreeOverride?: { path: string | null; userPinned: boolean },
+  ): SessionRecord | undefined {
     const project = this.state.projects.find((p) => p.id === projectId);
     if (!project) return undefined;
 
+    const activeSession = project.sessions.find((s) => s.id === project.activeSessionId);
     const effectiveArgs = args ?? project.defaultArgs;
     const session: SessionRecord = {
       id: crypto.randomUUID(),
@@ -327,6 +347,25 @@ class AppState {
       cliSessionId: null,
       createdAt: new Date().toISOString(),
     };
+    if (gitWorktreeOverride !== undefined) {
+      const p = gitWorktreeOverride.path?.trim() ?? '';
+      if (p) {
+        session.gitWorktreePath = p;
+        if (gitWorktreeOverride.userPinned) {
+          session.gitWorktreeUserPinned = true;
+        } else {
+          delete session.gitWorktreeUserPinned;
+        }
+      } else {
+        delete session.gitWorktreePath;
+        delete session.gitWorktreeUserPinned;
+      }
+    } else if (activeSession && !activeSession.type && activeSession.gitWorktreePath) {
+      session.gitWorktreePath = activeSession.gitWorktreePath;
+      if (activeSession.gitWorktreeUserPinned) {
+        session.gitWorktreeUserPinned = true;
+      }
+    }
     project.sessions.push(session);
     project.activeSessionId = session.id;
     this.pushNav(session.id);
@@ -523,6 +562,7 @@ class AppState {
 
   private archiveSession(project: ProjectRecord, session: SessionRecord): void {
     const costInfo = getCost(session.id);
+    const wt = session.gitWorktreePath?.trim();
     const archived: ArchivedSession = {
       id: crypto.randomUUID(),
       name: session.name,
@@ -530,6 +570,7 @@ class AppState {
       cliSessionId: session.cliSessionId,
       createdAt: session.createdAt,
       closedAt: new Date().toISOString(),
+      ...(wt ? { gitWorktreePath: wt, ...(session.gitWorktreeUserPinned ? { gitWorktreeUserPinned: true as const } : {}) } : {}),
       cost: costInfo ? {
         totalCostUsd: costInfo.totalCostUsd,
         totalInputTokens: costInfo.totalInputTokens,
@@ -549,6 +590,15 @@ class AppState {
       if (archived.cost) project.sessionHistory[existingIndex].cost = archived.cost;
       if (archived.name !== project.sessionHistory[existingIndex].name) {
         project.sessionHistory[existingIndex].name = archived.name;
+      }
+      const entry = project.sessionHistory[existingIndex];
+      if (archived.gitWorktreePath) {
+        entry.gitWorktreePath = archived.gitWorktreePath;
+        if (archived.gitWorktreeUserPinned) entry.gitWorktreeUserPinned = true;
+        else delete entry.gitWorktreeUserPinned;
+      } else {
+        delete entry.gitWorktreePath;
+        delete entry.gitWorktreeUserPinned;
       }
     } else {
       project.sessionHistory.push(archived);
@@ -615,12 +665,16 @@ class AppState {
       return existing;
     }
 
+    const resumedWt = archived.gitWorktreePath?.trim();
     const session: SessionRecord = {
       id: crypto.randomUUID(),
       name: archived.name,
       providerId: archived.providerId,
       cliSessionId: archived.cliSessionId,
       createdAt: new Date().toISOString(),
+      ...(resumedWt
+        ? { gitWorktreePath: resumedWt, ...(archived.gitWorktreeUserPinned ? { gitWorktreeUserPinned: true as const } : {}) }
+        : {}),
     };
     project.sessions.push(session);
     project.activeSessionId = session.id;
@@ -773,6 +827,75 @@ class AppState {
     if (!session || session.browserTabUrl === url) return;
     session.browserTabUrl = url;
     this.persist();
+  }
+
+  /**
+   * Set which git worktree this terminal tab uses. null clears path and user pin (PTY sync).
+   * Pass `{ userPinned: true }` when the user chose a worktree from the menu.
+   */
+  setSessionGitWorktree(
+    projectId: string,
+    sessionId: string,
+    worktreePath: string | null,
+    opts?: { userPinned?: boolean },
+  ): void {
+    const project = this.state.projects.find((p) => p.id === projectId);
+    const session = project?.sessions.find((s) => s.id === sessionId);
+    if (!project || !session) return;
+    if (worktreePath === null || worktreePath === '') {
+      delete session.gitWorktreePath;
+      delete session.gitWorktreeUserPinned;
+    } else {
+      session.gitWorktreePath = worktreePath;
+      if (opts?.userPinned) {
+        session.gitWorktreeUserPinned = true;
+      } else {
+        delete session.gitWorktreeUserPinned;
+      }
+    }
+    this.persist();
+    this.emit('session-changed');
+  }
+
+  /**
+   * Update git worktree from PTY cwd detection. Does not emit `session-changed` (caller refreshes git UI).
+   */
+  syncSessionGitWorktreeFromDetect(projectId: string, sessionId: string, worktreePath: string | null): void {
+    const project = this.state.projects.find((p) => p.id === projectId);
+    const session = project?.sessions.find((s) => s.id === sessionId);
+    if (!project || !session || session.gitWorktreeUserPinned) return;
+    const norm = (p: string | undefined) => (p ?? '').replace(/\\/g, '/').replace(/\/+$/, '');
+    const next = worktreePath && worktreePath !== '' ? worktreePath : undefined;
+    const cur = session.gitWorktreePath;
+    if (norm(cur) === norm(next) || (!cur && !next)) return;
+    if (next) {
+      session.gitWorktreePath = next;
+    } else {
+      delete session.gitWorktreePath;
+    }
+    this.persist();
+  }
+
+  /** Drop git worktree pins that no longer exist (e.g. after `git worktree remove`). */
+  pruneStaleSessionGitWorktrees(projectId: string, validPaths: Set<string>): void {
+    const project = this.state.projects.find((p) => p.id === projectId);
+    if (!project) return;
+    const norm = (p: string) => p.replace(/\\/g, '/').replace(/\/+$/, '');
+    const normalizedValid = new Set([...validPaths].map(norm));
+    let changed = false;
+    for (const s of project.sessions) {
+      if (!s.gitWorktreePath) continue;
+      const n = norm(s.gitWorktreePath);
+      if (![...normalizedValid].some((v) => v === n)) {
+        delete s.gitWorktreePath;
+        delete s.gitWorktreeUserPinned;
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.persist();
+      this.emit('session-changed');
+    }
   }
 
   renameSession(projectId: string, sessionId: string, name: string, userRenamed?: boolean): void {

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -44,6 +44,11 @@ const defaultPreferences: Preferences = {
   sidebarViews: { configSections: true, gitPanel: true, sessionHistory: true, costFooter: true, readinessSection: true },
   uiZoom: 1,
   terminalFontSize: 14,
+  terminalBackgroundMode: 'none',
+  terminalBackgroundPresetId: 'metro',
+  terminalBackgroundImagePath: null,
+  terminalBackgroundDim: 0.28,
+  terminalBackgroundSurfaceAlpha: 0.88,
 };
 
 const NAV_HISTORY_MAX = 50;
@@ -326,6 +331,8 @@ class AppState {
   /**
    * @param gitWorktreeOverride Set when creating from "New Session" (etc.) so `session-added` sees
    * the final worktree before the PTY is created. `path: null` clears inherited path (Auto mode).
+   * @param opts Pass `userChoseDisplayName` when the name came from explicit user input (e.g. New Custom Session)
+   * so auto-title from CLI output does not replace it.
    */
   addSession(
     projectId: string,
@@ -333,6 +340,7 @@ class AppState {
     args?: string,
     providerId?: ProviderId,
     gitWorktreeOverride?: { path: string | null; userPinned: boolean },
+    opts?: { userChoseDisplayName?: boolean },
   ): SessionRecord | undefined {
     const project = this.state.projects.find((p) => p.id === projectId);
     if (!project) return undefined;
@@ -346,6 +354,7 @@ class AppState {
       ...(effectiveArgs ? { args: effectiveArgs } : {}),
       cliSessionId: null,
       createdAt: new Date().toISOString(),
+      ...(opts?.userChoseDisplayName ? { userRenamed: true as const } : {}),
     };
     if (gitWorktreeOverride !== undefined) {
       const p = gitWorktreeOverride.path?.trim() ?? '';
@@ -672,6 +681,7 @@ class AppState {
       providerId: archived.providerId,
       cliSessionId: archived.cliSessionId,
       createdAt: new Date().toISOString(),
+      userRenamed: true,
       ...(resumedWt
         ? { gitWorktreePath: resumedWt, ...(archived.gitWorktreeUserPinned ? { gitWorktreeUserPinned: true as const } : {}) }
         : {}),
@@ -737,6 +747,7 @@ class AppState {
       providerId: targetProviderId,
       cliSessionId: null,
       createdAt: new Date().toISOString(),
+      userRenamed: true,
       pendingInitialPrompt: initialPrompt,
     };
     project.sessions.push(session);
@@ -767,6 +778,22 @@ class AppState {
     if (!project) return;
     project.activeSessionId = sessionId;
     this.pushNav(sessionId);
+    this.persist();
+    this.emit('session-changed');
+  }
+
+  /**
+   * Clear the persisted CLI resume id so the next spawn starts a new CLI conversation.
+   * Used when the provider reports the saved session no longer exists (e.g. Claude
+   * "No conversation found with session ID").
+   */
+  clearSessionCliResumeId(projectId: string, sessionId: string): void {
+    const project = this.state.projects.find((p) => p.id === projectId);
+    if (!project) return;
+    const session = project.sessions.find((s) => s.id === sessionId);
+    if (!session || session.type) return;
+    if (!session.cliSessionId) return;
+    session.cliSessionId = null;
     this.persist();
     this.emit('session-changed');
   }

--- a/src/renderer/styles/base.css
+++ b/src/renderer/styles/base.css
@@ -32,6 +32,40 @@ html, body {
   background: var(--bg-primary);
 }
 
+/* Global scrollbars — thin, dark, no OS arrow buttons (Electron / Chromium + Firefox) */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+*::-webkit-scrollbar-button {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
 #app {
   display: flex;
   width: 100%;

--- a/src/renderer/styles/base.css
+++ b/src/renderer/styles/base.css
@@ -34,6 +34,8 @@ html, body {
 
 #app {
   display: flex;
+  width: 100%;
+  min-width: 0;
   height: 100vh;
 }
 

--- a/src/renderer/styles/git-panel.css
+++ b/src/renderer/styles/git-panel.css
@@ -12,10 +12,15 @@
 }
 
 .git-worktree-selector {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   padding: 4px 12px 4px;
 }
 
 .git-worktree-select {
+  flex: 1;
+  min-width: 0;
   width: 100%;
   padding: 3px 6px;
   font-size: 11px;

--- a/src/renderer/styles/preferences.css
+++ b/src/renderer/styles/preferences.css
@@ -21,6 +21,30 @@
   flex-shrink: 0;
 }
 
+.pref-slider-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 0;
+}
+
+.pref-slider-field label {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.pref-slider-field input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+.pref-image-path {
+  font-size: 11px;
+  color: var(--text-muted);
+  word-break: break-all;
+  margin-top: 4px;
+}
+
 /* Preferences layout */
 #modal.modal-wide {
   width: 750px;
@@ -62,6 +86,14 @@
   padding: 4px 16px;
   min-width: 0;
   overflow-y: auto;
+}
+
+.preferences-wsl-intro {
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-muted);
+  margin: 0 0 10px 0;
+  max-width: 52ch;
 }
 
 .about-section {

--- a/src/renderer/styles/tabs.css
+++ b/src/renderer/styles/tabs.css
@@ -4,6 +4,80 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
+  position: relative;
+}
+
+/*
+ * Backdrop layers live on #main-area so they cannot be lost if DOM is reordered
+ * (e.g. update banner prepend) or an older HTML template omitted the inner div.
+ */
+#main-area.main-area-has-backdrop::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image: var(--vy-terminal-backdrop-image, none);
+  background-color: var(--vy-terminal-backdrop-color, transparent);
+  background-size: var(--vy-terminal-backdrop-size, auto);
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+#main-area.main-area-has-backdrop::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background: rgba(0, 0, 0, var(--vy-terminal-backdrop-dim, 0));
+}
+
+/*
+ * Custom images use a real <img> + blob: URL — huge data: strings in CSS variables
+ * often fail silently; <img src="blob:…"> is reliable and covered by img-src.
+ */
+#main-area.main-area-has-backdrop #main-area-backdrop-photo {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+}
+
+#main-area.main-area-has-backdrop.main-area-has-custom-photo #main-area-backdrop-photo {
+  opacity: 1;
+  visibility: visible;
+}
+
+#main-area.main-area-has-backdrop.main-area-has-custom-photo::before {
+  background-image: none;
+  background-color: transparent;
+}
+
+#main-area.main-area-has-backdrop #tab-bar {
+  background: rgba(10, 10, 10, 0.72);
+}
+
+#main-area.main-area-has-backdrop #project-terminal-panel {
+  background: rgba(0, 0, 0, 0.55);
+}
+
+#main-area.main-area-has-backdrop #project-terminal-header {
+  background: rgba(15, 15, 15, 0.82);
+}
+
+#tab-bar,
+#terminal-container,
+#project-terminal-resize-handle,
+#project-terminal-panel {
+  position: relative;
+  z-index: 1;
 }
 
 /* Tab bar */

--- a/src/renderer/styles/tabs.css
+++ b/src/renderer/styles/tabs.css
@@ -20,6 +20,7 @@
 #tab-list {
   display: flex;
   flex: 1;
+  min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
   height: 100%;
@@ -189,6 +190,7 @@
   align-items: center;
   gap: 2px;
   padding: 0 8px;
+  flex-shrink: 0;
 }
 
 .icon-btn {
@@ -248,6 +250,41 @@
   height: 1px;
   background: var(--border);
   margin: 4px 0;
+}
+
+.tab-context-menu-header {
+  padding: 6px 14px 4px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+/* Linked git worktree only (not main checkout): muted hint; full path in tooltip */
+.tab-worktree-pill {
+  display: inline-block;
+  margin-left: 5px;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+  font-size: 9px;
+  font-weight: 500;
+  line-height: 1.35;
+  padding: 0 5px;
+  border-radius: 4px;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--text-muted) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  opacity: 0.92;
+}
+
+.tab-item.active .tab-worktree-pill {
+  opacity: 1;
+  color: color-mix(in srgb, var(--text-primary) 72%, var(--text-muted));
+  background: color-mix(in srgb, var(--text-muted) 12%, transparent);
 }
 
 /* Branch search input */

--- a/src/renderer/styles/terminal.css
+++ b/src/renderer/styles/terminal.css
@@ -255,3 +255,12 @@
   height: 100%;
   padding: 4px;
 }
+
+/*
+ * xterm ships `.xterm-viewport { background-color: #000 }` for scrollbar contrast. That layer sits
+ * behind `.xterm-screen` / the canvas; with allowTransparency, cleared pixels show the viewport
+ * color — so opaque black hid the main-area backdrop. Transparent viewport lets the wallpaper show.
+ */
+#main-area.main-area-has-backdrop .xterm .xterm-viewport {
+  background-color: transparent !important;
+}

--- a/src/renderer/terminal-backdrop.ts
+++ b/src/renderer/terminal-backdrop.ts
@@ -1,0 +1,119 @@
+import type { Preferences } from '../shared/types.js';
+import {
+  backdropIsActive,
+  effectiveTerminalBackgroundMode,
+  getPresetGradientCss,
+  getTerminalBackgroundDim,
+  normalizePresetId,
+} from './terminal-background-helpers.js';
+import { refreshTerminalSurfacesFromPreferences } from './refresh-terminal-surfaces.js';
+
+const BACKDROP_PHOTO_ID = 'main-area-backdrop-photo';
+
+/** Blob URL for custom photo; revoked when backdrop changes. */
+let backdropPhotoObjectUrl: string | null = null;
+
+function revokeBackdropPhotoObjectUrl(): void {
+  if (backdropPhotoObjectUrl) {
+    URL.revokeObjectURL(backdropPhotoObjectUrl);
+    backdropPhotoObjectUrl = null;
+  }
+}
+
+function clearBackdropCssVars(main: HTMLElement): void {
+  main.style.removeProperty('--vy-terminal-backdrop-image');
+  main.style.removeProperty('--vy-terminal-backdrop-color');
+  main.style.removeProperty('--vy-terminal-backdrop-size');
+  main.style.removeProperty('--vy-terminal-backdrop-dim');
+}
+
+function clearCustomBackdropPhoto(main: HTMLElement): void {
+  revokeBackdropPhotoObjectUrl();
+  main.classList.remove('main-area-has-custom-photo');
+  const img = document.getElementById(BACKDROP_PHOTO_ID) as HTMLImageElement | null;
+  if (img) img.removeAttribute('src');
+}
+
+function ensureBackdropPhotoImg(main: HTMLElement): HTMLImageElement {
+  let img = document.getElementById(BACKDROP_PHOTO_ID) as HTMLImageElement | null;
+  if (!img) {
+    img = document.createElement('img');
+    img.id = BACKDROP_PHOTO_ID;
+    img.alt = '';
+    img.setAttribute('aria-hidden', 'true');
+    img.decoding = 'async';
+    main.prepend(img);
+  }
+  return img;
+}
+
+function toArrayBuffer(data: ArrayBuffer | ArrayBufferView): ArrayBuffer {
+  if (data instanceof ArrayBuffer) return data;
+  const view = data as ArrayBufferView;
+  return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength);
+}
+
+/**
+ * Applies backdrop visuals and syncs xterm surface colors from preferences.
+ * Safe to call repeatedly (e.g. on `preferences-changed`).
+ */
+export async function refreshTerminalBackdropFromPreferences(prefs: Preferences): Promise<void> {
+  const main = document.getElementById('main-area');
+  if (!main) return;
+
+  const active = backdropIsActive(prefs);
+  main.classList.toggle('main-area-has-backdrop', active);
+  refreshTerminalSurfacesFromPreferences(prefs);
+
+  if (!active) {
+    clearCustomBackdropPhoto(main);
+    clearBackdropCssVars(main);
+    return;
+  }
+
+  const dim = getTerminalBackgroundDim(prefs);
+  main.style.setProperty('--vy-terminal-backdrop-dim', String(dim));
+
+  const mode = effectiveTerminalBackgroundMode(prefs);
+  if (mode === 'preset') {
+    clearCustomBackdropPhoto(main);
+    const grad = getPresetGradientCss(normalizePresetId(prefs.terminalBackgroundPresetId));
+    main.style.setProperty('--vy-terminal-backdrop-image', grad);
+    main.style.setProperty('--vy-terminal-backdrop-color', 'transparent');
+    main.style.removeProperty('--vy-terminal-backdrop-size');
+    return;
+  }
+
+  const path = prefs.terminalBackgroundImagePath;
+  if (typeof path !== 'string' || path.length === 0) {
+    return;
+  }
+
+  let payload: { mime: string; data: ArrayBuffer } | null = null;
+  try {
+    const raw = await window.vibeyard.app.readBackgroundImage(path);
+    if (raw?.mime && raw.data) {
+      payload = { mime: raw.mime, data: toArrayBuffer(raw.data as ArrayBuffer | ArrayBufferView) };
+    }
+  } catch {
+    payload = null;
+  }
+
+  if (!payload) {
+    clearCustomBackdropPhoto(main);
+    main.style.setProperty('--vy-terminal-backdrop-image', 'none');
+    main.style.setProperty('--vy-terminal-backdrop-color', 'var(--bg-primary)');
+    main.style.removeProperty('--vy-terminal-backdrop-size');
+    return;
+  }
+
+  clearCustomBackdropPhoto(main);
+  const blob = new Blob([payload.data], { type: payload.mime });
+  backdropPhotoObjectUrl = URL.createObjectURL(blob);
+  const img = ensureBackdropPhotoImg(main);
+  img.src = backdropPhotoObjectUrl;
+  main.classList.add('main-area-has-custom-photo');
+  main.style.setProperty('--vy-terminal-backdrop-image', 'none');
+  main.style.setProperty('--vy-terminal-backdrop-color', 'transparent');
+  main.style.setProperty('--vy-terminal-backdrop-size', 'cover');
+}

--- a/src/renderer/terminal-background-helpers.test.ts
+++ b/src/renderer/terminal-background-helpers.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { Preferences, TerminalBackgroundMode } from '../shared/types.js';
+import {
+  backdropIsActive,
+  effectiveTerminalBackgroundMode,
+  getPresetGradientCss,
+  getTerminalSurfaceBackgroundColor,
+  normalizePresetId,
+} from './terminal-background-helpers.js';
+
+function prefs(p: Partial<Preferences>): Preferences {
+  return {
+    soundOnSessionWaiting: true,
+    notificationsDesktop: true,
+    debugMode: false,
+    sessionHistoryEnabled: true,
+    insightsEnabled: true,
+    autoTitleEnabled: true,
+    ...p,
+  } as Preferences;
+}
+
+describe('terminal-background-helpers', () => {
+  it('getTerminalSurfaceBackgroundColor is opaque when backdrop inactive', () => {
+    expect(getTerminalSurfaceBackgroundColor(prefs({ terminalBackgroundMode: 'none' }))).toBe('#000000');
+    expect(getTerminalSurfaceBackgroundColor(undefined)).toBe('#000000');
+  });
+
+  it('getTerminalSurfaceBackgroundColor uses alpha when preset active', () => {
+    const c = getTerminalSurfaceBackgroundColor(
+      prefs({ terminalBackgroundMode: 'preset', terminalBackgroundSurfaceAlpha: 0.5 }),
+    );
+    expect(c).toBe('rgba(0,0,0,0.5)');
+  });
+
+  it('backdropIsActive for custom requires path', () => {
+    expect(backdropIsActive(prefs({ terminalBackgroundMode: 'custom', terminalBackgroundImagePath: '/a.png' }))).toBe(true);
+    expect(backdropIsActive(prefs({ terminalBackgroundMode: 'custom', terminalBackgroundImagePath: null }))).toBe(false);
+  });
+
+  it('effectiveTerminalBackgroundMode normalizes casing', () => {
+    expect(
+      effectiveTerminalBackgroundMode(prefs({ terminalBackgroundMode: 'PRESET' as unknown as TerminalBackgroundMode })),
+    ).toBe('preset');
+    expect(
+      effectiveTerminalBackgroundMode(prefs({ terminalBackgroundMode: '  Custom ' as unknown as TerminalBackgroundMode })),
+    ).toBe('custom');
+  });
+
+  it('normalizePresetId falls back for unknown id', () => {
+    expect(normalizePresetId('nope')).toBe('metro');
+  });
+
+  it('getPresetGradientCss returns a gradient string', () => {
+    const g = getPresetGradientCss('metro');
+    expect(g).toContain('linear-gradient');
+  });
+});

--- a/src/renderer/terminal-background-helpers.ts
+++ b/src/renderer/terminal-background-helpers.ts
@@ -1,0 +1,110 @@
+import type { Preferences, TerminalBackgroundMode } from '../shared/types.js';
+
+export const DEFAULT_TERMINAL_BG_PRESET_ID = 'metro';
+
+export const TERMINAL_BG_PRESETS: readonly { id: string; label: string; gradient: string }[] = [
+  {
+    id: 'metro',
+    label: 'City night',
+    gradient: 'linear-gradient(165deg, #183060 0%, #402040 38%, #1a4080 100%)',
+  },
+  {
+    id: 'aurora',
+    label: 'Aurora',
+    gradient: 'linear-gradient(140deg, #201050 0%, #5838a0 45%, #186060 100%)',
+  },
+  {
+    id: 'ember',
+    label: 'Ember',
+    gradient: 'linear-gradient(180deg, #301010 0%, #602828 50%, #1c0808 100%)',
+  },
+  {
+    id: 'depths',
+    label: 'Depths',
+    gradient: 'linear-gradient(160deg, #0c2048 0%, #2050a0 55%, #103850 100%)',
+  },
+  {
+    id: 'synthwave',
+    label: 'Synthwave',
+    gradient: 'linear-gradient(125deg, #1a0830 0%, #701858 42%, #083a58 100%)',
+  },
+  {
+    id: 'lagoon',
+    label: 'Lagoon',
+    gradient: 'linear-gradient(160deg, #042830 0%, #0d6e6e 48%, #043a50 100%)',
+  },
+  {
+    id: 'horizon',
+    label: 'Horizon',
+    gradient: 'linear-gradient(185deg, #102050 0%, #c84820 45%, #284878 100%)',
+  },
+  {
+    id: 'twilight',
+    label: 'Twilight',
+    gradient: 'linear-gradient(150deg, #281040 0%, #502090 50%, #102040 100%)',
+  },
+  {
+    id: 'magma',
+    label: 'Magma',
+    gradient: 'linear-gradient(170deg, #200808 0%, #a02010 40%, #401808 100%)',
+  },
+  {
+    id: 'noir',
+    label: 'Noir steel',
+    gradient: 'linear-gradient(165deg, #101418 0%, #303848 50%, #0a1018 100%)',
+  },
+] as const;
+
+export function clampUnit(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.min(1, Math.max(0, n));
+}
+
+export function effectiveTerminalBackgroundMode(prefs: Preferences | undefined): TerminalBackgroundMode {
+  if (!prefs) return 'none';
+  const raw = prefs.terminalBackgroundMode;
+  const m = typeof raw === 'string' ? raw.trim().toLowerCase() : raw;
+  if (m === 'preset' || m === 'custom') return m;
+  return 'none';
+}
+
+export function getTerminalBackgroundDim(prefs: Preferences | undefined): number {
+  return clampUnit(prefs?.terminalBackgroundDim ?? 0.28);
+}
+
+export function getTerminalBackgroundSurfaceAlpha(prefs: Preferences | undefined): number {
+  return clampUnit(prefs?.terminalBackgroundSurfaceAlpha ?? 0.88);
+}
+
+export function getPresetGradientCss(presetId: string | undefined): string {
+  const id = presetId && presetId.length > 0 ? presetId : DEFAULT_TERMINAL_BG_PRESET_ID;
+  const hit = TERMINAL_BG_PRESETS.find((p) => p.id === id);
+  return (hit ?? TERMINAL_BG_PRESETS[0]).gradient;
+}
+
+export function normalizePresetId(presetId: string | undefined): string {
+  const id = presetId && presetId.length > 0 ? presetId : DEFAULT_TERMINAL_BG_PRESET_ID;
+  return TERMINAL_BG_PRESETS.some((p) => p.id === id) ? id : DEFAULT_TERMINAL_BG_PRESET_ID;
+}
+
+/**
+ * xterm `theme.background` color: opaque black when backdrop off; translucent black when on.
+ */
+export function getTerminalSurfaceBackgroundColor(prefs: Preferences | undefined): string {
+  if (!backdropIsActive(prefs)) {
+    return '#000000';
+  }
+  const a = getTerminalBackgroundSurfaceAlpha(prefs);
+  return `rgba(0,0,0,${a})`;
+}
+
+export function backdropIsActive(prefs: Preferences | undefined): boolean {
+  if (!prefs) return false;
+  const mode = effectiveTerminalBackgroundMode(prefs);
+  if (mode === 'preset') return true;
+  if (mode === 'custom') {
+    const p = prefs.terminalBackgroundImagePath;
+    return typeof p === 'string' && p.length > 0;
+  }
+  return false;
+}

--- a/src/renderer/terminal-font-size.test.ts
+++ b/src/renderer/terminal-font-size.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockPrefs: { terminalFontSize?: number } = {};
+
+vi.mock('./state.js', () => ({
+  appState: {
+    get preferences() {
+      return { terminalFontSize: mockPrefs.terminalFontSize };
+    },
+  },
+}));
+
+describe('getEffectiveTerminalFontSize', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    mockPrefs.terminalFontSize = undefined;
+  });
+
+  it('returns default when unset', async () => {
+    const { getEffectiveTerminalFontSize, DEFAULT_TERMINAL_FONT_SIZE } = await import('./terminal-font-size.js');
+    expect(getEffectiveTerminalFontSize()).toBe(DEFAULT_TERMINAL_FONT_SIZE);
+  });
+
+  it('clamps to 10–32', async () => {
+    const { getEffectiveTerminalFontSize } = await import('./terminal-font-size.js');
+    mockPrefs.terminalFontSize = 4;
+    expect(getEffectiveTerminalFontSize()).toBe(10);
+    mockPrefs.terminalFontSize = 99;
+    expect(getEffectiveTerminalFontSize()).toBe(32);
+    mockPrefs.terminalFontSize = 17.5;
+    expect(getEffectiveTerminalFontSize()).toBe(18);
+  });
+});

--- a/src/renderer/terminal-font-size.ts
+++ b/src/renderer/terminal-font-size.ts
@@ -1,0 +1,33 @@
+import type { Terminal } from '@xterm/xterm';
+import { appState } from './state.js';
+
+export const DEFAULT_TERMINAL_FONT_SIZE = 14;
+
+/** Min/max terminal font (px) — keyboard nudges by 1 within this range. */
+export const TERMINAL_FONT_MIN = 10;
+export const TERMINAL_FONT_MAX = 32;
+
+/** Every integer px for Preferences (matches shortcut steps). */
+export const TERMINAL_FONT_SIZE_OPTIONS: readonly number[] = Array.from(
+  { length: TERMINAL_FONT_MAX - TERMINAL_FONT_MIN + 1 },
+  (_, i) => TERMINAL_FONT_MIN + i,
+);
+
+export function getEffectiveTerminalFontSize(): number {
+  const n = appState.preferences?.terminalFontSize;
+  if (typeof n !== 'number' || !Number.isFinite(n)) return DEFAULT_TERMINAL_FONT_SIZE;
+  return Math.min(TERMINAL_FONT_MAX, Math.max(TERMINAL_FONT_MIN, Math.round(n)));
+}
+
+/** Apply font size and force a full redraw (WebGL/canvas can ignore a bare `options.fontSize` write). */
+export function applyXtermFontSize(terminal: Terminal, fontSize: number): void {
+  terminal.options.fontSize = fontSize;
+  const end = Math.max(0, terminal.rows - 1);
+  terminal.refresh(0, end);
+}
+
+export function stepTerminalFontSize(direction: 1 | -1): void {
+  const cur = getEffectiveTerminalFontSize();
+  const next = Math.min(TERMINAL_FONT_MAX, Math.max(TERMINAL_FONT_MIN, cur + direction));
+  appState.setPreference('terminalFontSize', next);
+}

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -83,6 +83,12 @@ export interface VibeyardApi {
   stats: {
     getCache(): Promise<StatsCache | null>;
   };
+  wsl: {
+    isAvailable(): Promise<boolean>;
+    getDistros(): Promise<string[]>;
+    getDefaultDistro(): Promise<string | null>;
+    browseDirs(dirPath: string, prefix?: string): Promise<string[]>;
+  };
   menu: {
     onNewProject(callback: () => void): () => void;
     onNewSession(callback: () => void): () => void;

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -50,6 +50,7 @@ export interface VibeyardApi {
     getFiles(path: string): Promise<unknown>;
     getDiff(path: string, file: string, area: string): Promise<string>;
     getWorktrees(path: string): Promise<GitWorktree[]>;
+    createWorktree(path: string, worktreePath: string, newBranch?: string): Promise<void>;
     watchProject(path: string): void;
     onChanged(callback: () => void): () => void;
   };
@@ -65,6 +66,7 @@ export interface VibeyardApi {
     focus(): void;
     getVersion(): Promise<string>;
     openExternal(url: string): Promise<void>;
+    setZoomFactor(factor: number): Promise<void>;
     onQuitting(callback: () => void): () => void;
   };
   mcp: {

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -66,7 +66,10 @@ export interface VibeyardApi {
     focus(): void;
     getVersion(): Promise<string>;
     openExternal(url: string): Promise<void>;
+    getBrowserPreloadPath(): Promise<string>;
     setZoomFactor(factor: number): Promise<void>;
+    browseImageFile(): Promise<string | null>;
+    readBackgroundImage(filePath: string): Promise<{ mime: string; data: ArrayBuffer } | null>;
     onQuitting(callback: () => void): () => void;
   };
   mcp: {

--- a/src/renderer/worktree-actions.ts
+++ b/src/renderer/worktree-actions.ts
@@ -1,0 +1,48 @@
+import { appState } from './state.js';
+import { refreshGitStatus } from './git-status.js';
+import { showModal, closeModal, setModalError } from './components/modal.js';
+
+export function applyWorktreeSelection(projectId: string, path: string | null): void {
+  const project = appState.projects.find((p) => p.id === projectId);
+  if (!project?.activeSessionId) return;
+  const pin = path != null && path !== '';
+  appState.setSessionGitWorktree(projectId, project.activeSessionId, path, { userPinned: pin });
+  void refreshGitStatus();
+}
+
+export function promptCreateWorktree(project: { id: string; path: string }): void {
+  showModal(
+    'Create New Worktree',
+    [
+      {
+        label: 'Worktree path',
+        id: 'wt-path',
+        placeholder: 'Folder name (next to repo) or absolute path',
+      },
+      {
+        label: 'New branch (optional)',
+        id: 'wt-branch',
+        placeholder: 'Leave empty to checkout detached at HEAD',
+      },
+    ],
+    async (values) => {
+      const wtPath = values['wt-path']?.trim() ?? '';
+      if (!wtPath) {
+        setModalError('wt-path', 'Worktree path is required');
+        return;
+      }
+      const branch = values['wt-branch']?.trim();
+      if (branch && /\s/.test(branch)) {
+        setModalError('wt-branch', 'Branch name cannot contain spaces');
+        return;
+      }
+      try {
+        await window.vibeyard.git.createWorktree(project.path, wtPath, branch || undefined);
+        closeModal();
+        await refreshGitStatus();
+      } catch (err) {
+        setModalError('wt-path', err instanceof Error ? err.message : 'Failed to create worktree');
+      }
+    },
+  );
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -161,6 +161,10 @@ export interface Preferences {
     costFooter: boolean;
     readinessSection: boolean;
   };
+  /** When true on Windows, spawn CLI tools inside WSL2 instead of natively. */
+  wslEnabled?: boolean;
+  /** WSL distro to use. When unset, the system default distro is used. */
+  wslDistro?: string;
 }
 
 // --- Settings Validation ---

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -81,7 +81,15 @@ export interface SessionRecord {
   mcpServerUrl?: string;
   diffFilePath?: string;
   diffArea?: string;
+  /** Diff viewer only: repo root used for that diff tab. */
   worktreePath?: string;
+  /**
+   * Terminal tabs: git status / branch menu / sidebar root. When `gitWorktreeUserPinned`
+   * is set, this path was chosen explicitly; otherwise it may be synced from PTY cwd.
+   */
+  gitWorktreePath?: string;
+  /** True when the user pinned a worktree from the menu (not PTY sync). */
+  gitWorktreeUserPinned?: boolean;
   fileReaderPath?: string;
   fileReaderLine?: number;
   createdAt: string;
@@ -102,6 +110,9 @@ export interface ArchivedSession {
   cliSessionId: string | null;
   createdAt: string;
   closedAt: string;
+  /** Git worktree cwd used for this CLI session (so resume spawns in the same checkout). */
+  gitWorktreePath?: string;
+  gitWorktreeUserPinned?: boolean;
   bookmarked?: boolean;
   cost: {
     totalCostUsd: number;
@@ -165,6 +176,12 @@ export interface Preferences {
   wslEnabled?: boolean;
   /** WSL distro to use. When unset, the system default distro is used. */
   wslDistro?: string;
+  /**
+   * Whole-app UI scale (Chromium `zoom` on `#app`). 1 = 100%. Helps on high-DPI tablets.
+   */
+  uiZoom?: number;
+  /** xterm.js font size in CSS pixels. Default 14. */
+  terminalFontSize?: number;
 }
 
 // --- Settings Validation ---

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -154,6 +154,8 @@ export interface ProjectRecord {
   readiness?: ReadinessResult;
 }
 
+export type TerminalBackgroundMode = 'none' | 'preset' | 'custom';
+
 export interface Preferences {
   soundOnSessionWaiting: boolean;
   notificationsDesktop: boolean;
@@ -172,7 +174,10 @@ export interface Preferences {
     costFooter: boolean;
     readinessSection: boolean;
   };
-  /** When true on Windows, spawn CLI tools inside WSL2 instead of natively. */
+  /**
+   * When true on Windows (and WSL is installed), spawn CLI tools inside WSL2 and resolve
+   * Linux-style paths. Leave false for native Windows or when syncing preferences to macOS/Linux.
+   */
   wslEnabled?: boolean;
   /** WSL distro to use. When unset, the system default distro is used. */
   wslDistro?: string;
@@ -182,6 +187,21 @@ export interface Preferences {
   uiZoom?: number;
   /** xterm.js font size in CSS pixels. Default 14. */
   terminalFontSize?: number;
+  /** Backdrop behind the main column (tab bar + terminals + project shell). */
+  terminalBackgroundMode?: TerminalBackgroundMode;
+  /** Built-in gradient id when `terminalBackgroundMode` is `preset`. */
+  terminalBackgroundPresetId?: string;
+  /** Absolute filesystem path when `terminalBackgroundMode` is `custom`. */
+  terminalBackgroundImagePath?: string | null;
+  /**
+   * Extra darkening on top of the image or preset (0 = none, 1 = heavy).
+   * Defaults in renderer state when missing.
+   */
+  terminalBackgroundDim?: number;
+  /**
+   * Opacity of the xterm cell background black layer (0–1). Higher = more readable, less wallpaper bleed-through.
+   */
+  terminalBackgroundSurfaceAlpha?: number;
 }
 
 // --- Settings Validation ---


### PR DESCRIPTION
## Summary
- Terminal backdrop support: built-in gradient presets, optional custom image, dim and surface opacity, and an **Appearance** section in Preferences.
- WSL2 integration stays opt-in: backdrop path logic only probes `\\wsl$\...` when WSL2 execution mode is enabled; the WSL preferences block is built only on Windows so macOS installs are unaffected.
- Main-process helpers for reading backdrop images (IPC browse/read), plus tests for background path candidates and related code.

## Testing
- `npm run build` passes locally.
- `npm test`: all suites that load pass here; `pty-manager` / provider registry tests may fail to load on some environments (Electron / node-pty native); CI matrix covers macOS, Ubuntu, and Windows.


Made with [Cursor](https://cursor.com)