### PR TITLE
feat: add global session search palette (Cmd+Shift+F)

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -17,6 +17,7 @@ import { checkForUpdates, quitAndInstall } from './auto-updater';
 import { createAppMenu } from './menu';
 import { getProvider, getProviderMeta, getAllProviderMetas } from './providers/registry';
 import { buildHandoffPrompt } from './providers/resume-handoff';
+import { searchSessions } from './session-deep-search';
 import type { ProviderId, GitFileEntry, SettingsValidationResult, ReadFileResult } from '../shared/types';
 import { analyzeReadiness } from './readiness/analyzer';
 import { expandUserPath, isBinaryBuffer, BINARY_SNIFF_BYTES } from './fs-utils';
@@ -273,6 +274,10 @@ export function registerIpcHandlers(): void {
       }
     }
     return buildHandoffPrompt({ fromProviderLabel, sessionName, transcriptPath });
+  });
+
+  ipcMain.handle('session:deepSearch', (_event, query: string) => {
+    return searchSessions(query);
   });
 
   ipcMain.handle('provider:checkBinary', (_event, providerId: ProviderId = 'claude') => {

--- a/src/main/providers/claude-provider.search.test.ts
+++ b/src/main/providers/claude-provider.search.test.ts
@@ -1,0 +1,109 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  promises: { readFile: vi.fn(), readdir: vi.fn(), stat: vi.fn() },
+}));
+vi.mock('os', () => ({ homedir: () => '/mock/home' }));
+
+// Heavy main-process deps imported by claude-provider that we don't exercise here.
+vi.mock('../pty-manager', () => ({ getFullPath: () => '' }));
+vi.mock('../hook-status', () => ({ installStatusLineScript: () => {}, cleanupAll: () => {} }));
+vi.mock('../config-watcher', () => ({ startConfigWatcher: () => {}, stopConfigWatcher: () => {} }));
+vi.mock('../claude-cli', () => ({ installHooksOnly: () => {}, installStatusLine: () => {}, getClaudeConfig: async () => ({}) }));
+vi.mock('../settings-guard', () => ({ guardedInstall: async () => {}, validateSettings: () => ({}), reinstallSettings: () => {} }));
+vi.mock('./resolve-binary', () => ({ resolveBinary: () => '', validateBinaryExists: () => true }));
+
+import * as fs from 'fs';
+import { ClaudeProvider } from './claude-provider';
+
+const mockReadFile = vi.mocked(fs.promises.readFile);
+const mockReaddir = vi.mocked(fs.promises.readdir);
+
+const FAKE_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+function dir(name: string) { return { name, isDirectory: () => true } as fs.Dirent; }
+function file(name: string) { return { name, isDirectory: () => false } as fs.Dirent; }
+
+function makeJsonl(entries: object[]): string {
+  return entries.map(e => JSON.stringify(e)).join('\n');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ClaudeProvider.discoverTranscripts()', () => {
+  it('returns [] when projects root is missing', async () => {
+    mockReaddir.mockRejectedValueOnce(new Error('ENOENT'));
+    expect(await new ClaudeProvider().discoverTranscripts()).toEqual([]);
+  });
+
+  it('lists every UUID-named JSONL across slugs', async () => {
+    mockReaddir
+      .mockResolvedValueOnce([dir('proj-a'), dir('proj-b')] as any)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`, 'history.jsonl'] as any)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as any);
+
+    const out = await new ClaudeProvider().discoverTranscripts();
+    expect(out).toHaveLength(2);
+    expect(out[0].cliSessionId).toBe(FAKE_UUID);
+    expect(out[0].projectSlug).toBe('proj-a');
+    expect(out[0].transcriptPath).toMatch(/proj-a/);
+  });
+
+  it('skips non-directory entries and non-UUID filenames', async () => {
+    mockReaddir
+      .mockResolvedValueOnce([file('file.json'), dir('validslug')] as any)
+      .mockResolvedValueOnce(['notes.jsonl', `${FAKE_UUID}.jsonl`] as any);
+
+    const out = await new ClaudeProvider().discoverTranscripts();
+    expect(out).toHaveLength(1);
+    expect(out[0].projectSlug).toBe('validslug');
+  });
+
+  it('skips slugs whose readdir fails', async () => {
+    mockReaddir
+      .mockResolvedValueOnce([dir('ok'), dir('bad')] as any)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as any)
+      .mockRejectedValueOnce(new Error('EACCES'));
+
+    const out = await new ClaudeProvider().discoverTranscripts();
+    expect(out).toHaveLength(1);
+    expect(out[0].projectSlug).toBe('ok');
+  });
+});
+
+describe('ClaudeProvider.indexTranscript()', () => {
+  it('extracts user-message text and the first cwd it sees', async () => {
+    const jsonl = makeJsonl([
+      { cwd: '/Users/me/repo' },
+      { type: 'user', message: { content: 'hello world' } },
+      { type: 'assistant', message: { content: 'never indexed' } },
+    ]);
+    mockReadFile.mockResolvedValueOnce(jsonl as any);
+    const r = await new ClaudeProvider().indexTranscript('/p');
+    expect(r.cwd).toBe('/Users/me/repo');
+    expect(r.text).toContain('hello world');
+    expect(r.text).not.toContain('never indexed');
+  });
+
+  it('handles content as array of text blocks, ignoring non-text blocks', async () => {
+    const jsonl = makeJsonl([
+      { type: 'user', message: { content: [
+        { type: 'text', text: 'refactor authentication' },
+        { type: 'tool_use', id: 't1' },
+      ] } },
+    ]);
+    mockReadFile.mockResolvedValueOnce(jsonl as any);
+    const r = await new ClaudeProvider().indexTranscript('/p');
+    expect(r.text).toContain('refactor authentication');
+  });
+
+  it('tolerates malformed JSONL lines', async () => {
+    const jsonl = 'not json\n{"type":"user","message":{"content":"valid"}}\n{broken';
+    mockReadFile.mockResolvedValueOnce(jsonl as any);
+    const r = await new ClaudeProvider().indexTranscript('/p');
+    expect(r.text).toContain('valid');
+  });
+});

--- a/src/main/providers/claude-provider.ts
+++ b/src/main/providers/claude-provider.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import type { BrowserWindow } from 'electron';
-import type { CliProvider } from './provider';
+import type { CliProvider, TranscriptDescriptor } from './provider';
 import type { CliProviderMeta, ProviderConfig, SettingsValidationResult } from '../../shared/types';
 import { getFullPath } from '../pty-manager';
 import { installStatusLineScript, cleanupAll as cleanupHookStatus } from '../hook-status';
@@ -10,6 +10,7 @@ import { startConfigWatcher as startConfigWatch, stopConfigWatcher as stopConfig
 import { installHooksOnly, installStatusLine, getClaudeConfig } from '../claude-cli';
 import { guardedInstall, validateSettings, reinstallSettings } from '../settings-guard';
 import { resolveBinary, validateBinaryExists } from './resolve-binary';
+import { MAX_INDEX_CHARS_PER_SESSION, TRANSCRIPT_TEXT_SEPARATOR, UUID_RE } from './transcript-utils';
 
 const binaryCache = { path: null as string | null };
 
@@ -108,6 +109,66 @@ export class ClaudeProvider implements CliProvider {
     const slug = projectPath.replace(/[^a-zA-Z0-9]/g, '-');
     const filePath = path.join(os.homedir(), '.claude', 'projects', slug, `${cliSessionId}.jsonl`);
     return fs.existsSync(filePath) ? filePath : null;
+  }
+
+  async discoverTranscripts(): Promise<TranscriptDescriptor[]> {
+    const root = path.join(os.homedir(), '.claude', 'projects');
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(root, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    const out: TranscriptDescriptor[] = [];
+    for (const slugEntry of entries) {
+      if (!slugEntry.isDirectory()) continue;
+      const slug = slugEntry.name;
+      const slugPath = path.join(root, slug);
+      let files: string[];
+      try {
+        files = await fs.promises.readdir(slugPath);
+      } catch {
+        continue;
+      }
+      for (const file of files) {
+        if (!file.endsWith('.jsonl')) continue;
+        const cliSessionId = file.slice(0, -6);
+        if (!UUID_RE.test(cliSessionId)) continue;
+        out.push({ cliSessionId, transcriptPath: path.join(slugPath, file), projectSlug: slug });
+      }
+    }
+    return out;
+  }
+
+  async indexTranscript(transcriptPath: string): Promise<{ text: string; cwd: string }> {
+    const content = await fs.promises.readFile(transcriptPath, 'utf8');
+    const texts: string[] = [];
+    let cwd = '';
+    let totalChars = 0;
+    for (const line of content.split('\n')) {
+      if (!line.trim() || totalChars >= MAX_INDEX_CHARS_PER_SESSION) continue;
+      try {
+        const entry = JSON.parse(line);
+        if (!cwd && entry.cwd) cwd = entry.cwd;
+        if (entry.type !== 'user' || !entry.message?.content) continue;
+        const c = entry.message.content;
+        let text = '';
+        if (typeof c === 'string') {
+          text = c;
+        } else if (Array.isArray(c)) {
+          for (const block of c) {
+            if (block.type === 'text') text += block.text + '\n';
+          }
+        }
+        if (text) {
+          texts.push(text.trim());
+          totalChars += text.length;
+        }
+      } catch {
+        // partial-write tolerance: skip malformed lines
+      }
+    }
+    return { text: texts.join(TRANSCRIPT_TEXT_SEPARATOR), cwd };
   }
 
   parseCostFromOutput(rawText: string): { totalCostUsd: number } | null {

--- a/src/main/providers/codex-provider.search.test.ts
+++ b/src/main/providers/codex-provider.search.test.ts
@@ -1,0 +1,88 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  readdirSync: vi.fn(() => []),
+  promises: { readFile: vi.fn(), readdir: vi.fn() },
+}));
+vi.mock('os', () => ({ homedir: () => '/mock/home' }));
+
+vi.mock('../pty-manager', () => ({ getFullPath: () => '' }));
+vi.mock('../codex-config', () => ({ getCodexConfig: async () => ({}) }));
+vi.mock('../codex-hooks', () => ({
+  installCodexHooks: () => {}, validateCodexHooks: () => ({}), cleanupCodexHooks: () => {}, SESSION_ID_VAR: 'CODEX_SESSION_ID',
+}));
+vi.mock('../config-watcher', () => ({ startConfigWatcher: () => {}, stopConfigWatcher: () => {} }));
+vi.mock('./resolve-binary', () => ({ resolveBinary: () => '', validateBinaryExists: () => true }));
+
+import * as fs from 'fs';
+import { CodexProvider } from './codex-provider';
+
+const mockReadFile = vi.mocked(fs.promises.readFile);
+const mockReaddir = vi.mocked(fs.promises.readdir);
+
+const UUID = '019d3512-caf9-7b50-8d2b-ccccdcf8ff14';
+
+function dir(name: string) { return { name, isDirectory: () => true } as fs.Dirent; }
+function file(name: string) { return { name, isDirectory: () => false } as fs.Dirent; }
+
+function makeJsonl(entries: object[]): string {
+  return entries.map(e => JSON.stringify(e)).join('\n');
+}
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('CodexProvider.discoverTranscripts()', () => {
+  it('walks YYYY/MM/DD and parses cliSessionId from filename suffix', async () => {
+    // Walker uses readdir withFileTypes at each level; depth 3 enumerates files.
+    mockReaddir
+      .mockResolvedValueOnce([dir('2026')] as any)
+      .mockResolvedValueOnce([dir('03')] as any)
+      .mockResolvedValueOnce([dir('28')] as any)
+      .mockResolvedValueOnce([
+        file(`rollout-2026-03-28T18-31-57-${UUID}.jsonl`),
+        file('README.md'),
+      ] as any);
+
+    const out = await new CodexProvider().discoverTranscripts();
+    expect(out).toHaveLength(1);
+    expect(out[0].cliSessionId).toBe(UUID);
+    expect(out[0].transcriptPath).toContain(`rollout-2026-03-28T18-31-57-${UUID}.jsonl`);
+  });
+
+  it('returns [] when root is missing', async () => {
+    mockReaddir.mockRejectedValueOnce(new Error('ENOENT'));
+    expect(await new CodexProvider().discoverTranscripts()).toEqual([]);
+  });
+});
+
+describe('CodexProvider.indexTranscript()', () => {
+  it('pulls cwd from session_meta and user text from response_item with role=user', async () => {
+    const jsonl = makeJsonl([
+      { type: 'session_meta', payload: { cwd: '/Users/me/repo', id: UUID } },
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [
+        { type: 'input_text', text: 'fix the bug' },
+      ] } },
+      { type: 'response_item', payload: { type: 'message', role: 'assistant', content: [
+        { type: 'output_text', text: 'never indexed' },
+      ] } },
+    ]);
+    mockReadFile.mockResolvedValueOnce(jsonl as any);
+    const r = await new CodexProvider().indexTranscript('/p');
+    expect(r.cwd).toBe('/Users/me/repo');
+    expect(r.text).toContain('fix the bug');
+    expect(r.text).not.toContain('never indexed');
+  });
+
+  it('concatenates multiple input_text blocks', async () => {
+    const jsonl = makeJsonl([
+      { type: 'response_item', payload: { type: 'message', role: 'user', content: [
+        { type: 'input_text', text: 'part one' },
+        { type: 'input_text', text: 'part two' },
+      ] } },
+    ]);
+    mockReadFile.mockResolvedValueOnce(jsonl as any);
+    const r = await new CodexProvider().indexTranscript('/p');
+    expect(r.text).toContain('part one');
+    expect(r.text).toContain('part two');
+  });
+});

--- a/src/main/providers/codex-provider.ts
+++ b/src/main/providers/codex-provider.ts
@@ -1,14 +1,17 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import type { CliProvider } from './provider';
+import type { CliProvider, TranscriptDescriptor } from './provider';
 import type { CliProviderMeta, ProviderConfig, SettingsValidationResult } from '../../shared/types';
 import { getFullPath } from '../pty-manager';
 import { resolveBinary, validateBinaryExists } from './resolve-binary';
 import { getCodexConfig } from '../codex-config';
 import { installCodexHooks, validateCodexHooks, cleanupCodexHooks, SESSION_ID_VAR } from '../codex-hooks';
 import { startConfigWatcher as startConfigWatch, stopConfigWatcher as stopConfigWatch } from '../config-watcher';
+import { MAX_INDEX_CHARS_PER_SESSION, TRANSCRIPT_TEXT_SEPARATOR } from './transcript-utils';
 import type { BrowserWindow } from 'electron';
+
+const CODEX_FILE_RE = /-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/i;
 
 const binaryCache = { path: null as string | null };
 
@@ -114,6 +117,60 @@ export class CodexProvider implements CliProvider {
     } catch {
       return null;
     }
+  }
+
+  async discoverTranscripts(): Promise<TranscriptDescriptor[]> {
+    const root = path.join(os.homedir(), '.codex', 'sessions');
+    const out: TranscriptDescriptor[] = [];
+    const walk = async (dir: string, depth: number): Promise<void> => {
+      let entries: fs.Dirent[];
+      try {
+        entries = await fs.promises.readdir(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      if (depth === 3) {
+        for (const entry of entries) {
+          const m = entry.name.match(CODEX_FILE_RE);
+          if (!m) continue;
+          out.push({ cliSessionId: m[1], transcriptPath: path.join(dir, entry.name) });
+        }
+        return;
+      }
+      for (const entry of entries) {
+        if (entry.isDirectory()) await walk(path.join(dir, entry.name), depth + 1);
+      }
+    };
+    await walk(root, 0);
+    return out;
+  }
+
+  async indexTranscript(transcriptPath: string): Promise<{ text: string; cwd: string }> {
+    const content = await fs.promises.readFile(transcriptPath, 'utf8');
+    const texts: string[] = [];
+    let cwd = '';
+    let totalChars = 0;
+    for (const line of content.split('\n')) {
+      if (!line.trim() || totalChars >= MAX_INDEX_CHARS_PER_SESSION) continue;
+      try {
+        const entry = JSON.parse(line);
+        if (!cwd && entry.type === 'session_meta' && entry.payload?.cwd) cwd = entry.payload.cwd;
+        if (entry.type !== 'response_item') continue;
+        const p = entry.payload;
+        if (!p || p.type !== 'message' || p.role !== 'user' || !Array.isArray(p.content)) continue;
+        let text = '';
+        for (const block of p.content) {
+          if (block && typeof block.text === 'string') text += block.text + '\n';
+        }
+        if (text) {
+          texts.push(text.trim());
+          totalChars += text.length;
+        }
+      } catch {
+        // partial-write tolerance
+      }
+    }
+    return { text: texts.join(TRANSCRIPT_TEXT_SEPARATOR), cwd };
   }
 }
 

--- a/src/main/providers/copilot-provider.search.test.ts
+++ b/src/main/providers/copilot-provider.search.test.ts
@@ -1,0 +1,84 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => true),
+  promises: { readFile: vi.fn(), readdir: vi.fn() },
+}));
+vi.mock('os', () => ({ homedir: () => '/mock/home' }));
+
+vi.mock('../pty-manager', () => ({ getFullPath: () => '' }));
+vi.mock('../copilot-config', () => ({ getCopilotConfig: () => ({}) }));
+vi.mock('../copilot-hooks', () => ({
+  installCopilotHooks: () => {}, validateCopilotHooks: () => ({}), cleanupCopilotHooks: () => {}, SESSION_ID_VAR: 'COPILOT_SESSION_ID',
+}));
+vi.mock('../config-watcher', () => ({ startConfigWatcher: () => {}, stopConfigWatcher: () => {} }));
+vi.mock('./resolve-binary', () => ({ resolveBinary: () => '', validateBinaryExists: () => true }));
+
+import * as fs from 'fs';
+import { CopilotProvider } from './copilot-provider';
+
+const mockReadFile = vi.mocked(fs.promises.readFile);
+const mockReaddir = vi.mocked(fs.promises.readdir);
+
+const UUID = '54c23d7f-4fd6-4078-8a69-5eb73317a421';
+
+function dir(name: string) { return { name, isDirectory: () => true } as fs.Dirent; }
+function file(name: string) { return { name, isDirectory: () => false } as fs.Dirent; }
+
+function makeJsonl(entries: object[]): string {
+  return entries.map(e => JSON.stringify(e)).join('\n');
+}
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('CopilotProvider.discoverTranscripts()', () => {
+  it('uses dir name as cliSessionId and parses cwd from workspace.yaml', async () => {
+    mockReaddir.mockResolvedValueOnce([dir(UUID), dir('not-a-uuid'), file('stray.txt')] as any);
+    mockReadFile.mockResolvedValueOnce(
+      'id: ' + UUID + '\ncwd: /Users/me/dev/repo\nsummary_count: 0\n' as any,
+    );
+
+    const out = await new CopilotProvider().discoverTranscripts();
+    expect(out).toHaveLength(1);
+    expect(out[0].cliSessionId).toBe(UUID);
+    expect(out[0].projectCwd).toBe('/Users/me/dev/repo');
+    expect(out[0].transcriptPath).toContain('events.jsonl');
+  });
+
+  it('still discovers when workspace.yaml is missing (cwd empty)', async () => {
+    mockReaddir.mockResolvedValueOnce([dir(UUID)] as any);
+    mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+
+    const out = await new CopilotProvider().discoverTranscripts();
+    expect(out).toHaveLength(1);
+    expect(out[0].projectCwd).toBe('');
+  });
+
+  it('returns [] when session-state root is missing', async () => {
+    mockReaddir.mockRejectedValueOnce(new Error('ENOENT'));
+    expect(await new CopilotProvider().discoverTranscripts()).toEqual([]);
+  });
+});
+
+describe('CopilotProvider.indexTranscript()', () => {
+  it('only extracts user.message data.content', async () => {
+    const jsonl = makeJsonl([
+      { type: 'session.start', data: {} },
+      { type: 'user.message', data: { content: 'first prompt' } },
+      { type: 'assistant.message', data: { content: 'never indexed' } },
+      { type: 'user.message', data: { content: 'follow-up' } },
+    ]);
+    mockReadFile.mockResolvedValueOnce(jsonl as any);
+    const r = await new CopilotProvider().indexTranscript('/p');
+    expect(r.text).toContain('first prompt');
+    expect(r.text).toContain('follow-up');
+    expect(r.text).not.toContain('never indexed');
+  });
+
+  it('tolerates malformed lines', async () => {
+    const jsonl = '{broken\n' + JSON.stringify({ type: 'user.message', data: { content: 'good prompt' } });
+    mockReadFile.mockResolvedValueOnce(jsonl as any);
+    const r = await new CopilotProvider().indexTranscript('/p');
+    expect(r.text).toContain('good prompt');
+  });
+});

--- a/src/main/providers/copilot-provider.ts
+++ b/src/main/providers/copilot-provider.ts
@@ -1,11 +1,15 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 import type { BrowserWindow } from 'electron';
-import type { CliProvider } from './provider';
+import type { CliProvider, TranscriptDescriptor } from './provider';
 import type { CliProviderMeta, ProviderConfig, SettingsValidationResult } from '../../shared/types';
 import { getFullPath } from '../pty-manager';
 import { resolveBinary, validateBinaryExists } from './resolve-binary';
 import { getCopilotConfig } from '../copilot-config';
 import { installCopilotHooks, validateCopilotHooks, cleanupCopilotHooks, SESSION_ID_VAR } from '../copilot-hooks';
 import { startConfigWatcher as startConfigWatch, stopConfigWatcher as stopConfigWatch } from '../config-watcher';
+import { MAX_INDEX_CHARS_PER_SESSION, TRANSCRIPT_TEXT_SEPARATOR, UUID_RE } from './transcript-utils';
 
 const binaryCache = { path: null as string | null };
 
@@ -88,6 +92,58 @@ export class CopilotProvider implements CliProvider {
 
   reinstallSettings(): void {
     installCopilotHooks();
+  }
+
+  getTranscriptPath(cliSessionId: string, _projectPath: string): string | null {
+    const filePath = path.join(os.homedir(), '.copilot', 'session-state', cliSessionId, 'events.jsonl');
+    return fs.existsSync(filePath) ? filePath : null;
+  }
+
+  async discoverTranscripts(): Promise<TranscriptDescriptor[]> {
+    const root = path.join(os.homedir(), '.copilot', 'session-state');
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(root, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    const out: TranscriptDescriptor[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !UUID_RE.test(entry.name)) continue;
+      const cliSessionId = entry.name;
+      const dir = path.join(root, cliSessionId);
+      const transcriptPath = path.join(dir, 'events.jsonl');
+      let projectCwd = '';
+      try {
+        const yaml = await fs.promises.readFile(path.join(dir, 'workspace.yaml'), 'utf-8');
+        const m = yaml.match(/^cwd:\s*"?([^"\n]+?)"?\s*$/m);
+        if (m) projectCwd = m[1].trim();
+      } catch {
+        // workspace.yaml may be absent on partial-init sessions; cwd stays empty
+      }
+      out.push({ cliSessionId, transcriptPath, projectCwd });
+    }
+    return out;
+  }
+
+  async indexTranscript(transcriptPath: string): Promise<{ text: string; cwd: string }> {
+    const content = await fs.promises.readFile(transcriptPath, 'utf-8');
+    const texts: string[] = [];
+    let totalChars = 0;
+    for (const line of content.split('\n')) {
+      if (!line.trim() || totalChars >= MAX_INDEX_CHARS_PER_SESSION) continue;
+      try {
+        const entry = JSON.parse(line);
+        if (entry.type !== 'user.message') continue;
+        const c = entry.data?.content;
+        if (typeof c !== 'string' || !c) continue;
+        texts.push(c.trim());
+        totalChars += c.length;
+      } catch {
+        // partial-write tolerance
+      }
+    }
+    return { text: texts.join(TRANSCRIPT_TEXT_SEPARATOR), cwd: '' };
   }
 }
 

--- a/src/main/providers/gemini-provider.search.test.ts
+++ b/src/main/providers/gemini-provider.search.test.ts
@@ -1,0 +1,85 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => true),
+  promises: { readFile: vi.fn(), readdir: vi.fn() },
+}));
+vi.mock('os', () => ({ homedir: () => '/mock/home' }));
+
+vi.mock('../pty-manager', () => ({ getFullPath: () => '' }));
+vi.mock('../gemini-config', () => ({ getGeminiConfig: async () => ({}) }));
+vi.mock('../gemini-hooks', () => ({
+  installGeminiHooks: () => {}, validateGeminiHooks: () => ({}), cleanupGeminiHooks: () => {}, SESSION_ID_VAR: 'GEMINI_SESSION_ID',
+}));
+vi.mock('../config-watcher', () => ({ startConfigWatcher: () => {}, stopConfigWatcher: () => {} }));
+vi.mock('./resolve-binary', () => ({ resolveBinary: () => '', validateBinaryExists: () => true }));
+
+import * as fs from 'fs';
+import { GeminiProvider } from './gemini-provider';
+
+const mockReadFile = vi.mocked(fs.promises.readFile);
+const mockReaddir = vi.mocked(fs.promises.readdir);
+
+const FULL_ID = 'a840aafb-e00e-46b2-b8d4-1abedbb72ab1';
+const SHORT = FULL_ID.slice(0, 8);
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('GeminiProvider.discoverTranscripts()', () => {
+  it('reads .project_root for cwd and pulls full sessionId from JSON body, not the 8-char filename', async () => {
+    mockReaddir
+      .mockResolvedValueOnce(['my-project-key'] as any) // tmp/
+      .mockResolvedValueOnce([`session-2026-03-31T15-54-${SHORT}.json`, 'irrelevant.txt'] as any); // chats/
+
+    mockReadFile
+      .mockResolvedValueOnce('/Users/me/dev/forty-api\n' as any) // .project_root
+      .mockResolvedValueOnce(JSON.stringify({ sessionId: FULL_ID, messages: [] }) as any);
+
+    const out = await new GeminiProvider().discoverTranscripts();
+    expect(out).toHaveLength(1);
+    expect(out[0].cliSessionId).toBe(FULL_ID);
+    expect(out[0].projectCwd).toBe('/Users/me/dev/forty-api');
+    expect(out[0].projectSlug).toBe('my-project-key');
+    expect(out[0].transcriptPath).toContain(`session-2026-03-31T15-54-${SHORT}.json`);
+  });
+
+  it('skips project keys missing .project_root', async () => {
+    mockReaddir.mockResolvedValueOnce(['orphan'] as any);
+    mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+    expect(await new GeminiProvider().discoverTranscripts()).toEqual([]);
+  });
+});
+
+describe('GeminiProvider.indexTranscript()', () => {
+  it('extracts user-typed text only, joining multi-block content', async () => {
+    const json = JSON.stringify({
+      sessionId: FULL_ID,
+      messages: [
+        { type: 'user', content: [{ text: 'hey' }] },
+        { type: 'gemini', content: 'never indexed' },
+        { type: 'user', content: [{ text: 'follow-up question' }] },
+      ],
+    });
+    mockReadFile.mockResolvedValueOnce(json as any);
+
+    const r = await new GeminiProvider().indexTranscript('/p');
+    expect(r.text).toContain('hey');
+    expect(r.text).toContain('follow-up question');
+    expect(r.text).not.toContain('never indexed');
+  });
+
+  it('handles user content as plain string', async () => {
+    const json = JSON.stringify({
+      sessionId: FULL_ID,
+      messages: [{ type: 'user', content: 'plain text prompt' }],
+    });
+    mockReadFile.mockResolvedValueOnce(json as any);
+    const r = await new GeminiProvider().indexTranscript('/p');
+    expect(r.text).toContain('plain text prompt');
+  });
+
+  it('returns empty on parse failure', async () => {
+    mockReadFile.mockResolvedValueOnce('{not json' as any);
+    expect(await new GeminiProvider().indexTranscript('/p')).toEqual({ text: '', cwd: '' });
+  });
+});

--- a/src/main/providers/gemini-provider.ts
+++ b/src/main/providers/gemini-provider.ts
@@ -1,13 +1,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import type { CliProvider } from './provider';
+import type { CliProvider, TranscriptDescriptor } from './provider';
 import type { CliProviderMeta, ProviderConfig, SettingsValidationResult } from '../../shared/types';
 import { getFullPath } from '../pty-manager';
 import { resolveBinary, validateBinaryExists } from './resolve-binary';
 import { getGeminiConfig } from '../gemini-config';
 import { installGeminiHooks, validateGeminiHooks, cleanupGeminiHooks, SESSION_ID_VAR } from '../gemini-hooks';
 import { startConfigWatcher as startConfigWatch, stopConfigWatcher as stopConfigWatch } from '../config-watcher';
+import { MAX_INDEX_CHARS_PER_SESSION, TRANSCRIPT_TEXT_SEPARATOR } from './transcript-utils';
 import type { BrowserWindow } from 'electron';
 
 const binaryCache = { path: null as string | null };
@@ -144,6 +145,81 @@ export class GeminiProvider implements CliProvider {
     } catch {
       return null;
     }
+  }
+
+  async discoverTranscripts(): Promise<TranscriptDescriptor[]> {
+    const tmpRoot = path.join(os.homedir(), '.gemini', 'tmp');
+    let keys: string[];
+    try {
+      keys = await fs.promises.readdir(tmpRoot);
+    } catch {
+      return [];
+    }
+    const out: TranscriptDescriptor[] = [];
+    for (const key of keys) {
+      const projectDir = path.join(tmpRoot, key);
+      let projectCwd = '';
+      try {
+        projectCwd = (await fs.promises.readFile(path.join(projectDir, '.project_root'), 'utf-8')).trim();
+      } catch {
+        continue;
+      }
+      const chatsDir = path.join(projectDir, 'chats');
+      let files: string[];
+      try {
+        files = await fs.promises.readdir(chatsDir);
+      } catch {
+        continue;
+      }
+      for (const file of files) {
+        if (!file.startsWith('session-') || !file.endsWith('.json')) continue;
+        const transcriptPath = path.join(chatsDir, file);
+        // The full sessionId lives inside the JSON; the filename only encodes the first 8 chars.
+        let cliSessionId: string | null = null;
+        try {
+          const raw = await fs.promises.readFile(transcriptPath, 'utf-8');
+          const m = raw.match(/"sessionId"\s*:\s*"([0-9a-f-]+)"/i);
+          if (m) cliSessionId = m[1];
+          else cliSessionId = JSON.parse(raw)?.sessionId ?? null;
+        } catch {
+          continue;
+        }
+        if (!cliSessionId) continue;
+        out.push({ cliSessionId, transcriptPath, projectCwd, projectSlug: key });
+      }
+    }
+    return out;
+  }
+
+  async indexTranscript(transcriptPath: string): Promise<{ text: string; cwd: string }> {
+    let parsed: { messages?: Array<{ type?: string; content?: unknown }> };
+    try {
+      parsed = JSON.parse(await fs.promises.readFile(transcriptPath, 'utf-8'));
+    } catch {
+      return { text: '', cwd: '' };
+    }
+    const texts: string[] = [];
+    let totalChars = 0;
+    for (const msg of parsed.messages ?? []) {
+      if (totalChars >= MAX_INDEX_CHARS_PER_SESSION) break;
+      if (msg?.type !== 'user') continue;
+      let text = '';
+      const c = msg.content;
+      if (typeof c === 'string') {
+        text = c;
+      } else if (Array.isArray(c)) {
+        for (const block of c) {
+          if (block && typeof (block as { text?: unknown }).text === 'string') {
+            text += (block as { text: string }).text + '\n';
+          }
+        }
+      }
+      if (text) {
+        texts.push(text.trim());
+        totalChars += text.length;
+      }
+    }
+    return { text: texts.join(TRANSCRIPT_TEXT_SEPARATOR), cwd: '' };
   }
 }
 

--- a/src/main/providers/provider.ts
+++ b/src/main/providers/provider.ts
@@ -1,6 +1,17 @@
 import type { BrowserWindow } from 'electron';
 import type { CliProviderMeta, ProviderConfig, SettingsValidationResult } from '../../shared/types';
 
+/** Lightweight pointer to one on-disk transcript, used by global session search. */
+export interface TranscriptDescriptor {
+  cliSessionId: string;
+  /** Absolute path used as the cache key and mtime source for indexing. */
+  transcriptPath: string;
+  /** Pre-computed cwd, when the format makes it cheap (e.g. read from a sidecar). */
+  projectCwd?: string;
+  /** Provider-specific project key (Claude slug, Gemini project hash, etc.). Display fallback. */
+  projectSlug?: string;
+}
+
 export interface CliProvider {
   readonly meta: CliProviderMeta;
   resolveBinaryPath(): string;
@@ -17,6 +28,10 @@ export interface CliProvider {
   parseCostFromOutput?(rawText: string): { totalCostUsd: number } | null;
   /** Return the absolute path to the source transcript file for a prior session, if any. */
   getTranscriptPath?(cliSessionId: string, projectPath: string): string | null;
+  /** Cheap enumeration of every on-disk transcript for global session search. */
+  discoverTranscripts?(): Promise<TranscriptDescriptor[]>;
+  /** Read user-visible text (and optionally the cwd) out of one transcript file. */
+  indexTranscript?(transcriptPath: string): Promise<{ text: string; cwd: string }>;
   startConfigWatcher?(win: BrowserWindow, projectPath: string): void;
   stopConfigWatcher?(): void;
 }

--- a/src/main/providers/transcript-utils.ts
+++ b/src/main/providers/transcript-utils.ts
@@ -1,0 +1,8 @@
+/** Per-session character cap when indexing transcript content for global search. */
+export const MAX_INDEX_CHARS_PER_SESSION = 50 * 1024;
+
+/** UUID v4-shaped string used as a cliSessionId by Claude/Codex/Copilot. */
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Joins extracted user-message snippets with a clear separator the snippet extractor can land on. */
+export const TRANSCRIPT_TEXT_SEPARATOR = '\n---\n';

--- a/src/main/session-deep-search.test.ts
+++ b/src/main/session-deep-search.test.ts
@@ -212,6 +212,25 @@ describe('searchSessions()', () => {
     expect(results).toHaveLength(0);
   });
 
+  it('gibberish query returns no results even when chars appear as subsequence', async () => {
+    // "asdcv" chars all appear in long English text as a subsequence — should NOT match
+    const jsonl = makeJsonl([
+      { cwd: '/repo' },
+      { type: 'user', message: { content: 'please add some documentation and cover all cases very well' } },
+    ]);
+
+    mockReaddir
+      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
+      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
+    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    const results = await searchSessions('asdcv');
+    expect(results).toHaveLength(0);
+  });
+
   it('returns zero score and excludes session when query has no match', async () => {
     const jsonl = makeJsonl([
       { cwd: '/repo' },

--- a/src/main/session-deep-search.test.ts
+++ b/src/main/session-deep-search.test.ts
@@ -1,0 +1,393 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  promises: {
+    readFile: vi.fn(),
+    stat: vi.fn(),
+    readdir: vi.fn(),
+  },
+}));
+
+vi.mock('os', () => ({
+  homedir: () => '/mock/home',
+}));
+
+import * as fs from 'fs';
+import { searchSessions, _resetForTesting } from './session-deep-search';
+
+const mockReadFile = vi.mocked(fs.promises.readFile);
+const mockStat = vi.mocked(fs.promises.stat);
+const mockReaddir = vi.mocked(fs.promises.readdir);
+
+const FAKE_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+function makeStat(opts: { isDirectory?: boolean; mtime?: number } = {}): Awaited<ReturnType<typeof fs.promises.stat>> {
+  return {
+    isDirectory: () => opts.isDirectory ?? false,
+    mtimeMs: opts.mtime ?? 1000,
+  } as Awaited<ReturnType<typeof fs.promises.stat>>;
+}
+
+function makeJsonl(entries: object[]): string {
+  return entries.map(e => JSON.stringify(e)).join('\n');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetForTesting();
+});
+
+describe('searchSessions()', () => {
+  it('returns empty array when projects dir does not exist', async () => {
+    mockReaddir.mockRejectedValueOnce(new Error('ENOENT'));
+    expect(await searchSessions('hello')).toEqual([]);
+  });
+
+  it('returns empty array when projects dir is empty', async () => {
+    mockReaddir.mockResolvedValueOnce([] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    expect(await searchSessions('hello')).toEqual([]);
+  });
+
+  it('finds exact phrase match with score 100', async () => {
+    const slug = 'Users-itay-repo';
+    const jsonl = makeJsonl([
+      { cwd: '/Users/itay/repo' },
+      { type: 'user', message: { content: 'hello world this is a test' } },
+    ]);
+
+    mockReaddir
+      .mockResolvedValueOnce([slug] as unknown as Awaited<ReturnType<typeof mockReaddir>>)   // slugDirs
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);  // files in slug
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: true }))   // slugPath stat
+      .mockResolvedValueOnce(makeStat({ mtime: 1234 }));        // file stat for cache
+    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    const results = await searchSessions('hello world');
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(100);
+    expect(results[0].cliSessionId).toBe(FAKE_UUID);
+    expect(results[0].projectCwd).toBe('/Users/itay/repo');
+    expect(results[0].projectSlug).toBe(slug);
+    expect(results[0].snippet).toBeTruthy();
+  });
+
+  it('scores all-words match at 80', async () => {
+    const jsonl = makeJsonl([
+      { cwd: '/repo' },
+      { type: 'user', message: { content: 'fix the memory leak in the allocator' } },
+    ]);
+
+    mockReaddir
+      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
+      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
+    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    const results = await searchSessions('memory allocator');
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(80);
+  });
+
+  it('scores partial word match proportionally', async () => {
+    const jsonl = makeJsonl([
+      { cwd: '/repo' },
+      { type: 'user', message: { content: 'only memory here nothing else' } },
+    ]);
+
+    mockReaddir
+      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
+      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
+    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    const results = await searchSessions('memory allocator');
+    expect(results).toHaveLength(1);
+    // 1/2 words matched → score = round(50 * 1/2) = 25
+    expect(results[0].score).toBe(25);
+  });
+
+  it('skips non-UUID filenames', async () => {
+    mockReaddir
+      .mockResolvedValueOnce(['proj'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce(['history.jsonl', 'settings.json', 'notes.jsonl'] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    mockStat.mockResolvedValueOnce(makeStat({ isDirectory: true }));
+
+    const results = await searchSessions('anything');
+    expect(results).toHaveLength(0);
+    // readFile should never be called since all filenames are invalid UUIDs
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it('skips non-directory entries in projects dir', async () => {
+    mockReaddir
+      .mockResolvedValueOnce(['file.json', 'validslug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    // First slug: not a directory
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: false }))
+      // Second slug: is a directory
+      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
+      // File stat for the JSONL
+      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
+
+    const jsonl = makeJsonl([
+      { type: 'user', message: { content: 'find this text' } },
+    ]);
+    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    const results = await searchSessions('find this text');
+    // Only the second slug (directory) should be searched
+    expect(results).toHaveLength(1);
+    expect(results[0].projectSlug).toBe('validslug');
+  });
+
+  it('extracts cwd from first JSONL entry that has cwd field', async () => {
+    const jsonl = makeJsonl([
+      { cwd: '/projects/myapp' },
+      { type: 'user', message: { content: 'deploy the app' } },
+    ]);
+
+    mockReaddir
+      .mockResolvedValueOnce(['slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
+      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
+    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    const results = await searchSessions('deploy');
+    expect(results[0].projectCwd).toBe('/projects/myapp');
+  });
+
+  it('handles content as array of text blocks', async () => {
+    const jsonl = makeJsonl([
+      { cwd: '/repo' },
+      {
+        type: 'user',
+        message: {
+          content: [
+            { type: 'text', text: 'refactor the authentication module' },
+            { type: 'tool_use', id: 'tool1' },
+          ],
+        },
+      },
+    ]);
+
+    mockReaddir
+      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
+      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
+    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    const results = await searchSessions('authentication');
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(100);
+  });
+
+  it('ignores non-user message types', async () => {
+    const jsonl = makeJsonl([
+      { cwd: '/repo' },
+      { type: 'assistant', message: { content: 'xylophone quantum' } },
+      { type: 'system', message: { content: 'xylophone quantum' } },
+      { type: 'user', message: { content: 'completely different text here' } },
+    ]);
+
+    mockReaddir
+      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
+      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
+    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    // 'xylophone quantum' only appears in assistant/system messages, not user
+    const results = await searchSessions('xylophone quantum');
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns zero score and excludes session when query has no match', async () => {
+    const jsonl = makeJsonl([
+      { cwd: '/repo' },
+      { type: 'user', message: { content: 'hello world' } },
+    ]);
+
+    mockReaddir
+      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
+      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
+    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    const results = await searchSessions('zzzzzzzzz');
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns results sorted by score descending', async () => {
+    const uuidHigh = '550e8400-e29b-41d4-a716-446655440001'; // slug-a, exact match
+    const uuidLow  = '550e8400-e29b-41d4-a716-446655440002'; // slug-b, partial match
+    const jsonlHigh = makeJsonl([
+      { cwd: '/a' },
+      { type: 'user', message: { content: 'deploy kubernetes cluster' } },
+    ]);
+    const jsonlLow = makeJsonl([
+      { cwd: '/b' },
+      { type: 'user', message: { content: 'only deploy here nothing else' } },
+    ]);
+
+    mockReaddir
+      .mockResolvedValueOnce(['slug-a', 'slug-b'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${uuidHigh}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>) // slug-a: exact
+      .mockResolvedValueOnce([`${uuidLow}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);  // slug-b: partial
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: true })) // slug-a
+      .mockResolvedValueOnce(makeStat({ mtime: 1 }))          // uuidHigh file
+      .mockResolvedValueOnce(makeStat({ isDirectory: true })) // slug-b
+      .mockResolvedValueOnce(makeStat({ mtime: 2 }));         // uuidLow file
+    mockReadFile
+      .mockResolvedValueOnce(jsonlHigh as unknown as Buffer)
+      .mockResolvedValueOnce(jsonlLow as unknown as Buffer);
+
+    const results = await searchSessions('deploy kubernetes');
+    expect(results[0].cliSessionId).toBe(uuidHigh); // exact match (score 100) first
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+  });
+
+  it('caps results at 20', async () => {
+    const uuids = Array.from({ length: 25 }, (_, i) =>
+      `550e8400-e29b-41d4-a716-${String(i).padStart(12, '0')}`,
+    );
+    const slugs = uuids.map((_, i) => `slug-${i}`);
+
+    mockReaddir.mockResolvedValueOnce(slugs as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    for (let i = 0; i < 25; i++) {
+      mockReaddir.mockResolvedValueOnce([`${uuids[i]}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+      mockStat
+        .mockResolvedValueOnce(makeStat({ isDirectory: true }))
+        .mockResolvedValueOnce(makeStat({ mtime: i }));
+      mockReadFile.mockResolvedValueOnce(
+        makeJsonl([{ type: 'user', message: { content: 'find me please' } }]) as unknown as Buffer,
+      );
+    }
+
+    const results = await searchSessions('find me');
+    expect(results).toHaveLength(20);
+  });
+
+  it('uses cached entry when mtime is unchanged', async () => {
+    const jsonl = makeJsonl([
+      { cwd: '/repo' },
+      { type: 'user', message: { content: 'cached content search' } },
+    ]);
+    const filePath = `/mock/home/.claude/projects/slug/${FAKE_UUID}.jsonl`;
+
+    mockReaddir
+      .mockResolvedValue(['slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    mockReaddir
+      .mockResolvedValueOnce(['slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce(['slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+
+    mockStat
+      .mockResolvedValue(makeStat({ isDirectory: true, mtime: 999 }));
+
+    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    // First search — populates cache
+    await searchSessions('cached content');
+    // Second search — should use cache, not call readFile again
+    await searchSessions('cached content');
+
+    expect(mockReadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-reads file when mtime changes', async () => {
+    const jsonl = makeJsonl([
+      { type: 'user', message: { content: 'updated content search' } },
+    ]);
+
+    mockReaddir
+      .mockResolvedValueOnce(['slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce(['slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
+      .mockResolvedValueOnce(makeStat({ mtime: 100 }))  // first search: mtime=100
+      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
+      .mockResolvedValueOnce(makeStat({ mtime: 200 })); // second search: mtime=200 (changed)
+
+    mockReadFile
+      .mockResolvedValueOnce(jsonl as unknown as Buffer)
+      .mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    await searchSessions('updated content');
+    await searchSessions('updated content');
+
+    expect(mockReadFile).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles malformed JSONL lines gracefully', async () => {
+    const jsonl = 'not json\n{"type":"user","message":{"content":"valid line"}}\n{broken';
+
+    mockReaddir
+      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
+      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
+    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    // Should not throw; should find the valid user message
+    const results = await searchSessions('valid line');
+    expect(results).toHaveLength(1);
+  });
+
+  it('skips slugs when readdir fails', async () => {
+    mockReaddir
+      .mockResolvedValueOnce(['good-slug', 'bad-slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>) // good-slug files
+      .mockRejectedValueOnce(new Error('EACCES'));  // bad-slug readdir fails
+
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: true })) // good-slug
+      .mockResolvedValueOnce(makeStat({ mtime: 1 }));         // file stat
+
+    const jsonl = makeJsonl([{ type: 'user', message: { content: 'searchable text here' } }]);
+    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    const results = await searchSessions('searchable text');
+    expect(results).toHaveLength(1);
+    expect(results[0].projectSlug).toBe('good-slug');
+  });
+
+  it('snippet includes context around the match', async () => {
+    const content = 'A'.repeat(70) + 'needle' + 'B'.repeat(70);
+    const jsonl = makeJsonl([
+      { cwd: '/repo' },
+      { type: 'user', message: { content } },
+    ]);
+
+    mockReaddir
+      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
+      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+    mockStat
+      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
+      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
+    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
+
+    const results = await searchSessions('needle');
+    expect(results[0].snippet).toContain('needle');
+    // Should be truncated with ellipsis since content is longer than snippet window
+    expect(results[0].snippet).toMatch(/\u2026/);
+  });
+});

--- a/src/main/session-deep-search.test.ts
+++ b/src/main/session-deep-search.test.ts
@@ -1,412 +1,207 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { CliProvider, TranscriptDescriptor } from './providers/provider';
+import type { ProviderId } from '../shared/types';
 
 vi.mock('fs', () => ({
   promises: {
-    readFile: vi.fn(),
     stat: vi.fn(),
-    readdir: vi.fn(),
   },
 }));
 
-vi.mock('os', () => ({
-  homedir: () => '/mock/home',
+const providersForTest: CliProvider[] = [];
+vi.mock('./providers/registry', () => ({
+  getAllProviders: () => providersForTest,
 }));
 
 import * as fs from 'fs';
 import { searchSessions, _resetForTesting } from './session-deep-search';
 
-const mockReadFile = vi.mocked(fs.promises.readFile);
 const mockStat = vi.mocked(fs.promises.stat);
-const mockReaddir = vi.mocked(fs.promises.readdir);
 
-const FAKE_UUID = '550e8400-e29b-41d4-a716-446655440000';
-
-function makeStat(opts: { isDirectory?: boolean; mtime?: number } = {}): Awaited<ReturnType<typeof fs.promises.stat>> {
-  return {
-    isDirectory: () => opts.isDirectory ?? false,
-    mtimeMs: opts.mtime ?? 1000,
-  } as Awaited<ReturnType<typeof fs.promises.stat>>;
+function makeStat(mtime: number): Awaited<ReturnType<typeof fs.promises.stat>> {
+  return { mtimeMs: mtime } as Awaited<ReturnType<typeof fs.promises.stat>>;
 }
 
-function makeJsonl(entries: object[]): string {
-  return entries.map(e => JSON.stringify(e)).join('\n');
+interface FakeProviderOpts {
+  id: ProviderId;
+  descriptors?: TranscriptDescriptor[];
+  index?: Record<string, { text: string; cwd: string }>;
+  discoverThrows?: boolean;
+  omitDiscover?: boolean;
+  omitIndex?: boolean;
+}
+
+function fakeProvider(opts: FakeProviderOpts): CliProvider {
+  const provider: Partial<CliProvider> = {
+    meta: { id: opts.id, displayName: opts.id, binaryName: opts.id, capabilities: {} as any, defaultContextWindowSize: 0 },
+  };
+  if (!opts.omitDiscover) {
+    provider.discoverTranscripts = async () => {
+      if (opts.discoverThrows) throw new Error('boom');
+      return opts.descriptors ?? [];
+    };
+  }
+  if (!opts.omitIndex) {
+    provider.indexTranscript = async (p: string) => opts.index?.[p] ?? { text: '', cwd: '' };
+  }
+  return provider as CliProvider;
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   _resetForTesting();
+  providersForTest.length = 0;
 });
 
 describe('searchSessions()', () => {
-  it('returns empty array when projects dir does not exist', async () => {
-    mockReaddir.mockRejectedValueOnce(new Error('ENOENT'));
+  it('returns empty when no providers are registered', async () => {
     expect(await searchSessions('hello')).toEqual([]);
   });
 
-  it('returns empty array when projects dir is empty', async () => {
-    mockReaddir.mockResolvedValueOnce([] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
+  it('returns empty when no providers implement discover/index', async () => {
+    providersForTest.push(fakeProvider({ id: 'claude', omitDiscover: true }));
+    providersForTest.push(fakeProvider({ id: 'codex', omitIndex: true }));
     expect(await searchSessions('hello')).toEqual([]);
   });
 
-  it('finds exact phrase match with score 100', async () => {
-    const slug = 'Users-itay-repo';
-    const jsonl = makeJsonl([
-      { cwd: '/Users/itay/repo' },
-      { type: 'user', message: { content: 'hello world this is a test' } },
-    ]);
-
-    mockReaddir
-      .mockResolvedValueOnce([slug] as unknown as Awaited<ReturnType<typeof mockReaddir>>)   // slugDirs
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);  // files in slug
-    mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: true }))   // slugPath stat
-      .mockResolvedValueOnce(makeStat({ mtime: 1234 }));        // file stat for cache
-    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
-
-    const results = await searchSessions('hello world');
+  it('skips providers whose discoverTranscripts throws', async () => {
+    providersForTest.push(fakeProvider({ id: 'claude', discoverThrows: true }));
+    providersForTest.push(fakeProvider({
+      id: 'codex',
+      descriptors: [{ cliSessionId: 'cx', transcriptPath: '/tx', projectCwd: '/p' }],
+      index: { '/tx': { text: 'find me', cwd: '' } },
+    }));
+    mockStat.mockResolvedValue(makeStat(1));
+    const results = await searchSessions('find me');
     expect(results).toHaveLength(1);
-    expect(results[0].score).toBe(100);
-    expect(results[0].cliSessionId).toBe(FAKE_UUID);
-    expect(results[0].projectCwd).toBe('/Users/itay/repo');
-    expect(results[0].projectSlug).toBe(slug);
-    expect(results[0].snippet).toBeTruthy();
+    expect(results[0].providerId).toBe('codex');
   });
 
-  it('scores all-words match at 80', async () => {
-    const jsonl = makeJsonl([
-      { cwd: '/repo' },
-      { type: 'user', message: { content: 'fix the memory leak in the allocator' } },
-    ]);
-
-    mockReaddir
-      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-    mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
-      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
-    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
-
-    const results = await searchSessions('memory allocator');
-    expect(results).toHaveLength(1);
-    expect(results[0].score).toBe(80);
-  });
-
-  it('scores partial word match proportionally', async () => {
-    const jsonl = makeJsonl([
-      { cwd: '/repo' },
-      { type: 'user', message: { content: 'only memory here nothing else' } },
-    ]);
-
-    mockReaddir
-      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-    mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
-      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
-    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
-
-    const results = await searchSessions('memory allocator');
-    expect(results).toHaveLength(1);
-    // 1/2 words matched → score = round(50 * 1/2) = 25
-    expect(results[0].score).toBe(25);
-  });
-
-  it('skips non-UUID filenames', async () => {
-    mockReaddir
-      .mockResolvedValueOnce(['proj'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce(['history.jsonl', 'settings.json', 'notes.jsonl'] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-    mockStat.mockResolvedValueOnce(makeStat({ isDirectory: true }));
-
-    const results = await searchSessions('anything');
-    expect(results).toHaveLength(0);
-    // readFile should never be called since all filenames are invalid UUIDs
-    expect(mockReadFile).not.toHaveBeenCalled();
-  });
-
-  it('skips non-directory entries in projects dir', async () => {
-    mockReaddir
-      .mockResolvedValueOnce(['file.json', 'validslug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-    // First slug: not a directory
-    mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: false }))
-      // Second slug: is a directory
-      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
-      // File stat for the JSONL
-      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
-
-    const jsonl = makeJsonl([
-      { type: 'user', message: { content: 'find this text' } },
-    ]);
-    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
-
-    const results = await searchSessions('find this text');
-    // Only the second slug (directory) should be searched
-    expect(results).toHaveLength(1);
-    expect(results[0].projectSlug).toBe('validslug');
-  });
-
-  it('extracts cwd from first JSONL entry that has cwd field', async () => {
-    const jsonl = makeJsonl([
-      { cwd: '/projects/myapp' },
-      { type: 'user', message: { content: 'deploy the app' } },
-    ]);
-
-    mockReaddir
-      .mockResolvedValueOnce(['slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-    mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
-      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
-    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
-
-    const results = await searchSessions('deploy');
-    expect(results[0].projectCwd).toBe('/projects/myapp');
-  });
-
-  it('handles content as array of text blocks', async () => {
-    const jsonl = makeJsonl([
-      { cwd: '/repo' },
-      {
-        type: 'user',
-        message: {
-          content: [
-            { type: 'text', text: 'refactor the authentication module' },
-            { type: 'tool_use', id: 'tool1' },
-          ],
-        },
-      },
-    ]);
-
-    mockReaddir
-      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-    mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
-      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
-    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
-
-    const results = await searchSessions('authentication');
-    expect(results).toHaveLength(1);
-    expect(results[0].score).toBe(100);
-  });
-
-  it('ignores non-user message types', async () => {
-    const jsonl = makeJsonl([
-      { cwd: '/repo' },
-      { type: 'assistant', message: { content: 'xylophone quantum' } },
-      { type: 'system', message: { content: 'xylophone quantum' } },
-      { type: 'user', message: { content: 'completely different text here' } },
-    ]);
-
-    mockReaddir
-      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-    mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
-      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
-    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
-
-    // 'xylophone quantum' only appears in assistant/system messages, not user
-    const results = await searchSessions('xylophone quantum');
-    expect(results).toHaveLength(0);
-  });
-
-  it('gibberish query returns no results even when chars appear as subsequence', async () => {
-    // "asdcv" chars all appear in long English text as a subsequence — should NOT match
-    const jsonl = makeJsonl([
-      { cwd: '/repo' },
-      { type: 'user', message: { content: 'please add some documentation and cover all cases very well' } },
-    ]);
-
-    mockReaddir
-      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-    mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
-      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
-    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
-
-    const results = await searchSessions('asdcv');
-    expect(results).toHaveLength(0);
-  });
-
-  it('returns zero score and excludes session when query has no match', async () => {
-    const jsonl = makeJsonl([
-      { cwd: '/repo' },
-      { type: 'user', message: { content: 'hello world' } },
-    ]);
-
-    mockReaddir
-      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-    mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
-      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
-    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
-
-    const results = await searchSessions('zzzzzzzzz');
-    expect(results).toHaveLength(0);
-  });
-
-  it('returns results sorted by score descending', async () => {
-    const uuidHigh = '550e8400-e29b-41d4-a716-446655440001'; // slug-a, exact match
-    const uuidLow  = '550e8400-e29b-41d4-a716-446655440002'; // slug-b, partial match
-    const jsonlHigh = makeJsonl([
-      { cwd: '/a' },
-      { type: 'user', message: { content: 'deploy kubernetes cluster' } },
-    ]);
-    const jsonlLow = makeJsonl([
-      { cwd: '/b' },
-      { type: 'user', message: { content: 'only deploy here nothing else' } },
-    ]);
-
-    mockReaddir
-      .mockResolvedValueOnce(['slug-a', 'slug-b'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${uuidHigh}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>) // slug-a: exact
-      .mockResolvedValueOnce([`${uuidLow}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);  // slug-b: partial
-    mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: true })) // slug-a
-      .mockResolvedValueOnce(makeStat({ mtime: 1 }))          // uuidHigh file
-      .mockResolvedValueOnce(makeStat({ isDirectory: true })) // slug-b
-      .mockResolvedValueOnce(makeStat({ mtime: 2 }));         // uuidLow file
-    mockReadFile
-      .mockResolvedValueOnce(jsonlHigh as unknown as Buffer)
-      .mockResolvedValueOnce(jsonlLow as unknown as Buffer);
+  it('stamps providerId on each result and sorts merged hits by score desc', async () => {
+    providersForTest.push(fakeProvider({
+      id: 'claude',
+      descriptors: [{ cliSessionId: 'cl-1', transcriptPath: '/cl-1', projectSlug: 'cl-slug' }],
+      index: { '/cl-1': { text: 'only deploy here nothing else', cwd: '/a' } }, // partial → 25
+    }));
+    providersForTest.push(fakeProvider({
+      id: 'codex',
+      descriptors: [{ cliSessionId: 'cx-1', transcriptPath: '/cx-1', projectCwd: '/b' }],
+      index: { '/cx-1': { text: 'deploy kubernetes cluster', cwd: '' } }, // exact → 100
+    }));
+    mockStat.mockResolvedValue(makeStat(1));
 
     const results = await searchSessions('deploy kubernetes');
-    expect(results[0].cliSessionId).toBe(uuidHigh); // exact match (score 100) first
-    expect(results[0].score).toBeGreaterThan(results[1].score);
+    expect(results.map(r => r.providerId)).toEqual(['codex', 'claude']);
+    expect(results[0].score).toBe(100);
+    expect(results[0].cliSessionId).toBe('cx-1');
+    expect(results[0].projectCwd).toBe('/b');
+    expect(results[1].score).toBe(25);
+    expect(results[1].projectCwd).toBe('/a');
+    expect(results[1].projectSlug).toBe('cl-slug');
   });
 
-  it('caps results at 20', async () => {
-    const uuids = Array.from({ length: 25 }, (_, i) =>
-      `550e8400-e29b-41d4-a716-${String(i).padStart(12, '0')}`,
-    );
-    const slugs = uuids.map((_, i) => `slug-${i}`);
+  it('prefers descriptor.projectCwd over indexed cwd when both present', async () => {
+    providersForTest.push(fakeProvider({
+      id: 'gemini',
+      descriptors: [{ cliSessionId: 'g1', transcriptPath: '/g', projectCwd: '/from-descriptor' }],
+      index: { '/g': { text: 'searchable hit', cwd: '/from-index' } },
+    }));
+    mockStat.mockResolvedValue(makeStat(1));
+    const results = await searchSessions('searchable hit');
+    expect(results[0].projectCwd).toBe('/from-descriptor');
+  });
 
-    mockReaddir.mockResolvedValueOnce(slugs as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-    for (let i = 0; i < 25; i++) {
-      mockReaddir.mockResolvedValueOnce([`${uuids[i]}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-      mockStat
-        .mockResolvedValueOnce(makeStat({ isDirectory: true }))
-        .mockResolvedValueOnce(makeStat({ mtime: i }));
-      mockReadFile.mockResolvedValueOnce(
-        makeJsonl([{ type: 'user', message: { content: 'find me please' } }]) as unknown as Buffer,
-      );
+  it('falls back to indexed cwd when descriptor has none', async () => {
+    providersForTest.push(fakeProvider({
+      id: 'claude',
+      descriptors: [{ cliSessionId: 'c1', transcriptPath: '/c' }],
+      index: { '/c': { text: 'searchable hit', cwd: '/from-index' } },
+    }));
+    mockStat.mockResolvedValue(makeStat(1));
+    const results = await searchSessions('searchable hit');
+    expect(results[0].projectCwd).toBe('/from-index');
+  });
+
+  it('caps results at 20 across all providers', async () => {
+    const desc = (i: number): TranscriptDescriptor => ({ cliSessionId: `s${i}`, transcriptPath: `/p${i}` });
+    const idx: Record<string, { text: string; cwd: string }> = {};
+    const descsA: TranscriptDescriptor[] = [];
+    const descsB: TranscriptDescriptor[] = [];
+    for (let i = 0; i < 15; i++) {
+      descsA.push(desc(i));
+      idx[`/p${i}`] = { text: 'find me please', cwd: '' };
     }
-
-    const results = await searchSessions('find me');
-    expect(results).toHaveLength(20);
+    for (let i = 15; i < 30; i++) {
+      descsB.push(desc(i));
+      idx[`/p${i}`] = { text: 'find me please', cwd: '' };
+    }
+    providersForTest.push(fakeProvider({ id: 'claude', descriptors: descsA, index: idx }));
+    providersForTest.push(fakeProvider({ id: 'codex', descriptors: descsB, index: idx }));
+    mockStat.mockResolvedValue(makeStat(1));
+    expect(await searchSessions('find me')).toHaveLength(20);
   });
 
-  it('uses cached entry when mtime is unchanged', async () => {
-    const jsonl = makeJsonl([
-      { cwd: '/repo' },
-      { type: 'user', message: { content: 'cached content search' } },
-    ]);
-    const filePath = `/mock/home/.claude/projects/slug/${FAKE_UUID}.jsonl`;
+  it('caches indexed text by mtime and avoids re-indexing on second search', async () => {
+    const indexSpy = vi.fn(async () => ({ text: 'cached body content', cwd: '/x' }));
+    const provider: CliProvider = {
+      meta: { id: 'claude', displayName: 'c', binaryName: 'c', capabilities: {} as any, defaultContextWindowSize: 0 },
+      discoverTranscripts: async () => [{ cliSessionId: 'a', transcriptPath: '/a' }],
+      indexTranscript: indexSpy,
+    } as CliProvider;
+    providersForTest.push(provider);
+    mockStat.mockResolvedValue(makeStat(42));
 
-    mockReaddir
-      .mockResolvedValue(['slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-    mockReaddir
-      .mockResolvedValueOnce(['slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce(['slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-
-    mockStat
-      .mockResolvedValue(makeStat({ isDirectory: true, mtime: 999 }));
-
-    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
-
-    // First search — populates cache
-    await searchSessions('cached content');
-    // Second search — should use cache, not call readFile again
-    await searchSessions('cached content');
-
-    expect(mockReadFile).toHaveBeenCalledTimes(1);
+    await searchSessions('cached body');
+    await searchSessions('cached body');
+    expect(indexSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('re-reads file when mtime changes', async () => {
-    const jsonl = makeJsonl([
-      { type: 'user', message: { content: 'updated content search' } },
-    ]);
-
-    mockReaddir
-      .mockResolvedValueOnce(['slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce(['slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-
+  it('re-indexes when mtime changes', async () => {
+    const indexSpy = vi.fn(async () => ({ text: 'updated body content', cwd: '/x' }));
+    const provider: CliProvider = {
+      meta: { id: 'claude', displayName: 'c', binaryName: 'c', capabilities: {} as any, defaultContextWindowSize: 0 },
+      discoverTranscripts: async () => [{ cliSessionId: 'a', transcriptPath: '/a' }],
+      indexTranscript: indexSpy,
+    } as CliProvider;
+    providersForTest.push(provider);
     mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
-      .mockResolvedValueOnce(makeStat({ mtime: 100 }))  // first search: mtime=100
-      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
-      .mockResolvedValueOnce(makeStat({ mtime: 200 })); // second search: mtime=200 (changed)
-
-    mockReadFile
-      .mockResolvedValueOnce(jsonl as unknown as Buffer)
-      .mockResolvedValueOnce(jsonl as unknown as Buffer);
-
-    await searchSessions('updated content');
-    await searchSessions('updated content');
-
-    expect(mockReadFile).toHaveBeenCalledTimes(2);
+      .mockResolvedValueOnce(makeStat(100))
+      .mockResolvedValueOnce(makeStat(200));
+    await searchSessions('updated body');
+    await searchSessions('updated body');
+    expect(indexSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('handles malformed JSONL lines gracefully', async () => {
-    const jsonl = 'not json\n{"type":"user","message":{"content":"valid line"}}\n{broken';
-
-    mockReaddir
-      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-    mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
-      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
-    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
-
-    // Should not throw; should find the valid user message
-    const results = await searchSessions('valid line');
-    expect(results).toHaveLength(1);
-  });
-
-  it('skips slugs when readdir fails', async () => {
-    mockReaddir
-      .mockResolvedValueOnce(['good-slug', 'bad-slug'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>) // good-slug files
-      .mockRejectedValueOnce(new Error('EACCES'));  // bad-slug readdir fails
-
-    mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: true })) // good-slug
-      .mockResolvedValueOnce(makeStat({ mtime: 1 }));         // file stat
-
-    const jsonl = makeJsonl([{ type: 'user', message: { content: 'searchable text here' } }]);
-    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
-
-    const results = await searchSessions('searchable text');
-    expect(results).toHaveLength(1);
-    expect(results[0].projectSlug).toBe('good-slug');
+  it('drops zero-score sessions', async () => {
+    providersForTest.push(fakeProvider({
+      id: 'claude',
+      descriptors: [{ cliSessionId: 'a', transcriptPath: '/a' }],
+      index: { '/a': { text: 'completely unrelated content', cwd: '' } },
+    }));
+    mockStat.mockResolvedValue(makeStat(1));
+    expect(await searchSessions('zzz qqq')).toEqual([]);
   });
 
   it('snippet includes context around the match', async () => {
     const content = 'A'.repeat(70) + 'needle' + 'B'.repeat(70);
-    const jsonl = makeJsonl([
-      { cwd: '/repo' },
-      { type: 'user', message: { content } },
-    ]);
-
-    mockReaddir
-      .mockResolvedValueOnce(['repo'] as unknown as Awaited<ReturnType<typeof mockReaddir>>)
-      .mockResolvedValueOnce([`${FAKE_UUID}.jsonl`] as unknown as Awaited<ReturnType<typeof mockReaddir>>);
-    mockStat
-      .mockResolvedValueOnce(makeStat({ isDirectory: true }))
-      .mockResolvedValueOnce(makeStat({ mtime: 1 }));
-    mockReadFile.mockResolvedValueOnce(jsonl as unknown as Buffer);
-
+    providersForTest.push(fakeProvider({
+      id: 'claude',
+      descriptors: [{ cliSessionId: 'a', transcriptPath: '/a' }],
+      index: { '/a': { text: content, cwd: '/repo' } },
+    }));
+    mockStat.mockResolvedValue(makeStat(1));
     const results = await searchSessions('needle');
     expect(results[0].snippet).toContain('needle');
-    // Should be truncated with ellipsis since content is longer than snippet window
-    expect(results[0].snippet).toMatch(/\u2026/);
+    expect(results[0].snippet).toMatch(/…/);
+  });
+
+  it('gibberish query returns no results', async () => {
+    providersForTest.push(fakeProvider({
+      id: 'claude',
+      descriptors: [{ cliSessionId: 'a', transcriptPath: '/a' }],
+      index: { '/a': { text: 'please add some documentation and cover all cases very well', cwd: '' } },
+    }));
+    mockStat.mockResolvedValue(makeStat(1));
+    expect(await searchSessions('asdcv')).toEqual([]);
   });
 });

--- a/src/main/session-deep-search.ts
+++ b/src/main/session-deep-search.ts
@@ -80,18 +80,10 @@ function scoreFuzzy(text: string, query: string): number {
   if (t.includes(q)) return 100;
 
   const words = q.split(/\s+/).filter(Boolean);
-  if (words.length > 1) {
-    const matched = words.filter(w => t.includes(w));
-    if (matched.length === words.length) return 80;
-    if (matched.length > 0) return Math.round((matched.length / words.length) * 50);
-  }
-
-  // char subsequence fallback
-  let qi = 0;
-  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
-    if (t[ti] === q[qi]) qi++;
-  }
-  return qi === q.length ? 10 : 0;
+  const matched = words.filter(w => t.includes(w));
+  if (matched.length === words.length) return 80;
+  if (matched.length > 0) return Math.round((matched.length / words.length) * 50);
+  return 0;
 }
 
 function extractSnippet(text: string, query: string): string {

--- a/src/main/session-deep-search.ts
+++ b/src/main/session-deep-search.ts
@@ -1,14 +1,13 @@
 import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
 import type { DeepSearchResult } from '../shared/types';
+import type { CliProvider, TranscriptDescriptor } from './providers/provider';
+import { getAllProviders } from './providers/registry';
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const MAX_CHARS_PER_SESSION = 50 * 1024;
 const MAX_CACHE_ENTRIES = 500;
 
 interface CacheEntry {
   text: string;
+  textLower: string;
   cwd: string;
   mtime: number;
 }
@@ -19,80 +18,50 @@ export function _resetForTesting(): void {
   textCache.clear();
 }
 
-async function extractSessionText(jsonlPath: string): Promise<{ text: string; cwd: string }> {
-  const content = await fs.promises.readFile(jsonlPath, 'utf8');
-  const texts: string[] = [];
-  let cwd = '';
-  let totalChars = 0;
-
-  for (const line of content.split('\n')) {
-    if (!line.trim() || totalChars >= MAX_CHARS_PER_SESSION) continue;
-    try {
-      const entry = JSON.parse(line);
-      if (!cwd && entry.cwd) cwd = entry.cwd;
-      if (entry.type !== 'user' || !entry.message?.content) continue;
-      const c = entry.message.content;
-      let text = '';
-      if (typeof c === 'string') {
-        text = c;
-      } else if (Array.isArray(c)) {
-        for (const block of c) {
-          if (block.type === 'text') text += block.text + '\n';
-        }
-      }
-      if (text) {
-        texts.push(text.trim());
-        totalChars += text.length;
-      }
-    } catch {
-      // JSONL entries can be partially written on crash; skip gracefully
-    }
-  }
-
-  return { text: texts.join('\n---\n'), cwd };
-}
-
-async function getCachedEntry(jsonlPath: string): Promise<CacheEntry> {
+async function getCachedIndex(provider: CliProvider, transcriptPath: string): Promise<CacheEntry> {
   try {
-    const stat = await fs.promises.stat(jsonlPath);
+    const stat = await fs.promises.stat(transcriptPath);
     const mtime = stat.mtimeMs;
-    const cached = textCache.get(jsonlPath);
-    if (cached && cached.mtime === mtime) return cached;
+    const cached = textCache.get(transcriptPath);
+    if (cached && cached.mtime === mtime) {
+      // Move-to-end for true LRU semantics on cache hits.
+      textCache.delete(transcriptPath);
+      textCache.set(transcriptPath, cached);
+      return cached;
+    }
 
     if (textCache.size >= MAX_CACHE_ENTRIES) {
       const oldest = textCache.keys().next().value;
       if (oldest) textCache.delete(oldest);
     }
 
-    const { text, cwd } = await extractSessionText(jsonlPath);
-    const entry: CacheEntry = { text, cwd, mtime };
-    textCache.set(jsonlPath, entry);
+    const { text, cwd } = await provider.indexTranscript!(transcriptPath);
+    const entry: CacheEntry = { text, textLower: text.toLowerCase(), cwd, mtime };
+    textCache.set(transcriptPath, entry);
     return entry;
   } catch {
-    return { text: '', cwd: '', mtime: 0 };
+    return { text: '', textLower: '', cwd: '', mtime: 0 };
   }
 }
 
-function scoreFuzzy(text: string, query: string): number {
-  const t = text.toLowerCase();
+function scoreFuzzy(textLower: string, query: string): number {
   const q = query.toLowerCase().trim();
   if (!q) return 0;
-  if (t.includes(q)) return 100;
+  if (textLower.includes(q)) return 100;
 
   const words = q.split(/\s+/).filter(Boolean);
-  const matched = words.filter(w => t.includes(w));
+  const matched = words.filter(w => textLower.includes(w));
   if (matched.length === words.length) return 80;
   if (matched.length > 0) return Math.round((matched.length / words.length) * 50);
   return 0;
 }
 
-function extractSnippet(text: string, query: string): string {
+function extractSnippet(text: string, textLower: string, query: string): string {
   const q = query.toLowerCase().trim();
-  const t = text.toLowerCase();
-  let idx = t.indexOf(q);
+  let idx = textLower.indexOf(q);
   if (idx === -1) {
     const firstWord = q.split(/\s+/)[0];
-    idx = firstWord ? t.indexOf(firstWord) : -1;
+    idx = firstWord ? textLower.indexOf(firstWord) : -1;
   }
   if (idx === -1) idx = 0;
 
@@ -100,59 +69,43 @@ function extractSnippet(text: string, query: string): string {
   const start = Math.max(0, idx - RADIUS);
   const end = Math.min(text.length, idx + q.length + RADIUS);
   let snippet = text.slice(start, end).replace(/\n+/g, ' ').trim();
-  if (start > 0) snippet = '\u2026' + snippet;
-  if (end < text.length) snippet = snippet + '\u2026';
+  if (start > 0) snippet = '…' + snippet;
+  if (end < text.length) snippet = snippet + '…';
   return snippet;
 }
 
-export async function searchSessions(query: string): Promise<DeepSearchResult[]> {
-  const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects');
-
-  let slugDirs: string[];
+async function searchOneProvider(provider: CliProvider, query: string): Promise<DeepSearchResult[]> {
+  if (!provider.discoverTranscripts || !provider.indexTranscript) return [];
+  let descriptors: TranscriptDescriptor[];
   try {
-    slugDirs = await fs.promises.readdir(claudeProjectsDir);
+    descriptors = await provider.discoverTranscripts();
   } catch {
     return [];
   }
-
-  const results: DeepSearchResult[] = [];
-
-  for (const slug of slugDirs) {
-    const slugPath = path.join(claudeProjectsDir, slug);
-    try {
-      if (!(await fs.promises.stat(slugPath)).isDirectory()) continue;
-    } catch {
-      continue;
-    }
-
-    let files: string[];
-    try {
-      files = await fs.promises.readdir(slugPath);
-    } catch {
-      continue;
-    }
-
-    for (const file of files) {
-      if (!file.endsWith('.jsonl')) continue;
-      const cliSessionId = file.slice(0, -6);
-      if (!UUID_RE.test(cliSessionId)) continue;
-
-      const entry = await getCachedEntry(path.join(slugPath, file));
-      if (!entry.text) continue;
-
-      const score = scoreFuzzy(entry.text, query);
-      if (score === 0) continue;
-
-      results.push({
-        cliSessionId,
-        projectSlug: slug,
-        projectCwd: entry.cwd,
-        snippet: extractSnippet(entry.text, query),
-        score,
-      });
-    }
+  const indexed = await Promise.all(descriptors.map(async (desc) => {
+    const entry = await getCachedIndex(provider, desc.transcriptPath);
+    return { desc, entry };
+  }));
+  const out: DeepSearchResult[] = [];
+  for (const { desc, entry } of indexed) {
+    if (!entry.textLower) continue;
+    const score = scoreFuzzy(entry.textLower, query);
+    if (score === 0) continue;
+    out.push({
+      providerId: provider.meta.id,
+      cliSessionId: desc.cliSessionId,
+      projectSlug: desc.projectSlug ?? '',
+      projectCwd: desc.projectCwd || entry.cwd,
+      snippet: extractSnippet(entry.text, entry.textLower, query),
+      score,
+    });
   }
+  return out;
+}
 
+export async function searchSessions(query: string): Promise<DeepSearchResult[]> {
+  const all = await Promise.all(getAllProviders().map((p) => searchOneProvider(p, query)));
+  const results = all.flat();
   results.sort((a, b) => b.score - a.score);
   return results.slice(0, 20);
 }

--- a/src/main/session-deep-search.ts
+++ b/src/main/session-deep-search.ts
@@ -15,6 +15,10 @@ interface CacheEntry {
 
 const textCache = new Map<string, CacheEntry>();
 
+export function _resetForTesting(): void {
+  textCache.clear();
+}
+
 async function extractSessionText(jsonlPath: string): Promise<{ text: string; cwd: string }> {
   const content = await fs.promises.readFile(jsonlPath, 'utf8');
   const texts: string[] = [];

--- a/src/main/session-deep-search.ts
+++ b/src/main/session-deep-search.ts
@@ -1,0 +1,162 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import type { DeepSearchResult } from '../shared/types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_CHARS_PER_SESSION = 50 * 1024;
+const MAX_CACHE_ENTRIES = 500;
+
+interface CacheEntry {
+  text: string;
+  cwd: string;
+  mtime: number;
+}
+
+const textCache = new Map<string, CacheEntry>();
+
+async function extractSessionText(jsonlPath: string): Promise<{ text: string; cwd: string }> {
+  const content = await fs.promises.readFile(jsonlPath, 'utf8');
+  const texts: string[] = [];
+  let cwd = '';
+  let totalChars = 0;
+
+  for (const line of content.split('\n')) {
+    if (!line.trim() || totalChars >= MAX_CHARS_PER_SESSION) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (!cwd && entry.cwd) cwd = entry.cwd;
+      if (entry.type !== 'user' || !entry.message?.content) continue;
+      const c = entry.message.content;
+      let text = '';
+      if (typeof c === 'string') {
+        text = c;
+      } else if (Array.isArray(c)) {
+        for (const block of c) {
+          if (block.type === 'text') text += block.text + '\n';
+        }
+      }
+      if (text) {
+        texts.push(text.trim());
+        totalChars += text.length;
+      }
+    } catch {
+      // JSONL entries can be partially written on crash; skip gracefully
+    }
+  }
+
+  return { text: texts.join('\n---\n'), cwd };
+}
+
+async function getCachedEntry(jsonlPath: string): Promise<CacheEntry> {
+  try {
+    const stat = await fs.promises.stat(jsonlPath);
+    const mtime = stat.mtimeMs;
+    const cached = textCache.get(jsonlPath);
+    if (cached && cached.mtime === mtime) return cached;
+
+    if (textCache.size >= MAX_CACHE_ENTRIES) {
+      const oldest = textCache.keys().next().value;
+      if (oldest) textCache.delete(oldest);
+    }
+
+    const { text, cwd } = await extractSessionText(jsonlPath);
+    const entry: CacheEntry = { text, cwd, mtime };
+    textCache.set(jsonlPath, entry);
+    return entry;
+  } catch {
+    return { text: '', cwd: '', mtime: 0 };
+  }
+}
+
+function scoreFuzzy(text: string, query: string): number {
+  const t = text.toLowerCase();
+  const q = query.toLowerCase().trim();
+  if (!q) return 0;
+  if (t.includes(q)) return 100;
+
+  const words = q.split(/\s+/).filter(Boolean);
+  if (words.length > 1) {
+    const matched = words.filter(w => t.includes(w));
+    if (matched.length === words.length) return 80;
+    if (matched.length > 0) return Math.round((matched.length / words.length) * 50);
+  }
+
+  // char subsequence fallback
+  let qi = 0;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) qi++;
+  }
+  return qi === q.length ? 10 : 0;
+}
+
+function extractSnippet(text: string, query: string): string {
+  const q = query.toLowerCase().trim();
+  const t = text.toLowerCase();
+  let idx = t.indexOf(q);
+  if (idx === -1) {
+    const firstWord = q.split(/\s+/)[0];
+    idx = firstWord ? t.indexOf(firstWord) : -1;
+  }
+  if (idx === -1) idx = 0;
+
+  const RADIUS = 60;
+  const start = Math.max(0, idx - RADIUS);
+  const end = Math.min(text.length, idx + q.length + RADIUS);
+  let snippet = text.slice(start, end).replace(/\n+/g, ' ').trim();
+  if (start > 0) snippet = '\u2026' + snippet;
+  if (end < text.length) snippet = snippet + '\u2026';
+  return snippet;
+}
+
+export async function searchSessions(query: string): Promise<DeepSearchResult[]> {
+  const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects');
+
+  let slugDirs: string[];
+  try {
+    slugDirs = await fs.promises.readdir(claudeProjectsDir);
+  } catch {
+    return [];
+  }
+
+  const results: DeepSearchResult[] = [];
+
+  for (const slug of slugDirs) {
+    const slugPath = path.join(claudeProjectsDir, slug);
+    try {
+      if (!(await fs.promises.stat(slugPath)).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    let files: string[];
+    try {
+      files = await fs.promises.readdir(slugPath);
+    } catch {
+      continue;
+    }
+
+    for (const file of files) {
+      if (!file.endsWith('.jsonl')) continue;
+      const cliSessionId = file.slice(0, -6);
+      if (!UUID_RE.test(cliSessionId)) continue;
+
+      const entry = await getCachedEntry(path.join(slugPath, file));
+      if (!entry.text) continue;
+
+      const score = scoreFuzzy(entry.text, query);
+      if (score === 0) continue;
+
+      results.push({
+        cliSessionId,
+        projectSlug: slug,
+        projectCwd: entry.cwd,
+        snippet: extractSnippet(entry.text, query),
+        score,
+      });
+    }
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results.slice(0, 20);
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer, webFrame } from 'electron';
-import type { CostData, ProviderId, CliProviderMeta, StatsCache, ReadinessResult, ToolFailureData, SettingsWarningData, SettingsValidationResult, StatusLineConflictData, InspectorEvent, ProviderConfig, ReadFileResult } from '../shared/types';
+import type { CostData, ProviderId, CliProviderMeta, StatsCache, ReadinessResult, ToolFailureData, SettingsWarningData, SettingsValidationResult, StatusLineConflictData, InspectorEvent, ProviderConfig, ReadFileResult, DeepSearchResult } from '../shared/types';
 import { ZOOM_MIN, ZOOM_MAX } from '../shared/types';
 
 export type { CostData } from '../shared/types';
@@ -17,6 +17,7 @@ export interface VibeyardApi {
   };
   session: {
     buildResumeWithPrompt(sourceProviderId: ProviderId, sourceCliSessionId: string | null, projectPath: string, sessionName: string): Promise<string>;
+    deepSearch(query: string): Promise<DeepSearchResult[]>;
     onHookStatus(callback: (sessionId: string, status: 'working' | 'waiting' | 'completed' | 'input', hookName: string) => void): () => void;
     onCliSessionId(callback: (sessionId: string, cliSessionId: string) => void): () => void;
     /** @deprecated Use onCliSessionId instead */
@@ -166,6 +167,8 @@ const api: VibeyardApi = {
   session: {
     buildResumeWithPrompt: (sourceProviderId, sourceCliSessionId, projectPath, sessionName) =>
       ipcRenderer.invoke('session:buildResumeWithPrompt', sourceProviderId, sourceCliSessionId, projectPath, sessionName),
+    deepSearch: (query) =>
+      ipcRenderer.invoke('session:deepSearch', query),
     onHookStatus: (callback) =>
       onChannel('session:hookStatus', (sessionId, status, hookName) =>
         callback(sessionId as string, status as 'working' | 'waiting' | 'completed' | 'input', (hookName as string) || '')),

--- a/src/renderer/components/dom-search-backend.ts
+++ b/src/renderer/components/dom-search-backend.ts
@@ -10,7 +10,7 @@ export function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-function escapeRegExp(s: string): string {
+export function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 

--- a/src/renderer/components/session-search-palette.test.ts
+++ b/src/renderer/components/session-search-palette.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../state.js', () => ({ appState: {} }));
+
+import { highlightMatches } from './session-search-palette.js';
+
+describe('highlightMatches', () => {
+  it('returns escaped text when query is empty', () => {
+    expect(highlightMatches('hello <world>', '')).toBe('hello &lt;world&gt;');
+    expect(highlightMatches('plain', '   ')).toBe('plain');
+  });
+
+  it('wraps a single-word match (case-insensitive)', () => {
+    expect(highlightMatches('Hello world', 'hello'))
+      .toBe('<mark class="search-match">Hello</mark> world');
+  });
+
+  it('highlights every occurrence of a multi-word query', () => {
+    const out = highlightMatches('claude code is fun. claude rocks. just code.', 'claude code');
+    expect(out).toBe(
+      '<mark class="search-match">claude code</mark> is fun. ' +
+      '<mark class="search-match">claude</mark> rocks. just ' +
+      '<mark class="search-match">code</mark>.',
+    );
+  });
+
+  it('treats regex metacharacters as literals', () => {
+    expect(highlightMatches('call foo(bar) and foo.bar', 'foo(bar)'))
+      .toBe('call <mark class="search-match">foo(bar)</mark> and foo.bar');
+    expect(() => highlightMatches('anything', '.*')).not.toThrow();
+    expect(highlightMatches('a.*b plain', '.*'))
+      .toBe('a<mark class="search-match">.*</mark>b plain');
+  });
+
+  it('returns just the escaped text when nothing matches', () => {
+    expect(highlightMatches('nothing here & <ok>', 'zzz'))
+      .toBe('nothing here &amp; &lt;ok&gt;');
+  });
+
+  it('escapes HTML in both matched and unmatched segments', () => {
+    expect(highlightMatches('<script>alert("x")</script>', 'script'))
+      .toBe('&lt;<mark class="search-match">script</mark>&gt;alert(&quot;x&quot;)&lt;/<mark class="search-match">script</mark>&gt;');
+  });
+});

--- a/src/renderer/components/session-search-palette.ts
+++ b/src/renderer/components/session-search-palette.ts
@@ -1,10 +1,29 @@
 import { appState } from '../state.js';
+import { escapeHtml, escapeRegExp } from './dom-search-backend.js';
 import type { DeepSearchResult } from '../../shared/types.js';
 
 interface ResolvedResult extends DeepSearchResult {
   sessionName: string | null;
   projectId: string | null;
   archivedId: string | null;
+}
+
+export function highlightMatches(text: string, query: string): string {
+  const q = query.trim();
+  if (!q) return escapeHtml(text);
+  const tokens = Array.from(new Set([q, ...q.split(/\s+/)])).filter(Boolean);
+  tokens.sort((a, b) => b.length - a.length);
+  const re = new RegExp(tokens.map(escapeRegExp).join('|'), 'gi');
+  let html = '';
+  let pos = 0;
+  for (const m of text.matchAll(re)) {
+    const start = m.index!;
+    html += escapeHtml(text.slice(pos, start));
+    html += `<mark class="search-match">${escapeHtml(m[0])}</mark>`;
+    pos = start + m[0].length;
+  }
+  html += escapeHtml(text.slice(pos));
+  return html;
 }
 
 let overlay: HTMLElement | null = null;
@@ -127,6 +146,7 @@ function renderResults(): void {
   }
 
   const activeProjectId = appState.activeProject?.id;
+  const query = input?.value.trim() ?? '';
   for (let i = 0; i < resolvedResults.length; i++) {
     const r = resolvedResults[i];
     const isCurrentProject = r.projectId === activeProjectId;
@@ -156,7 +176,7 @@ function renderResults(): void {
 
     const snippet = document.createElement('div');
     snippet.className = 'session-palette-item-snippet';
-    snippet.textContent = r.snippet;
+    snippet.innerHTML = highlightMatches(r.snippet, query);
 
     item.appendChild(nameRow);
     item.appendChild(meta);

--- a/src/renderer/components/session-search-palette.ts
+++ b/src/renderer/components/session-search-palette.ts
@@ -150,11 +150,15 @@ function renderResults(): void {
     return;
   }
 
-  const activeProjectId = appState.activeProject?.id;
+  const activeProject = appState.activeProject;
+  const activeProjectId = activeProject?.id;
+  const activeProjectPath = activeProject?.path;
   const query = input?.value.trim() ?? '';
   for (let i = 0; i < resolvedResults.length; i++) {
     const r = resolvedResults[i];
-    const isCurrentProject = r.projectId === activeProjectId;
+    const isCurrentProject =
+      r.projectId === activeProjectId ||
+      (!!activeProjectPath && r.projectCwd === activeProjectPath);
 
     const item = document.createElement('div');
     item.className = 'session-palette-item';

--- a/src/renderer/components/session-search-palette.ts
+++ b/src/renderer/components/session-search-palette.ts
@@ -32,6 +32,7 @@ let resultsList: HTMLElement | null = null;
 let activeIndex = 0;
 let resolvedResults: ResolvedResult[] = [];
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let latestSearchToken = 0;
 
 function buildSessionMap(): Map<string, { projectId: string; archivedId: string; name: string }> {
   const map = new Map<string, { projectId: string; archivedId: string; name: string }>();
@@ -103,6 +104,7 @@ function onInput(): void {
 async function searchSessions(): Promise<void> {
   if (!input || !resultsList) return;
   const query = input.value.trim();
+  const myToken = ++latestSearchToken;
   if (query.length < 2) {
     resolvedResults = [];
     renderResults();
@@ -121,6 +123,8 @@ async function searchSessions(): Promise<void> {
   } catch {
     raw = [];
   }
+
+  if (myToken !== latestSearchToken) return;
 
   const sessionMap = buildSessionMap();
   resolvedResults = raw.map(r => {
@@ -232,6 +236,7 @@ export function showSessionSearchPalette(): void {
   input.value = '';
   resolvedResults = [];
   activeIndex = 0;
+  latestSearchToken++;
   renderResults();
   input.focus();
 }
@@ -239,4 +244,5 @@ export function showSessionSearchPalette(): void {
 function hidePalette(): void {
   if (overlay) overlay.style.display = 'none';
   if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+  latestSearchToken++;
 }

--- a/src/renderer/components/session-search-palette.ts
+++ b/src/renderer/components/session-search-palette.ts
@@ -1,4 +1,5 @@
 import { appState } from '../state.js';
+import { getProviderDisplayName } from '../provider-availability.js';
 import { escapeHtml, escapeRegExp } from './dom-search-backend.js';
 import type { DeepSearchResult } from '../../shared/types.js';
 
@@ -168,6 +169,11 @@ function renderResults(): void {
     nameText.textContent = r.sessionName ?? r.cliSessionId.slice(0, 8) + '\u2026';
     nameRow.appendChild(nameText);
 
+    const providerBadge = document.createElement('span');
+    providerBadge.className = `session-palette-badge provider provider-${r.providerId}`;
+    providerBadge.textContent = getProviderDisplayName(r.providerId);
+    nameRow.appendChild(providerBadge);
+
     const badge = document.createElement('span');
     badge.className = `session-palette-badge${isCurrentProject ? ' current' : ''}`;
     const projectName = r.projectCwd ? r.projectCwd.split('/').filter(Boolean).pop() ?? r.projectSlug : r.projectSlug;
@@ -208,7 +214,7 @@ function openResult(r: ResolvedResult): void {
       project = appState.addProject(name, r.projectCwd);
     }
     const name = r.sessionName ?? r.cliSessionId.slice(0, 8) + '\u2026';
-    appState.openCliSession(project.id, r.cliSessionId, name);
+    appState.openCliSession(project.id, r.cliSessionId, name, r.providerId);
   }
   hidePalette();
 }

--- a/src/renderer/components/session-search-palette.ts
+++ b/src/renderer/components/session-search-palette.ts
@@ -1,0 +1,222 @@
+import { appState } from '../state.js';
+import type { DeepSearchResult } from '../../shared/types.js';
+
+interface ResolvedResult extends DeepSearchResult {
+  sessionName: string | null;
+  projectId: string | null;
+  archivedId: string | null;
+}
+
+let overlay: HTMLElement | null = null;
+let input: HTMLInputElement | null = null;
+let resultsList: HTMLElement | null = null;
+let activeIndex = 0;
+let resolvedResults: ResolvedResult[] = [];
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+function buildSessionMap(): Map<string, { projectId: string; archivedId: string; name: string }> {
+  const map = new Map<string, { projectId: string; archivedId: string; name: string }>();
+  for (const project of appState.projects) {
+    for (const archived of appState.getSessionHistory(project.id)) {
+      if (archived.cliSessionId) {
+        map.set(archived.cliSessionId, { projectId: project.id, archivedId: archived.id, name: archived.name });
+      }
+    }
+  }
+  return map;
+}
+
+function createOverlay(): void {
+  if (overlay) return;
+
+  overlay = document.createElement('div');
+  overlay.className = 'session-palette-overlay';
+  overlay.addEventListener('mousedown', (e) => {
+    if (e.target === overlay) hidePalette();
+  });
+
+  const container = document.createElement('div');
+  container.className = 'session-palette-container';
+
+  const inputRow = document.createElement('div');
+  inputRow.className = 'session-palette-input-row';
+
+  const icon = document.createElement('span');
+  icon.className = 'session-palette-icon';
+  icon.textContent = '⚡';
+
+  input = document.createElement('input');
+  input.className = 'session-palette-input';
+  input.type = 'text';
+  input.placeholder = 'Search all sessions...';
+  input.addEventListener('input', onInput);
+  input.addEventListener('keydown', onKeydown);
+
+  inputRow.appendChild(icon);
+  inputRow.appendChild(input);
+
+  resultsList = document.createElement('div');
+  resultsList.className = 'session-palette-results';
+
+  const footer = document.createElement('div');
+  footer.className = 'session-palette-footer';
+  for (const [keys, label] of [['↑↓', 'navigate'], ['↵', 'open session'], ['Esc', 'close']] as [string, string][]) {
+    const span = document.createElement('span');
+    const kbd = document.createElement('kbd');
+    kbd.textContent = keys;
+    span.appendChild(kbd);
+    span.append(' ' + label);
+    footer.appendChild(span);
+  }
+
+  container.appendChild(inputRow);
+  container.appendChild(resultsList);
+  container.appendChild(footer);
+  overlay.appendChild(container);
+  document.body.appendChild(overlay);
+}
+
+function onInput(): void {
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => searchSessions(), 400);
+}
+
+async function searchSessions(): Promise<void> {
+  if (!input || !resultsList) return;
+  const query = input.value.trim();
+  if (query.length < 2) {
+    resolvedResults = [];
+    renderResults();
+    return;
+  }
+
+  resultsList.innerHTML = '';
+  const loading = document.createElement('div');
+  loading.className = 'session-palette-empty';
+  loading.textContent = 'Searching\u2026';
+  resultsList.appendChild(loading);
+
+  let raw: DeepSearchResult[] = [];
+  try {
+    raw = await window.vibeyard.session.deepSearch(query);
+  } catch {
+    raw = [];
+  }
+
+  const sessionMap = buildSessionMap();
+  resolvedResults = raw.map(r => {
+    const match = sessionMap.get(r.cliSessionId) ?? null;
+    return { ...r, sessionName: match?.name ?? null, projectId: match?.projectId ?? null, archivedId: match?.archivedId ?? null };
+  });
+
+  activeIndex = 0;
+  renderResults();
+}
+
+function renderResults(): void {
+  if (!resultsList) return;
+  resultsList.innerHTML = '';
+
+  if (resolvedResults.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'session-palette-empty';
+    const query = input?.value.trim() ?? '';
+    empty.textContent = query.length >= 2 ? 'No sessions found' : 'Type 2+ characters to search all sessions';
+    resultsList.appendChild(empty);
+    return;
+  }
+
+  const activeProjectId = appState.activeProject?.id;
+  for (let i = 0; i < resolvedResults.length; i++) {
+    const r = resolvedResults[i];
+    const isCurrentProject = r.projectId === activeProjectId;
+
+    const item = document.createElement('div');
+    item.className = 'session-palette-item';
+    if (i === activeIndex) item.classList.add('active');
+    item.style.cursor = 'pointer';
+    item.addEventListener('mouseenter', () => { activeIndex = i; updateActiveItem(); });
+    item.addEventListener('click', () => { activeIndex = i; openResult(r); });
+
+    const nameRow = document.createElement('div');
+    nameRow.className = 'session-palette-item-name';
+    const nameText = document.createElement('span');
+    nameText.textContent = r.sessionName ?? r.cliSessionId.slice(0, 8) + '\u2026';
+    nameRow.appendChild(nameText);
+
+    const badge = document.createElement('span');
+    badge.className = `session-palette-badge${isCurrentProject ? ' current' : ''}`;
+    const projectName = r.projectCwd ? r.projectCwd.split('/').filter(Boolean).pop() ?? r.projectSlug : r.projectSlug;
+    badge.textContent = isCurrentProject ? 'current project' : projectName;
+    nameRow.appendChild(badge);
+
+    const meta = document.createElement('div');
+    meta.className = 'session-palette-item-meta';
+    meta.textContent = r.projectCwd || r.projectSlug;
+
+    const snippet = document.createElement('div');
+    snippet.className = 'session-palette-item-snippet';
+    snippet.textContent = r.snippet;
+
+    item.appendChild(nameRow);
+    item.appendChild(meta);
+    item.appendChild(snippet);
+    resultsList.appendChild(item);
+  }
+}
+
+function updateActiveItem(): void {
+  if (!resultsList) return;
+  const items = resultsList.querySelectorAll('.session-palette-item');
+  items.forEach((el, i) => el.classList.toggle('active', i === activeIndex));
+  (items[activeIndex] as HTMLElement | undefined)?.scrollIntoView({ block: 'nearest' });
+}
+
+function openResult(r: ResolvedResult): void {
+  if (r.projectId && r.archivedId) {
+    appState.setActiveProject(r.projectId);
+    appState.resumeFromHistory(r.projectId, r.archivedId);
+  } else {
+    // Not in Vibeyard — find or create project by cwd, then open session directly
+    let project = appState.projects.find(p => p.path === r.projectCwd);
+    if (!project) {
+      const name = r.projectCwd ? r.projectCwd.split('/').filter(Boolean).pop()! : r.projectSlug;
+      project = appState.addProject(name, r.projectCwd);
+    }
+    const name = r.sessionName ?? r.cliSessionId.slice(0, 8) + '\u2026';
+    appState.openCliSession(project.id, r.cliSessionId, name);
+  }
+  hidePalette();
+}
+
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    if (resolvedResults.length > 0) { activeIndex = (activeIndex + 1) % resolvedResults.length; updateActiveItem(); }
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    if (resolvedResults.length > 0) { activeIndex = (activeIndex - 1 + resolvedResults.length) % resolvedResults.length; updateActiveItem(); }
+  } else if (e.key === 'Enter') {
+    e.preventDefault();
+    if (resolvedResults[activeIndex]) openResult(resolvedResults[activeIndex]);
+  } else if (e.key === 'Escape') {
+    e.preventDefault();
+    hidePalette();
+  }
+}
+
+export function showSessionSearchPalette(): void {
+  createOverlay();
+  if (!overlay || !input) return;
+  overlay.style.display = 'flex';
+  input.value = '';
+  resolvedResults = [];
+  activeIndex = 0;
+  renderResults();
+  input.focus();
+}
+
+function hidePalette(): void {
+  if (overlay) overlay.style.display = 'none';
+  if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+}

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -10,6 +10,7 @@ import { showSearchBar, TerminalSearchBackend, ShellTerminalSearchBackend } from
 import { getActiveShellSessionId } from './components/project-terminal.js';
 import { toggleGitPanel } from './components/git-panel.js';
 import { showQuickOpen } from './components/quick-open.js';
+import { showSessionSearchPalette } from './components/session-search-palette.js';
 import { shortcutManager } from './shortcuts.js';
 import { getFileReaderInstance, getFileReaderTextSelector, showGoToLineBar } from './components/file-reader.js';
 import { getFileViewerInstance } from './components/file-viewer.js';
@@ -57,6 +58,7 @@ export function initKeybindings(): void {
   shortcutManager.registerHandler('debug-panel', toggleDebugPanel);
   shortcutManager.registerHandler('git-panel', toggleGitPanel);
   shortcutManager.registerHandler('quick-open', showQuickOpen);
+  shortcutManager.registerHandler('session-search', showSessionSearchPalette);
   shortcutManager.registerHandler('find-in-terminal', () => {
     const shellPanel = document.getElementById('project-terminal-panel');
     if (shellPanel && !shellPanel.classList.contains('hidden') &&

--- a/src/renderer/shortcuts.ts
+++ b/src/renderer/shortcuts.ts
@@ -40,6 +40,7 @@ export const SHORTCUT_DEFAULTS: ShortcutDefault[] = [
   { id: 'debug-panel', label: 'Debug Panel', category: 'Panels', defaultKeys: 'CmdOrCtrl+Shift+D' },
   { id: 'git-panel', label: 'Git Panel', category: 'Panels', defaultKeys: 'CmdOrCtrl+Shift+G' },
   { id: 'quick-open', label: 'Quick Open File', category: 'Search & Help', defaultKeys: 'CmdOrCtrl+P' },
+  { id: 'session-search', label: 'Search All Sessions', category: 'Search & Help', defaultKeys: 'CmdOrCtrl+Shift+F' },
   { id: 'find-in-terminal', label: 'Find', category: 'Search & Help', defaultKeys: 'CmdOrCtrl+F' },
   { id: 'goto-line', label: 'Go to Line', category: 'Search & Help', defaultKeys: 'CmdOrCtrl+L' },
   { id: 'help', label: 'Help', category: 'Search & Help', defaultKeys: 'F1' },

--- a/src/renderer/state.test.ts
+++ b/src/renderer/state.test.ts
@@ -1749,3 +1749,66 @@ describe('toggleSwarm() sync new CLI sessions', () => {
     expect(appState.activeProject!.layout.splitPanes).toContain(newSession.id);
   });
 });
+
+describe('openCliSession()', () => {
+  it('creates a new session with the given cliSessionId', () => {
+    const project = addProject();
+    const session = appState.openCliSession(project.id, 'cli-abc-123', 'My Session')!;
+    expect(session).toBeDefined();
+    expect(session.cliSessionId).toBe('cli-abc-123');
+    expect(session.name).toBe('My Session');
+    expect(session.providerId).toBe('claude');
+  });
+
+  it('sets the new session as active', () => {
+    const project = addProject();
+    const session = appState.openCliSession(project.id, 'cli-abc-123', 'My Session')!;
+    expect(appState.activeProject!.activeSessionId).toBe(session.id);
+  });
+
+  it('activates existing tab when cliSessionId already open', () => {
+    const project = addProject();
+    const first = appState.openCliSession(project.id, 'cli-same', 'Session A')!;
+    appState.addSession(project.id, 'Other');
+    expect(appState.activeProject!.activeSessionId).not.toBe(first.id);
+
+    const second = appState.openCliSession(project.id, 'cli-same', 'Session A')!;
+    expect(second.id).toBe(first.id);
+    expect(appState.activeProject!.sessions).toHaveLength(2); // no duplicate created
+  });
+
+  it('emits session-added for new session', () => {
+    const project = addProject();
+    const addedCb = vi.fn();
+    appState.on('session-added', addedCb);
+    appState.openCliSession(project.id, 'cli-xyz', 'S');
+    expect(addedCb).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit session-added when activating existing tab', () => {
+    const project = addProject();
+    appState.openCliSession(project.id, 'cli-dup', 'S');
+    const addedCb = vi.fn();
+    appState.on('session-added', addedCb);
+    appState.openCliSession(project.id, 'cli-dup', 'S');
+    expect(addedCb).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined for nonexistent project', () => {
+    expect(appState.openCliSession('no-such-project', 'cli-123', 'S')).toBeUndefined();
+  });
+
+  it('persists state after opening session', () => {
+    const project = addProject();
+    mockSave.mockClear();
+    appState.openCliSession(project.id, 'cli-persist', 'S');
+    expect(mockSave).toHaveBeenCalled();
+  });
+
+  it('appends to swarm splitPanes when in swarm mode', () => {
+    const project = addProject();
+    // swarm mode is the default layout mode
+    const session = appState.openCliSession(project.id, 'cli-swarm', 'S')!;
+    expect(appState.activeProject!.layout.splitPanes).toContain(session.id);
+  });
+});

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -524,15 +524,15 @@ class AppState {
     return session;
   }
 
-  /** Open a Claude session by cliSessionId, bypassing Vibeyard history. Used for cross-project deep search results. */
-  openCliSession(projectId: string, cliSessionId: string, name: string): SessionRecord | undefined {
+  /** Open a CLI session by cliSessionId, bypassing Vibeyard history. Used for cross-project deep search results. */
+  openCliSession(projectId: string, cliSessionId: string, name: string, providerId: ProviderId = 'claude'): SessionRecord | undefined {
     const project = this.state.projects.find((p) => p.id === projectId);
     if (!project) return undefined;
 
     const existing = project.sessions.find((s) => s.cliSessionId === cliSessionId);
     if (existing) return this.activateExistingSession(project, existing);
 
-    const session = buildResumedSessionFromCliId(cliSessionId, name);
+    const session = buildResumedSessionFromCliId(cliSessionId, name, providerId);
     attachSessionToProject(project, session, { addToSwarm: true });
     this.commitNewSession(projectId, session);
     return session;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -5,7 +5,7 @@ import { restoreContext } from './session-context.js';
 import { getProviderCapabilities, getProviderAvailabilitySnapshot } from './provider-availability.js';
 import { basename } from '../shared/platform.js';
 import { isCliSession } from './session-utils.js';
-import { archiveSession as archiveSessionPure, buildResumedSession } from './state/session-archive.js';
+import { archiveSession as archiveSessionPure, buildResumedSession, buildResumedSessionFromCliId } from './state/session-archive.js';
 import {
   attachSessionToProject,
   buildBrowserTabSession,
@@ -519,6 +519,20 @@ class AppState {
     if (existing) return this.activateExistingSession(project, existing);
 
     const session = buildResumedSession(archived);
+    attachSessionToProject(project, session, { addToSwarm: true });
+    this.commitNewSession(projectId, session);
+    return session;
+  }
+
+  /** Open a Claude session by cliSessionId, bypassing Vibeyard history. Used for cross-project deep search results. */
+  openCliSession(projectId: string, cliSessionId: string, name: string): SessionRecord | undefined {
+    const project = this.state.projects.find((p) => p.id === projectId);
+    if (!project) return undefined;
+
+    const existing = project.sessions.find((s) => s.cliSessionId === cliSessionId);
+    if (existing) return this.activateExistingSession(project, existing);
+
+    const session = buildResumedSessionFromCliId(cliSessionId, name);
     attachSessionToProject(project, session, { addToSwarm: true });
     this.commitNewSession(projectId, session);
     return session;

--- a/src/renderer/state/session-archive.test.ts
+++ b/src/renderer/state/session-archive.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../session-cost.js', () => ({
+  getCost: vi.fn().mockReturnValue(null),
+}));
+
+let uuidCounter = 0;
+vi.stubGlobal('crypto', {
+  randomUUID: () => `uuid-${++uuidCounter}`,
+});
+
+import { buildResumedSessionFromCliId } from './session-archive';
+
+beforeEach(() => {
+  uuidCounter = 0;
+});
+
+describe('buildResumedSessionFromCliId()', () => {
+  it('creates a SessionRecord with the given cliSessionId', () => {
+    const session = buildResumedSessionFromCliId('cli-abc-123', 'My Session');
+    expect(session.cliSessionId).toBe('cli-abc-123');
+    expect(session.name).toBe('My Session');
+  });
+
+  it('defaults providerId to claude', () => {
+    const session = buildResumedSessionFromCliId('cli-xyz', 'Test');
+    expect(session.providerId).toBe('claude');
+  });
+
+  it('accepts an explicit providerId', () => {
+    const session = buildResumedSessionFromCliId('cli-xyz', 'Test', 'codex');
+    expect(session.providerId).toBe('codex');
+  });
+
+  it('generates a unique id each call', () => {
+    const a = buildResumedSessionFromCliId('cli-1', 'A');
+    const b = buildResumedSessionFromCliId('cli-2', 'B');
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it('sets createdAt to a valid ISO timestamp', () => {
+    const before = new Date().toISOString();
+    const session = buildResumedSessionFromCliId('cli-t', 'T');
+    const after = new Date().toISOString();
+    expect(session.createdAt >= before).toBe(true);
+    expect(session.createdAt <= after).toBe(true);
+  });
+
+  it('does not set type field (plain CLI session)', () => {
+    const session = buildResumedSessionFromCliId('cli-t', 'T');
+    expect((session as Record<string, unknown>).type).toBeUndefined();
+  });
+});

--- a/src/renderer/state/session-archive.ts
+++ b/src/renderer/state/session-archive.ts
@@ -60,3 +60,14 @@ export function buildResumedSession(archived: ArchivedSession): SessionRecord {
     createdAt: new Date().toISOString(),
   };
 }
+
+/** Build a fresh SessionRecord from a bare cliSessionId (no Vibeyard history entry required). */
+export function buildResumedSessionFromCliId(cliSessionId: string, name: string, providerId: ProviderId = 'claude'): SessionRecord {
+  return {
+    id: crypto.randomUUID(),
+    name,
+    providerId,
+    cliSessionId,
+    createdAt: new Date().toISOString(),
+  };
+}

--- a/src/renderer/styles/dialogs.css
+++ b/src/renderer/styles/dialogs.css
@@ -1,3 +1,149 @@
+/* Session Search Palette */
+.session-palette-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.75);
+  display: none;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 80px;
+}
+
+.session-palette-container {
+  background: var(--bg-tertiary);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  width: 560px;
+  max-width: 90vw;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.8), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+}
+
+.session-palette-input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.session-palette-icon {
+  font-size: 14px;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.session-palette-input {
+  flex: 1;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 14px;
+  outline: none;
+  font-family: inherit;
+}
+
+.session-palette-input::placeholder {
+  color: var(--text-secondary);
+}
+
+.session-palette-results {
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.session-palette-results::-webkit-scrollbar {
+  width: 6px;
+}
+
+.session-palette-results::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+.session-palette-empty {
+  padding: 16px 14px;
+  font-size: 12px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.session-palette-item {
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  cursor: default;
+}
+
+.session-palette-item.active {
+  background: var(--bg-hover);
+}
+
+.session-palette-item-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.session-palette-badge {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: rgba(232, 163, 23, 0.15);
+  color: #e8a317;
+  border: 1px solid rgba(232, 163, 23, 0.3);
+  flex-shrink: 0;
+}
+
+.session-palette-badge.current {
+  background: rgba(52, 168, 83, 0.15);
+  color: #34a853;
+  border-color: rgba(52, 168, 83, 0.3);
+}
+
+.session-palette-item-meta {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-palette-item-snippet {
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-palette-footer {
+  display: flex;
+  gap: 16px;
+  padding: 6px 14px;
+  border-top: 1px solid var(--border);
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.session-palette-footer kbd {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0 4px;
+  font-size: 10px;
+  color: var(--text-secondary);
+  font-family: inherit;
+}
+
 /* Help dialog */
 .help-container {
   max-height: 400px;

--- a/src/renderer/styles/dialogs.css
+++ b/src/renderer/styles/dialogs.css
@@ -125,6 +125,15 @@
   text-overflow: ellipsis;
 }
 
+.session-palette-item-snippet .search-match {
+  background: var(--bookmark);
+  color: #1a1a1a;
+  font-weight: 700;
+  font-style: normal;
+  padding: 0 3px;
+  border-radius: 2px;
+}
+
 .session-palette-footer {
   display: flex;
   gap: 16px;

--- a/src/renderer/styles/dialogs.css
+++ b/src/renderer/styles/dialogs.css
@@ -108,6 +108,14 @@
   border-color: rgba(52, 168, 83, 0.3);
 }
 
+.session-palette-badge.provider {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border-color: var(--border);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
 .session-palette-item-meta {
   font-size: 11px;
   color: var(--text-muted);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -129,6 +129,7 @@ export interface InitialContextSnapshot {
 }
 
 export interface DeepSearchResult {
+  providerId: ProviderId;
   cliSessionId: string;
   projectSlug: string;
   projectCwd: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -128,6 +128,14 @@ export interface InitialContextSnapshot {
   usedPercentage: number;
 }
 
+export interface DeepSearchResult {
+  cliSessionId: string;
+  projectSlug: string;
+  projectCwd: string;
+  snippet: string;
+  score: number;
+}
+
 export interface ProjectInsightsData {
   initialContextSnapshots: InitialContextSnapshot[];
   dismissed: string[];


### PR DESCRIPTION
## Summary

- Adds a global command palette overlay (Cmd+Shift+F / Ctrl+Shift+F) that fuzzy-searches all Claude Code session transcripts (`~/.claude/projects/**/*.jsonl`) across all projects
- Results show session name, project badge, and a matched content snippet
- Clicking any result — including sessions not in Vibeyard — switches to or creates the matching project and resumes the session by `cliSessionId`

## How it works

**Main process** (`session-deep-search.ts`): scans `~/.claude/projects/`, extracts user message text from each JSONL, caches entries by mtime (capped at 500), fuzzy-scores against the query, returns top 20 results.

**IPC**: `session:deepSearch` handler → preload bridge → `window.vibeyard.session.deepSearch(query)`.

**Renderer** (`session-search-palette.ts`): command palette overlay with debounced search (400ms), keyboard navigation (↑↓ / Enter / Esc), and cross-project session opening.

**Cross-project opening**: if a result matches a known Vibeyard project+session, it resumes normally. If not (session from a different project not yet in Vibeyard), it finds or creates a project record by `cwd` path and opens the session directly via the new `appState.openCliSession()`.

## New APIs

- `appState.openCliSession(projectId, cliSessionId, name)` — resumes a session by bare `cliSessionId`, bypassing history
- `buildResumedSessionFromCliId(cliSessionId, name, providerId?)` in `session-archive.ts`
- Shortcut id `session-search` registered in `shortcuts.ts` + `keybindings.ts`

## Test plan

- [ ] Open palette with Cmd+Shift+F (Mac) or Ctrl+Shift+F (Win/Linux)
- [ ] Type 2+ characters — results appear from all Claude Code sessions
- [ ] Click a result from the current project — session resumes in place
- [ ] Click a result from a different project — project switches and session resumes
- [ ] Click a result with no matching Vibeyard project — new project is created, session opens
- [ ] Keyboard navigate with ↑↓, confirm with Enter, dismiss with Esc or backdrop click
- [ ] `npm test` — all 1198 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)