### PR TITLE
add custom command override for new sessions

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -70,7 +70,7 @@ export function resetHookWatcher(): void {
 }
 
 export function registerIpcHandlers(): void {
-  ipcMain.handle('pty:create', async (_event, sessionId: string, cwd: string, cliSessionId: string | null, isResume: boolean, extraArgs: string, providerId: ProviderId = 'claude', initialPrompt?: string) => {
+  ipcMain.handle('pty:create', async (_event, sessionId: string, cwd: string, cliSessionId: string | null, isResume: boolean, extraArgs: string, providerId: ProviderId = 'claude', initialPrompt?: string, commandOverride?: string) => {
     const win = BrowserWindow.getAllWindows()[0];
     if (!win) return;
 
@@ -96,6 +96,7 @@ export function registerIpcHandlers(): void {
       extraArgs,
       providerId,
       initialPrompt,
+      commandOverride,
       (data) => {
         const w = BrowserWindow.getAllWindows()[0];
         if (w && !w.isDestroyed()) {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -164,6 +164,7 @@ export async function spawnPty(
   extraArgs: string,
   providerId: ProviderId,
   initialPrompt: string | undefined,
+  commandOverride: string | undefined,
   onData: (data: string) => void,
   onExit: (exitCode: number, signal?: number) => void
 ): Promise<void> {
@@ -190,8 +191,27 @@ export async function spawnPty(
 
   const env = provider.buildEnv(sessionId, { ...process.env } as Record<string, string>);
   const args = provider.buildArgs({ cliSessionId, isResume, extraArgs, initialPrompt });
-  const resolvedShell = provider.resolveBinaryPath();
-  const { shell, args: spawnArgs } = resolveWindowsShell(resolvedShell, args);
+
+  let shell: string;
+  let spawnArgs: string[];
+
+  if (commandOverride) {
+    // Command overrides may be shell functions/aliases (defined in .zshrc/.bashrc),
+    // not just executables on PATH. Spawn through an interactive login shell so
+    // the user's shell config is sourced and functions/aliases resolve correctly.
+    const userShell = isWin ? (process.env.COMSPEC || 'cmd.exe') : (process.env.SHELL || '/bin/zsh');
+    if (isWin) {
+      shell = userShell;
+      spawnArgs = ['/c', commandOverride, ...args];
+    } else {
+      shell = userShell;
+      const escaped = [commandOverride, ...args].map(a => `'${a.replace(/'/g, "'\\''")}'`).join(' ');
+      spawnArgs = ['-ic', escaped];
+    }
+  } else {
+    const resolvedShell = provider.resolveBinaryPath();
+    ({ shell, args: spawnArgs } = resolveWindowsShell(resolvedShell, args));
+  }
 
   const ptyProcess = pty.spawn(shell, spawnArgs, {
     name: 'xterm-256color',

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -6,7 +6,7 @@ export type { CostData } from '../shared/types';
 
 export interface VibeyardApi {
   pty: {
-    create(sessionId: string, cwd: string, cliSessionId: string | null, isResume: boolean, extraArgs?: string, providerId?: ProviderId, initialPrompt?: string): Promise<void>;
+    create(sessionId: string, cwd: string, cliSessionId: string | null, isResume: boolean, extraArgs?: string, providerId?: ProviderId, initialPrompt?: string, commandOverride?: string): Promise<void>;
     createShell(sessionId: string, cwd: string): Promise<void>;
     write(sessionId: string, data: string): void;
     resize(sessionId: string, cols: number, rows: number): void;
@@ -146,8 +146,8 @@ function onChannel(channel: string, callback: (...args: unknown[]) => void): () 
 
 const api: VibeyardApi = {
   pty: {
-    create: (sessionId, cwd, cliSessionId, isResume, extraArgs, providerId, initialPrompt) =>
-      ipcRenderer.invoke('pty:create', sessionId, cwd, cliSessionId, isResume, extraArgs || '', providerId || 'claude', initialPrompt),
+    create: (sessionId, cwd, cliSessionId, isResume, extraArgs, providerId, initialPrompt, commandOverride) =>
+      ipcRenderer.invoke('pty:create', sessionId, cwd, cliSessionId, isResume, extraArgs || '', providerId || 'claude', initialPrompt, commandOverride),
     createShell: (sessionId, cwd) =>
       ipcRenderer.invoke('pty:createShell', sessionId, cwd),
     write: (sessionId, data) =>

--- a/src/renderer/components/modal.ts
+++ b/src/renderer/components/modal.ts
@@ -12,6 +12,7 @@ export interface FieldDef {
   buttonLabel?: string;
   onButtonClick?: (input: HTMLInputElement) => void;
   onChange?: (checked: boolean) => void;
+  onSelectChange?: (value: string) => void;
 }
 
 const overlay = document.getElementById('modal-overlay')!;
@@ -108,7 +109,7 @@ export function showModal(
       div.appendChild(textarea);
     } else if (field.type === 'select') {
       div.appendChild(label);
-      const sel = createCustomSelect(`modal-${field.id}`, field.options ?? [], field.defaultValue);
+      const sel = createCustomSelect(`modal-${field.id}`, field.options ?? [], field.defaultValue, field.onSelectChange);
       div.appendChild(sel.element);
       if (!(overlay as any)._selectCleanups) (overlay as any)._selectCleanups = [];
       (overlay as any)._selectCleanups.push(() => sel.destroy());

--- a/src/renderer/components/split-layout.ts
+++ b/src/renderer/components/split-layout.ts
@@ -143,7 +143,7 @@ function onSessionAdded(data: unknown): void {
     renderLayout();
   } else {
     // Create and spawn immediately
-    createTerminalPane(session.id, project.path, session.cliSessionId, !!session.cliSessionId, session.args || '', (session.providerId as import('../../shared/types').ProviderId) || 'claude', project.id);
+    createTerminalPane(session.id, project.path, session.cliSessionId, !!session.cliSessionId, session.args || '', (session.providerId as import('../../shared/types').ProviderId) || 'claude', project.id, session.commandOverride);
     const pending = appState.consumePendingInitialPrompt(project.id, session.id);
     if (pending) {
       setPendingPrompt(session.id, pending);
@@ -232,7 +232,7 @@ export function renderLayout(): void {
       }
     } else {
       if (!getTerminalInstance(session.id)) {
-        createTerminalPane(session.id, project.path, session.cliSessionId, !!session.cliSessionId, session.args || '', session.providerId || 'claude', project.id);
+        createTerminalPane(session.id, project.path, session.cliSessionId, !!session.cliSessionId, session.args || '', session.providerId || 'claude', project.id, session.commandOverride);
       }
     }
   }

--- a/src/renderer/components/tab-bar.ts
+++ b/src/renderer/components/tab-bar.ts
@@ -828,8 +828,16 @@ export async function promptNewSession(onCreated?: (session: SessionRecord) => v
   const providers = providerSnapshot?.providers ?? [];
   const availabilityMap = providerSnapshot?.availability ?? new Map();
 
+  const getBinaryName = (id: string): string => providers.find(p => p.id === id)?.binaryName ?? 'claude';
+
+  const preferred = appState.preferences.defaultProvider ?? 'claude';
+  const firstAvailable = (providers.length > 1)
+    ? ((availabilityMap.get(preferred) ? preferred : providers.find(p => availabilityMap.get(p.id))?.id) ?? 'claude')
+    : 'claude';
+
   const fields: FieldDef[] = [
     { label: 'Name', id: 'session-name', placeholder: `Session ${sessionNum}`, defaultValue: `Session ${sessionNum}` },
+    { label: 'Command', id: 'session-command', placeholder: 'e.g. claude or /usr/local/bin/claude-beta', defaultValue: getBinaryName(firstAvailable) },
     { label: 'Arguments', id: 'session-args', placeholder: 'e.g. --model sonnet', defaultValue: project.defaultArgs ?? '' },
     {
       label: 'Keep args for future sessions',
@@ -840,8 +848,6 @@ export async function promptNewSession(onCreated?: (session: SessionRecord) => v
   ];
 
   if (providers.length > 1) {
-    const preferred = appState.preferences.defaultProvider ?? 'claude';
-    const firstAvailable = (availabilityMap.get(preferred) ? preferred : providers.find(p => availabilityMap.get(p.id))?.id) ?? 'claude';
     fields.unshift({
       label: 'Provider',
       id: 'provider',
@@ -851,6 +857,10 @@ export async function promptNewSession(onCreated?: (session: SessionRecord) => v
         const available = availabilityMap.get(p.id);
         return { value: p.id, label: available ? p.displayName : `${p.displayName} (not installed)`, disabled: !available };
       }),
+      onSelectChange: (value: string) => {
+        const commandInput = document.getElementById('modal-session-command') as HTMLInputElement | null;
+        if (commandInput) commandInput.value = getBinaryName(value);
+      },
     });
   }
 
@@ -862,7 +872,10 @@ export async function promptNewSession(onCreated?: (session: SessionRecord) => v
       const keepArgs = values['keep-args'] === 'true';
       project.defaultArgs = keepArgs ? (args || undefined) : undefined;
       const providerId = (values['provider'] || 'claude') as ProviderId;
-      const session = appState.addSession(project.id, name, args, providerId);
+      const command = values['session-command']?.trim() || undefined;
+      const defaultBinary = getBinaryName(providerId);
+      const commandOverride = (command && command !== defaultBinary) ? command : undefined;
+      const session = appState.addSession(project.id, name, args, providerId, commandOverride);
       if (session && onCreated) onCreated(session);
     }
   });

--- a/src/renderer/components/terminal-pane.ts
+++ b/src/renderer/components/terminal-pane.ts
@@ -22,6 +22,7 @@ interface TerminalInstance {
   projectPath: string;
   cliSessionId: string | null;
   providerId: ProviderId;
+  commandOverride: string | undefined;
   args: string;
   isResume: boolean;
   wasResumed: boolean;
@@ -41,7 +42,8 @@ export function createTerminalPane(
   isResume: boolean = false,
   args: string = '',
   providerId: ProviderId = 'claude',
-  projectId?: string
+  projectId?: string,
+  commandOverride?: string
 ): TerminalInstance {
   if (instances.has(sessionId)) {
     return instances.get(sessionId)!;
@@ -119,6 +121,7 @@ export function createTerminalPane(
     projectPath,
     cliSessionId,
     providerId,
+    commandOverride,
     args,
     isResume,
     wasResumed: isResume,
@@ -221,7 +224,7 @@ export async function spawnTerminal(sessionId: string): Promise<void> {
     initialPrompt = instance.pendingPrompt;
     instance.pendingPrompt = null;
   }
-  await window.vibeyard.pty.create(sessionId, instance.projectPath, instance.cliSessionId, instance.isResume, instance.args, instance.providerId, initialPrompt);
+  await window.vibeyard.pty.create(sessionId, instance.projectPath, instance.cliSessionId, instance.isResume, instance.args, instance.providerId, initialPrompt, instance.commandOverride);
   instance.isResume = true; // subsequent spawns (e.g. Restart Session) should resume
 }
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -349,7 +349,7 @@ class AppState {
     return this.addSession(projectId, name, args, providerId);
   }
 
-  addSession(projectId: string, name: string, args?: string, providerId?: ProviderId): SessionRecord | undefined {
+  addSession(projectId: string, name: string, args?: string, providerId?: ProviderId, commandOverride?: string): SessionRecord | undefined {
     const project = this.state.projects.find((p) => p.id === projectId);
     if (!project) return undefined;
 
@@ -358,6 +358,7 @@ class AppState {
       providerId: providerId ?? this.state.preferences.defaultProvider ?? 'claude',
       args: args ?? project.defaultArgs,
     });
+    if (commandOverride) session.commandOverride = commandOverride;
     attachSessionToProject(project, session, { addToSwarm: true });
     this.commitNewSession(projectId, session);
     return session;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -100,6 +100,7 @@ export interface SessionRecord {
   contextWindow?: ContextWindowInfo;
   remoteHostName?: string;
   shareMode?: 'readonly' | 'readwrite';
+  commandOverride?: string;
   browserTabUrl?: string;
   /** Transient: initial prompt to inject on first spawn. Not persisted. */
   pendingInitialPrompt?: string;


### PR DESCRIPTION
## Summary

- Adds a **Command** field to the "New Custom Session" modal, allowing users to override the provider's default binary
- Default value is set based on the selected provider (e.g. `claude`, `gemini`, `codex`) and updates when the provider dropdown changes
- Supports shell functions and aliases (e.g. `claude-personal` defined in `.zshrc`) by spawning through an interactive shell (`zsh -ic`) when a command override is set
- Persists `commandOverride` on the session record so it survives restarts

## Motivation

Users often define shell functions or aliases that wrap CLI tools with custom configuration (e.g. `CLAUDE_CONFIG_DIR=~/.claude-personal command claude`). Previously, there was no way to use these in Vibeyard — only the provider's resolved binary path was used. This change lets users type any command name, including shell functions and aliases.

## Changes

- `src/shared/types.ts` — Added `commandOverride?: string` to `SessionRecord`
- `src/renderer/components/modal.ts` — Added `onSelectChange` to `FieldDef`, wired to custom select
- `src/renderer/components/tab-bar.ts` — Added Command field to new session modal with provider-aware defaults
- `src/renderer/state.ts` — `addSession()` accepts and stores `commandOverride`
- `src/renderer/components/terminal-pane.ts` — Threads `commandOverride` through terminal instance to PTY
- `src/renderer/components/split-layout.ts` — Passes `commandOverride` at both createTerminalPane call sites
- `src/preload/preload.ts` — Added `commandOverride` to `pty.create` API
- `src/main/ipc-handlers.ts` — IPC handler forwards `commandOverride`
- `src/main/pty-manager.ts` — When `commandOverride` is set, spawns through interactive shell; otherwise uses normal binary resolution

## Test plan

- [ ] Create a new session with default command — should work as before
- [ ] Create a new session with a custom binary path (e.g. `/usr/local/bin/claude`) — should spawn that binary
- [ ] Create a new session with a shell function/alias name — should resolve through the user's shell
- [ ] Change provider in the dropdown — Command field should update to match
- [ ] Restart app — session with `commandOverride` should persist and re-spawn correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)