### PR TITLE
fix: disable background throttling on embedded browser webview

### DIFF
--- a/src/renderer/components/browser-tab/pane.ts
+++ b/src/renderer/components/browser-tab/pane.ts
@@ -187,6 +187,7 @@ export function createBrowserTabPane(sessionId: string, url?: string): void {
   const webview = document.createElement('webview') as unknown as WebviewElement;
   webview.className = 'browser-webview';
   webview.setAttribute('allowpopups', '');
+  webview.setAttribute('webpreferences', 'backgroundThrottling=false');
   viewportContainer.appendChild(webview);
   el.appendChild(viewportContainer);
 


### PR DESCRIPTION
## Summary
- Adds `backgroundThrottling=false` to the `<webview>` element's `webpreferences` attribute in the browser tab pane
- Fixes severe input lag (multi-second delays on clicks/hover) in the embedded browser

## Root Cause
Electron's `<webview>` tag defaults `backgroundThrottling` to `true`. Since the webview guest renderer doesn't hold keyboard focus (the host renderer does), Chromium treats it as a "background" page and throttles `setTimeout`/`setInterval` to ~1/second and pauses `requestAnimationFrame`. React and other frameworks rely on these timers to schedule state updates and renders, so every interaction gets delayed by seconds.

## Test plan
- [ ] Open a browser tab pointing at a React app (e.g. `localhost:5173`)
- [ ] Click interactive elements (nav collapse, dropdowns, hover states) — should respond immediately
- [ ] Verify no regressions in inspect mode, flow recording, or draw mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)