### PR TITLE
feat: add setting to dangerously skip permissions

### DIFF
--- a/src/main/store.test.ts
+++ b/src/main/store.test.ts
@@ -24,7 +24,7 @@ const DEFAULT_STATE: PersistedState = {
   version: 1,
   projects: [],
   activeProjectId: null,
-  preferences: { soundOnSessionWaiting: true, notificationsDesktop: true, debugMode: false, sessionHistoryEnabled: true, insightsEnabled: true, autoTitleEnabled: true },
+  preferences: { soundOnSessionWaiting: true, notificationsDesktop: true, debugMode: false, sessionHistoryEnabled: true, insightsEnabled: true, autoTitleEnabled: true, dangerouslySkipPermissions: false },
 };
 
 beforeEach(() => {
@@ -132,7 +132,7 @@ describe('migrateSessionIds', () => {
         layout: { mode: 'tabs', splitPanes: [], splitDirection: 'horizontal' },
       }],
       activeProjectId: 'p1',
-      preferences: { soundOnSessionWaiting: true, notificationsDesktop: true, debugMode: false, sessionHistoryEnabled: true, insightsEnabled: true, autoTitleEnabled: true },
+      preferences: { soundOnSessionWaiting: true, notificationsDesktop: true, debugMode: false, sessionHistoryEnabled: true, insightsEnabled: true, autoTitleEnabled: true, dangerouslySkipPermissions: false },
     };
     return JSON.stringify(state);
   }

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -15,7 +15,7 @@ function defaultState(): PersistedState {
     version: 1,
     projects: [],
     activeProjectId: null,
-    preferences: { soundOnSessionWaiting: true, notificationsDesktop: true, debugMode: false, sessionHistoryEnabled: true, insightsEnabled: true, autoTitleEnabled: true },
+    preferences: { soundOnSessionWaiting: true, notificationsDesktop: true, debugMode: false, sessionHistoryEnabled: true, insightsEnabled: true, autoTitleEnabled: true, dangerouslySkipPermissions: false },
   };
 }
 

--- a/src/renderer/components/preferences-modal.ts
+++ b/src/renderer/components/preferences-modal.ts
@@ -62,6 +62,7 @@ export function showPreferencesModal(): void {
   let historyCheckbox: HTMLInputElement | null = null;
   let insightsCheckbox: HTMLInputElement | null = null;
   let autoTitleCheckbox: HTMLInputElement | null = null;
+  let dangerouslySkipPermissionsCheckbox: HTMLInputElement | null = null;
   let defaultProviderSelect: CustomSelectInstance | null = null;
   let debugModeCheckbox: HTMLInputElement | null = null;
   let sidebarCheckboxes: { configSections: HTMLInputElement; gitPanel: HTMLInputElement; sessionHistory: HTMLInputElement; costFooter: HTMLInputElement; readinessSection: HTMLInputElement } | null = null;
@@ -197,6 +198,27 @@ export function showPreferencesModal(): void {
       autoTitleRow.appendChild(autoTitleLabel);
       autoTitleRow.appendChild(autoTitleCheckbox);
       content.appendChild(autoTitleRow);
+
+      const skipPermRow = document.createElement('div');
+      skipPermRow.className = 'modal-toggle-field';
+
+      const skipPermLabel = document.createElement('label');
+      skipPermLabel.htmlFor = 'pref-dangerously-skip-permissions';
+      skipPermLabel.textContent = 'Dangerously skip permissions (Claude Code)';
+
+      dangerouslySkipPermissionsCheckbox = document.createElement('input');
+      dangerouslySkipPermissionsCheckbox.type = 'checkbox';
+      dangerouslySkipPermissionsCheckbox.id = 'pref-dangerously-skip-permissions';
+      dangerouslySkipPermissionsCheckbox.checked = appState.preferences.dangerouslySkipPermissions;
+
+      skipPermRow.appendChild(skipPermLabel);
+      skipPermRow.appendChild(dangerouslySkipPermissionsCheckbox);
+      content.appendChild(skipPermRow);
+
+      const skipPermHint = document.createElement('div');
+      skipPermHint.className = 'modal-field-hint';
+      skipPermHint.textContent = 'New Claude Code sessions will start with --dangerously-skip-permissions. Use with caution.';
+      content.appendChild(skipPermHint);
 
     } else if (section === 'sidebar') {
       const views = appState.preferences.sidebarViews ?? { configSections: true, gitPanel: true, sessionHistory: true, costFooter: true, readinessSection: true };
@@ -669,6 +691,9 @@ export function showPreferencesModal(): void {
     }
     if (autoTitleCheckbox) {
       appState.setPreference('autoTitleEnabled', autoTitleCheckbox.checked);
+    }
+    if (dangerouslySkipPermissionsCheckbox) {
+      appState.setPreference('dangerouslySkipPermissions', dangerouslySkipPermissionsCheckbox.checked);
     }
     if (defaultProviderSelect) {
       appState.setPreference('defaultProvider', defaultProviderSelect.getValue() as ProviderId);

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -41,6 +41,7 @@ const defaultPreferences: Preferences = {
   sessionHistoryEnabled: true,
   insightsEnabled: true,
   autoTitleEnabled: true,
+  dangerouslySkipPermissions: false,
   readinessExcludedProviders: [],
   sidebarViews: { configSections: true, gitPanel: true, sessionHistory: true, costFooter: true, readinessSection: true },
 };
@@ -328,11 +329,19 @@ class AppState {
     const project = this.state.projects.find((p) => p.id === projectId);
     if (!project) return undefined;
 
-    const effectiveArgs = args ?? project.defaultArgs;
+    let effectiveArgs = args ?? project.defaultArgs;
+    const resolvedProvider = providerId ?? this.state.preferences.defaultProvider ?? 'claude';
+    // Append --dangerously-skip-permissions for Claude when the preference is enabled
+    if (resolvedProvider === 'claude' && this.state.preferences.dangerouslySkipPermissions) {
+      const flag = '--dangerously-skip-permissions';
+      if (!effectiveArgs?.includes(flag)) {
+        effectiveArgs = [effectiveArgs, flag].filter(Boolean).join(' ');
+      }
+    }
     const session: SessionRecord = {
       id: crypto.randomUUID(),
       name,
-      providerId: providerId ?? this.state.preferences.defaultProvider ?? 'claude',
+      providerId: resolvedProvider,
       ...(effectiveArgs ? { args: effectiveArgs } : {}),
       cliSessionId: null,
       createdAt: new Date().toISOString(),

--- a/src/renderer/styles/preferences.css
+++ b/src/renderer/styles/preferences.css
@@ -21,6 +21,13 @@
   flex-shrink: 0;
 }
 
+.modal-field-hint {
+  font-size: 11px;
+  color: var(--text-secondary);
+  padding: 0 0 4px;
+  margin-top: -4px;
+}
+
 /* Preferences layout */
 #modal.modal-wide {
   width: 750px;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -150,6 +150,7 @@ export interface Preferences {
   sessionHistoryEnabled: boolean;
   insightsEnabled: boolean;
   autoTitleEnabled: boolean;
+  dangerouslySkipPermissions: boolean;
   defaultProvider?: ProviderId;
   statusLineConsent?: 'granted' | 'declined' | null;
   keybindings?: Record<string, string>;


### PR DESCRIPTION
## Summary
- Adds a new `dangerouslySkipPermissions` toggle in **Settings > General**
- When enabled, new Claude Code sessions automatically start with `--dangerously-skip-permissions`
- The flag is appended to session args at creation time (both regular and plan sessions)
- Only applies to Claude Code provider sessions — other providers are unaffected

## Changes
- `src/shared/types.ts` — Added `dangerouslySkipPermissions: boolean` to `Preferences` interface
- `src/renderer/state.ts` — Default `false`, inject flag in `addSession()` when enabled
- `src/renderer/components/preferences-modal.ts` — Toggle UI with hint text
- `src/renderer/styles/preferences.css` — Hint text styling
- `src/main/store.ts` + `src/main/store.test.ts` — Default value in main process

## Test plan
- [ ] Toggle the setting on in Settings > General
- [ ] Create a new Claude Code session — verify `--dangerously-skip-permissions` appears in the spawned command
- [ ] Create a plan session — verify the flag is also present
- [ ] Toggle off — verify new sessions do NOT include the flag
- [ ] Verify non-Claude providers (Codex, Gemini) are unaffected
- [ ] Verify existing sessions are not modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)