### PR TITLE
Add browser tab toolbar button

### DIFF
--- a/src/renderer/components/tab-bar.ts
+++ b/src/renderer/components/tab-bar.ts
@@ -28,6 +28,7 @@ const btnAddSession = document.getElementById('btn-add-session')!;
 const btnAddSessionMenu = document.getElementById('btn-add-session-menu')!;
 const btnAddMcpInspector = document.getElementById('btn-add-mcp-inspector')!;
 const btnToggleSwarm = document.getElementById('btn-toggle-swarm')!;
+const btnAddBrowserTab = document.getElementById('btn-add-browser-tab')!;
 const btnHelp = document.getElementById('btn-help')!;
 
 let activeContextMenu: HTMLElement | null = null;
@@ -51,6 +52,10 @@ export function initTabBar(): void {
   });
   btnAddMcpInspector.addEventListener('click', promptNewMcpInspector);
   btnToggleSwarm.addEventListener('click', () => appState.toggleSwarm());
+  btnAddBrowserTab.addEventListener('click', () => {
+    const project = appState.activeProject;
+    if (project) appState.addBrowserTabSession(project.id);
+  });
   btnHelp.addEventListener('click', () => showHelpDialog());
   gitStatusEl.addEventListener('click', (e) => showBranchContextMenu(e));
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -38,6 +38,11 @@
           <button id="btn-toggle-terminal" class="icon-btn" title="Toggle Terminal (Ctrl+`)" style="font-size:13px;">&#x2588;</button>
           <button id="btn-add-mcp-inspector" class="icon-btn" title="MCP Inspector" style="font-size:11px;font-weight:600;">MCP</button>
           <button id="btn-toggle-swarm" class="icon-btn" title="Toggle Swarm Mode (Ctrl+\)">&#x229E;</button>
+          <button id="btn-add-browser-tab" class="icon-btn" title="New Browser Tab" aria-label="New Browser Tab">
+            <span class="toolbar-icon toolbar-icon-browser" aria-hidden="true">
+              <span class="toolbar-icon-browser-dot"></span>
+            </span>
+          </button>
           <div class="split-btn-group">
             <button id="btn-add-session" class="icon-btn split-btn-main" title="New Session (Ctrl+Shift+N)">+</button>
             <button id="btn-add-session-menu" class="icon-btn split-btn-caret" title="More session options" aria-haspopup="menu">&#x25BE;</button>

--- a/src/renderer/styles/tabs.css
+++ b/src/renderer/styles/tabs.css
@@ -211,6 +211,39 @@
   border-color: var(--border);
 }
 
+.toolbar-icon {
+  position: relative;
+  display: block;
+  width: 14px;
+  height: 14px;
+  color: currentColor;
+}
+
+.toolbar-icon-browser {
+  box-sizing: border-box;
+  border: 1.5px solid currentColor;
+  border-radius: 3px;
+}
+
+.toolbar-icon-browser::before {
+  content: '';
+  position: absolute;
+  left: -1px;
+  top: 3px;
+  width: calc(100% + 2px);
+  border-top: 1.5px solid currentColor;
+}
+
+.toolbar-icon-browser-dot {
+  position: absolute;
+  top: 1px;
+  left: 2px;
+  width: 2px;
+  height: 2px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
 .split-btn-group {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add a dedicated browser tab button to the tab toolbar
- wire the button to create a browser tab session for the active project
- style the new toolbar icon in the existing tabs stylesheet

The button looks like this, right button from the swarm
<img width="441" height="89" alt="image" src="https://github.com/user-attachments/assets/34310b26-ad3b-43cf-8b3f-63fc4ebe9bdd" />
