### PR TITLE
Add close-confirmation dialogs for tab/project/window with active sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ out/
 
 # Log files
 *.log
+
+# Superpowers brainstorm sessions
+.superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ out/
 
 # Superpowers brainstorm sessions
 .superpowers/
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Three renderer modules (`session-cost.ts`, `session-activity.ts`, `session-conte
 Three-process Electron architecture with strict context isolation:
 
 - **Main process** (`src/main/`) — Node.js side: window creation, PTY lifecycle via `node-pty`, filesystem access, persistent state (`~/.vibeyard/state.json`). IPC handlers in `ipc-handlers.ts` dispatch to `pty-manager.ts` and `store.ts`. CLI tool behavior is abstracted via the provider system (`src/main/providers/`).
-- **Preload** (`src/preload/preload.ts`) — Secure bridge exposing `window.vibeyard` API via `contextBridge` with namespaces: `pty`, `session`, `store`, `fs`, `provider`, `menu`, `app`.
+- **Preload** (`src/preload/preload.ts`) — Secure bridge exposing `window.vibeyard` API via `contextBridge` with namespaces: `pty`, `session`, `fs`, `store`, `provider`, `claude`, `git`, `update`, `app`, `browser`, `mcp`, `readiness`, `stats`, `settings`, `menu`.
 - **Renderer** (`src/renderer/`) — Vanilla TypeScript DOM UI (no framework). `AppState` singleton in `state.ts` uses an event emitter pattern; components in `components/` subscribe to state changes.
 
 ### Data Flow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Three renderer modules (`session-cost.ts`, `session-activity.ts`, `session-conte
 Three-process Electron architecture with strict context isolation:
 
 - **Main process** (`src/main/`) — Node.js side: window creation, PTY lifecycle via `node-pty`, filesystem access, persistent state (`~/.vibeyard/state.json`). IPC handlers in `ipc-handlers.ts` dispatch to `pty-manager.ts` and `store.ts`. CLI tool behavior is abstracted via the provider system (`src/main/providers/`).
-- **Preload** (`src/preload/preload.ts`) — Secure bridge exposing `window.vibeyard` API via `contextBridge` with namespaces: `pty`, `session`, `store`, `fs`, `provider`, `menu`.
+- **Preload** (`src/preload/preload.ts`) — Secure bridge exposing `window.vibeyard` API via `contextBridge` with namespaces: `pty`, `session`, `store`, `fs`, `provider`, `menu`, `app`.
 - **Renderer** (`src/renderer/`) — Vanilla TypeScript DOM UI (no framework). `AppState` singleton in `state.ts` uses an event emitter pattern; components in `components/` subscribe to state changes.
 
 ### Data Flow
@@ -65,6 +65,18 @@ CLI-specific behavior is encapsulated behind a `CliProvider` interface (`src/mai
 - `session-activity.ts` — Tracks working/waiting/idle status with debounced transitions
 - `session-cost.ts` — Structured cost tracking via Claude CLI status line (`statusLine` setting), with regex fallback for older CLI versions. Provides per-session and aggregate cost data (USD, tokens, cache, duration)
 - `browser-tab/` — Browser tab pane split into focused modules: `types.ts`, `instance.ts` (registry + preload path), `navigation.ts`, `viewport.ts`, `selector-ui.ts`, `inspect-mode.ts`, `flow-recording.ts`, `flow-picker.ts`, `session-integration.ts`, and `pane.ts` (DOM build + event wiring). `browser-tab-pane.ts` is a re-export shim for backward compatibility.
+- `confirm-dialog.ts` — Promise-based confirmation dialog (`showConfirmDialog()`) returning `true`/`false`. Separate from `modal.ts` (which handles form inputs). Supports optional warning banner via `detail` HTML.
+- `confirm-helpers.ts` — Utility functions `countActiveStatuses()` and `buildWarningBannerDetail()` for building session status warning banners in close confirmation dialogs.
+- `close-guard.ts` — Window close guard; listens for `app:confirmClose` IPC from main process, checks active session status and `confirmCloseActive` preference, shows warning banner dialog if needed, responds with `app:closeConfirmed` or `app:closeCancelled`.
+
+### Close Confirmation System
+
+Three close actions are gated by confirmation dialogs when active sessions (working/waiting/input) exist:
+- **Tab close** (X button, middle-click, context menu) — minimal dialog with session name and status dot
+- **Project removal** (sidebar context menu) — warning banner with aggregated status counts
+- **Window close** (X / Alt+F4) — warning banner via IPC round-trip (`app:confirmClose` → renderer checks → `app:closeConfirmed`/`app:closeCancelled`)
+
+Two preferences in General section: `confirmCloseActive` (default: on), `confirmCloseInactive` (default: off). The `forceClose` flag in `main.ts` is module-scoped and reset on cancel; `before-quit` sets it to bypass the dialog during Cmd+Q/menu quit.
 
 ### Platform Checks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,12 +33,78 @@
         "electron": "^41.0.0",
         "electron-builder": "^26.8.1",
         "esbuild": "^0.27.4",
+        "jsdom": "^28.1.0",
         "typescript": "^5.7.0",
         "vitest": "^4.1.0"
       },
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -98,6 +164,151 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.0.tgz",
+      "integrity": "sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -1041,6 +1252,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hono/node-server": {
@@ -2532,6 +2761,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -3206,6 +3445,60 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3222,6 +3515,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -3842,6 +4142,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -4708,6 +5021,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4910,6 +5236,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -5061,6 +5394,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -5559,6 +5933,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -6124,6 +6505,19 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -6705,6 +7099,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -7185,6 +7592,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar": {
       "version": "7.5.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
@@ -7346,6 +7760,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
+      "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.25"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
+      "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -7373,6 +7807,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/truncate-utf8-bytes": {
@@ -7458,6 +7918,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.23.0.tgz",
+      "integrity": "sha512-HVMxHKZKi+eL2mrUZDzDkKW3XvCjynhbtpSq20xQp4ePDFeSFuAfnvM0GIwZIv8fiKHjXFQ5WjxhCt15KRNj+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -7721,6 +8191,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -7729,6 +8212,41 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -7807,6 +8325,16 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -7816,6 +8344,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "electron": "^41.0.0",
     "electron-builder": "^26.8.1",
     "esbuild": "^0.27.4",
+    "jsdom": "^28.1.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"
   },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -56,25 +56,25 @@ function createWindow(): void {
     mainWindow!.webContents.send('app:confirmClose');
   });
 
-  ipcMain.on('app:closeConfirmed', () => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      forceClose = true;
-      mainWindow.close();
-    }
-  });
-
-  ipcMain.on('app:closeCancelled', () => {
-    // Reset forceClose so the next close attempt shows the dialog again.
-    // This matters on macOS where closing hides the window instead of quitting.
-    forceClose = false;
-  });
-
   mainWindow.on('closed', () => {
     killAllPtys();
     resetHookWatcher();
     mainWindow = null;
   });
 }
+
+// Close confirmation IPC — registered once at module scope to avoid
+// duplicate listeners when createWindow() is called again on macOS dock click.
+ipcMain.on('app:closeConfirmed', () => {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    forceClose = true;
+    mainWindow.close();
+  }
+});
+
+ipcMain.on('app:closeCancelled', () => {
+  forceClose = false;
+});
 
 app.whenReady().then(async () => {
   initProviders();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,6 +12,7 @@ import { checkPythonAvailable } from './prerequisites';
 import { isMac } from './platform';
 
 let mainWindow: BrowserWindow | null = null;
+let forceClose = false;
 
 function createWindow(): void {
   mainWindow = new BrowserWindow({
@@ -48,8 +49,6 @@ function createWindow(): void {
     }
   });
 
-  let forceClose = false;
-
   mainWindow.on('close', (e) => {
     flushState();
     if (forceClose) return;
@@ -62,6 +61,12 @@ function createWindow(): void {
       forceClose = true;
       mainWindow.close();
     }
+  });
+
+  ipcMain.on('app:closeCancelled', () => {
+    // Reset forceClose so the next close attempt shows the dialog again.
+    // This matters on macOS where closing hides the window instead of quitting.
+    forceClose = false;
   });
 
   mainWindow.on('closed', () => {
@@ -136,6 +141,9 @@ app.whenReady().then(async () => {
 });
 
 app.on('before-quit', () => {
+  // Skip close confirmation during app quit (Cmd+Q / menu quit).
+  // The quit is already committed at this point — cleanup is happening.
+  forceClose = true;
   flushState();
   const win = BrowserWindow.getAllWindows()[0];
   if (win && !win.isDestroyed()) {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, powerMonitor, shell } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, powerMonitor, shell } from 'electron';
 import * as path from 'path';
 import { registerIpcHandlers, resetHookWatcher } from './ipc-handlers';
 import { killAllPtys } from './pty-manager';
@@ -48,8 +48,20 @@ function createWindow(): void {
     }
   });
 
-  mainWindow.on('close', () => {
+  let forceClose = false;
+
+  mainWindow.on('close', (e) => {
     flushState();
+    if (forceClose) return;
+    e.preventDefault();
+    mainWindow!.webContents.send('app:confirmClose');
+  });
+
+  ipcMain.on('app:closeConfirmed', () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      forceClose = true;
+      mainWindow.close();
+    }
   });
 
   mainWindow.on('closed', () => {

--- a/src/main/store.test.ts
+++ b/src/main/store.test.ts
@@ -24,7 +24,7 @@ const DEFAULT_STATE: PersistedState = {
   version: 1,
   projects: [],
   activeProjectId: null,
-  preferences: { soundOnSessionWaiting: true, notificationsDesktop: true, debugMode: false, sessionHistoryEnabled: true, insightsEnabled: true, autoTitleEnabled: true },
+  preferences: { soundOnSessionWaiting: true, notificationsDesktop: true, debugMode: false, sessionHistoryEnabled: true, insightsEnabled: true, autoTitleEnabled: true, confirmCloseActive: true, confirmCloseInactive: false },
 };
 
 beforeEach(() => {

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -15,7 +15,7 @@ function defaultState(): PersistedState {
     version: 1,
     projects: [],
     activeProjectId: null,
-    preferences: { soundOnSessionWaiting: true, notificationsDesktop: true, debugMode: false, sessionHistoryEnabled: true, insightsEnabled: true, autoTitleEnabled: true },
+    preferences: { soundOnSessionWaiting: true, notificationsDesktop: true, debugMode: false, sessionHistoryEnabled: true, insightsEnabled: true, autoTitleEnabled: true, confirmCloseActive: true, confirmCloseInactive: false },
   };
 }
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -82,6 +82,8 @@ export interface VibeyardApi {
     openExternal(url: string): Promise<void>;
     getBrowserPreloadPath(): Promise<string>;
     onQuitting(callback: () => void): () => void;
+    onConfirmClose(callback: () => void): () => void;
+    closeConfirmed(): void;
   };
   browser: {
     saveScreenshot(sessionId: string, dataUrl: string): Promise<string>;
@@ -231,6 +233,8 @@ const api: VibeyardApi = {
     openExternal: (url: string) => ipcRenderer.invoke('app:openExternal', url),
     getBrowserPreloadPath: () => ipcRenderer.invoke('app:getBrowserPreloadPath'),
     onQuitting: (cb: () => void) => onChannel('app:quitting', cb),
+    onConfirmClose: (cb: () => void) => onChannel('app:confirmClose', cb),
+    closeConfirmed: () => { ipcRenderer.send('app:closeConfirmed'); },
   },
   browser: {
     saveScreenshot: (sessionId: string, dataUrl: string) =>

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -84,6 +84,7 @@ export interface VibeyardApi {
     onQuitting(callback: () => void): () => void;
     onConfirmClose(callback: () => void): () => void;
     closeConfirmed(): void;
+    closeCancelled(): void;
   };
   browser: {
     saveScreenshot(sessionId: string, dataUrl: string): Promise<string>;
@@ -235,6 +236,7 @@ const api: VibeyardApi = {
     onQuitting: (cb: () => void) => onChannel('app:quitting', cb),
     onConfirmClose: (cb: () => void) => onChannel('app:confirmClose', cb),
     closeConfirmed: () => { ipcRenderer.send('app:closeConfirmed'); },
+    closeCancelled: () => { ipcRenderer.send('app:closeCancelled'); },
   },
   browser: {
     saveScreenshot: (sessionId: string, dataUrl: string) =>

--- a/src/renderer/close-guard.ts
+++ b/src/renderer/close-guard.ts
@@ -37,6 +37,8 @@ export function initCloseGuard(): void {
 
     if (confirmed) {
       window.vibeyard.app.closeConfirmed();
+    } else {
+      window.vibeyard.app.closeCancelled();
     }
   });
 }

--- a/src/renderer/close-guard.ts
+++ b/src/renderer/close-guard.ts
@@ -1,0 +1,42 @@
+import { appState } from './state.js';
+import { getStatus } from './session-activity.js';
+import { showConfirmDialog } from './components/confirm-dialog.js';
+import { countActiveStatuses, buildWarningBannerDetail } from './components/confirm-helpers.js';
+
+export function initCloseGuard(): void {
+  window.vibeyard.app.onConfirmClose(async () => {
+    if (!appState.preferences.confirmCloseActive) {
+      window.vibeyard.app.closeConfirmed();
+      return;
+    }
+
+    // Gather active session statuses across all projects
+    const allStatuses: string[] = [];
+    for (const project of appState.projects) {
+      for (const session of project.sessions) {
+        allStatuses.push(getStatus(session.id));
+      }
+    }
+
+    const counts = countActiveStatuses(allStatuses);
+    const hasActive = counts.working + counts.waiting + counts.input > 0;
+
+    if (!hasActive) {
+      window.vibeyard.app.closeConfirmed();
+      return;
+    }
+
+    const detail = buildWarningBannerDetail(counts);
+    const confirmed = await showConfirmDialog({
+      title: 'Close Vibeyard?',
+      message: '',
+      detail,
+      confirmLabel: 'Close Anyway',
+      confirmDangerous: true,
+    });
+
+    if (confirmed) {
+      window.vibeyard.app.closeConfirmed();
+    }
+  });
+}

--- a/src/renderer/close-guard.ts
+++ b/src/renderer/close-guard.ts
@@ -3,8 +3,12 @@ import { getStatus } from './session-activity.js';
 import { showConfirmDialog } from './components/confirm-dialog.js';
 import { countActiveStatuses, buildWarningBannerDetail } from './components/confirm-helpers.js';
 
+let dialogPending = false;
+
 export function initCloseGuard(): void {
   window.vibeyard.app.onConfirmClose(async () => {
+    if (dialogPending) return;
+
     if (!appState.preferences.confirmCloseActive) {
       window.vibeyard.app.closeConfirmed();
       return;
@@ -26,14 +30,15 @@ export function initCloseGuard(): void {
       return;
     }
 
+    dialogPending = true;
     const detail = buildWarningBannerDetail(counts);
     const confirmed = await showConfirmDialog({
       title: 'Close Vibeyard?',
       message: '',
       detail,
       confirmLabel: 'Close Anyway',
-      confirmDangerous: true,
     });
+    dialogPending = false;
 
     if (confirmed) {
       window.vibeyard.app.closeConfirmed();

--- a/src/renderer/components/confirm-dialog.test.ts
+++ b/src/renderer/components/confirm-dialog.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { showConfirmDialog } from './confirm-dialog.js';
+
+describe('showConfirmDialog', () => {
+  afterEach(() => {
+    document.querySelectorAll('.confirm-overlay').forEach(el => el.remove());
+  });
+
+  it('resolves true when confirm button is clicked', async () => {
+    const promise = showConfirmDialog({
+      title: 'Close?',
+      message: 'Are you sure?',
+      confirmLabel: 'Close',
+    });
+    const confirmBtn = document.querySelector('.confirm-overlay .modal-btn.primary') as HTMLElement;
+    expect(confirmBtn).not.toBeNull();
+    confirmBtn.click();
+    expect(await promise).toBe(true);
+  });
+
+  it('resolves false when cancel button is clicked', async () => {
+    const promise = showConfirmDialog({
+      title: 'Close?',
+      message: 'Are you sure?',
+      confirmLabel: 'Close',
+    });
+    const cancelBtn = document.querySelector('.confirm-overlay .modal-btn:not(.primary)') as HTMLElement;
+    expect(cancelBtn).not.toBeNull();
+    cancelBtn.click();
+    expect(await promise).toBe(false);
+  });
+
+  it('resolves false on Escape key', async () => {
+    const promise = showConfirmDialog({
+      title: 'Close?',
+      message: 'Are you sure?',
+      confirmLabel: 'Close',
+    });
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(await promise).toBe(false);
+  });
+
+  it('renders warning banner when detail is provided', async () => {
+    const promise = showConfirmDialog({
+      title: 'Close Vibeyard?',
+      message: '',
+      detail: '<div class="confirm-status-line">1 working</div>',
+      confirmLabel: 'Close Anyway',
+      confirmDangerous: true,
+    });
+    const banner = document.querySelector('.confirm-warning-banner');
+    expect(banner).not.toBeNull();
+    expect(banner!.innerHTML).toContain('1 working');
+    const cancelBtn = document.querySelector('.confirm-overlay .modal-btn:not(.primary)') as HTMLElement;
+    cancelBtn.click();
+    await promise;
+  });
+
+  it('does not render banner when detail is omitted', async () => {
+    const promise = showConfirmDialog({
+      title: 'Close session?',
+      message: 'Session is working.',
+      confirmLabel: 'Close',
+    });
+    const banner = document.querySelector('.confirm-warning-banner');
+    expect(banner).toBeNull();
+    const cancelBtn = document.querySelector('.confirm-overlay .modal-btn:not(.primary)') as HTMLElement;
+    cancelBtn.click();
+    await promise;
+  });
+
+  it('removes overlay from DOM after resolution', async () => {
+    const promise = showConfirmDialog({
+      title: 'Close?',
+      message: 'Sure?',
+      confirmLabel: 'Close',
+    });
+    const confirmBtn = document.querySelector('.confirm-overlay .modal-btn.primary') as HTMLElement;
+    confirmBtn.click();
+    await promise;
+    expect(document.querySelector('.confirm-overlay')).toBeNull();
+  });
+});

--- a/src/renderer/components/confirm-dialog.test.ts
+++ b/src/renderer/components/confirm-dialog.test.ts
@@ -47,7 +47,6 @@ describe('showConfirmDialog', () => {
       message: '',
       detail: '<div class="confirm-status-line">1 working</div>',
       confirmLabel: 'Close Anyway',
-      confirmDangerous: true,
     });
     const banner = document.querySelector('.confirm-warning-banner');
     expect(banner).not.toBeNull();

--- a/src/renderer/components/confirm-dialog.ts
+++ b/src/renderer/components/confirm-dialog.ts
@@ -1,0 +1,74 @@
+export interface ConfirmDialogOptions {
+  title: string;
+  message: string;
+  detail?: string;
+  confirmLabel: string;
+  confirmDangerous?: boolean;
+}
+
+export function showConfirmDialog(options: ConfirmDialogOptions): Promise<boolean> {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'confirm-overlay modal-overlay';
+
+    const box = document.createElement('div');
+    box.className = 'modal-box';
+
+    const title = document.createElement('div');
+    title.className = 'modal-title';
+    title.textContent = options.title;
+    box.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'modal-body';
+
+    if (options.detail) {
+      const banner = document.createElement('div');
+      banner.className = 'confirm-warning-banner';
+      banner.innerHTML = options.detail;
+      body.appendChild(banner);
+    }
+
+    if (options.message) {
+      const msg = document.createElement('div');
+      msg.className = 'confirm-message';
+      msg.innerHTML = options.message;
+      body.appendChild(msg);
+    }
+
+    box.appendChild(body);
+
+    const actions = document.createElement('div');
+    actions.className = 'modal-actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'modal-btn';
+    cancelBtn.textContent = 'Cancel';
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.className = 'modal-btn primary';
+    confirmBtn.textContent = options.confirmLabel;
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(confirmBtn);
+    box.appendChild(actions);
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+
+    function cleanup(result: boolean): void {
+      document.removeEventListener('keydown', onKey);
+      overlay.remove();
+      resolve(result);
+    }
+
+    function onKey(e: KeyboardEvent): void {
+      if (e.key === 'Escape') cleanup(false);
+    }
+
+    cancelBtn.addEventListener('click', () => cleanup(false));
+    confirmBtn.addEventListener('click', () => cleanup(true));
+    document.addEventListener('keydown', onKey);
+
+    confirmBtn.focus();
+  });
+}

--- a/src/renderer/components/confirm-dialog.ts
+++ b/src/renderer/components/confirm-dialog.ts
@@ -46,7 +46,7 @@ export function showConfirmDialog(options: ConfirmDialogOptions): Promise<boolea
     cancelBtn.textContent = 'Cancel';
 
     const confirmBtn = document.createElement('button');
-    confirmBtn.className = 'modal-btn primary';
+    confirmBtn.className = options.confirmDangerous ? 'modal-btn primary danger' : 'modal-btn primary';
     confirmBtn.textContent = options.confirmLabel;
 
     actions.appendChild(cancelBtn);

--- a/src/renderer/components/confirm-dialog.ts
+++ b/src/renderer/components/confirm-dialog.ts
@@ -3,7 +3,6 @@ export interface ConfirmDialogOptions {
   message: string;
   detail?: string;
   confirmLabel: string;
-  confirmDangerous?: boolean;
 }
 
 export function showConfirmDialog(options: ConfirmDialogOptions): Promise<boolean> {
@@ -46,7 +45,7 @@ export function showConfirmDialog(options: ConfirmDialogOptions): Promise<boolea
     cancelBtn.textContent = 'Cancel';
 
     const confirmBtn = document.createElement('button');
-    confirmBtn.className = options.confirmDangerous ? 'modal-btn primary danger' : 'modal-btn primary';
+    confirmBtn.className = 'modal-btn primary';
     confirmBtn.textContent = options.confirmLabel;
 
     actions.appendChild(cancelBtn);

--- a/src/renderer/components/confirm-helpers.test.ts
+++ b/src/renderer/components/confirm-helpers.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { buildWarningBannerDetail, countActiveStatuses } from './confirm-helpers.js';
+
+describe('countActiveStatuses', () => {
+  it('counts working, waiting, and input statuses', () => {
+    const statuses = ['working', 'waiting', 'idle', 'input', 'working', 'completed'] as const;
+    const counts = countActiveStatuses(statuses as unknown as string[]);
+    expect(counts).toEqual({ working: 2, waiting: 1, input: 1 });
+  });
+
+  it('returns zero counts when no active sessions', () => {
+    const counts = countActiveStatuses(['idle', 'completed']);
+    expect(counts).toEqual({ working: 0, waiting: 0, input: 0 });
+  });
+
+  it('returns zero counts for empty array', () => {
+    const counts = countActiveStatuses([]);
+    expect(counts).toEqual({ working: 0, waiting: 0, input: 0 });
+  });
+});
+
+describe('buildWarningBannerDetail', () => {
+  it('renders only non-zero status categories', () => {
+    const html = buildWarningBannerDetail({ working: 2, waiting: 0, input: 1 });
+    expect(html).toContain('2 working');
+    expect(html).toContain('1 needs input');
+    expect(html).not.toContain('waiting');
+  });
+
+  it('renders all three when all non-zero', () => {
+    const html = buildWarningBannerDetail({ working: 1, waiting: 3, input: 2 });
+    expect(html).toContain('1 working');
+    expect(html).toContain('3 waiting');
+    expect(html).toContain('2 needs input');
+  });
+
+  it('includes warning header', () => {
+    const html = buildWarningBannerDetail({ working: 1, waiting: 0, input: 0 });
+    expect(html).toContain('Warning: Active sessions will be terminated');
+  });
+});

--- a/src/renderer/components/confirm-helpers.ts
+++ b/src/renderer/components/confirm-helpers.ts
@@ -1,0 +1,41 @@
+export interface ActiveStatusCounts {
+  working: number;
+  waiting: number;
+  input: number;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  working: '#e94560',
+  waiting: '#f4b400',
+  input: '#e67e22',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  working: 'working',
+  waiting: 'waiting',
+  input: 'needs input',
+};
+
+export function countActiveStatuses(statuses: string[]): ActiveStatusCounts {
+  const counts: ActiveStatusCounts = { working: 0, waiting: 0, input: 0 };
+  for (const s of statuses) {
+    if (s === 'working') counts.working++;
+    else if (s === 'waiting') counts.waiting++;
+    else if (s === 'input') counts.input++;
+  }
+  return counts;
+}
+
+export function buildWarningBannerDetail(counts: ActiveStatusCounts): string {
+  const parts: string[] = [];
+  for (const key of ['working', 'waiting', 'input'] as const) {
+    if (counts[key] > 0) {
+      const color = STATUS_COLORS[key];
+      const label = STATUS_LABELS[key];
+      parts.push(`<span style="color:${color}">&#9679;</span> ${counts[key]} ${label}`);
+    }
+  }
+
+  return `<div class="confirm-warning-header">\u26A0 Warning: Active sessions will be terminated</div>`
+    + `<div class="confirm-status-line">${parts.join('')}</div>`;
+}

--- a/src/renderer/components/confirm-helpers.ts
+++ b/src/renderer/components/confirm-helpers.ts
@@ -32,7 +32,7 @@ export function buildWarningBannerDetail(counts: ActiveStatusCounts): string {
     if (counts[key] > 0) {
       const color = STATUS_COLORS[key];
       const label = STATUS_LABELS[key];
-      parts.push(`<span style="color:${color}">&#9679;</span> ${counts[key]} ${label}`);
+      parts.push(`<span><span style="color:${color}">&#9679;</span> ${counts[key]} ${label}</span>`);
     }
   }
 

--- a/src/renderer/components/preferences-modal.ts
+++ b/src/renderer/components/preferences-modal.ts
@@ -62,6 +62,8 @@ export function showPreferencesModal(): void {
   let historyCheckbox: HTMLInputElement | null = null;
   let insightsCheckbox: HTMLInputElement | null = null;
   let autoTitleCheckbox: HTMLInputElement | null = null;
+  let confirmCloseActiveCheckbox: HTMLInputElement | null = null;
+  let confirmCloseInactiveCheckbox: HTMLInputElement | null = null;
   let defaultProviderSelect: CustomSelectInstance | null = null;
   let debugModeCheckbox: HTMLInputElement | null = null;
   let sidebarCheckboxes: { configSections: HTMLInputElement; gitPanel: HTMLInputElement; sessionHistory: HTMLInputElement; costFooter: HTMLInputElement; readinessSection: HTMLInputElement } | null = null;
@@ -197,6 +199,38 @@ export function showPreferencesModal(): void {
       autoTitleRow.appendChild(autoTitleLabel);
       autoTitleRow.appendChild(autoTitleCheckbox);
       content.appendChild(autoTitleRow);
+
+      const confirmActiveRow = document.createElement('div');
+      confirmActiveRow.className = 'modal-toggle-field';
+
+      const confirmActiveLabel = document.createElement('label');
+      confirmActiveLabel.htmlFor = 'pref-confirm-close-active';
+      confirmActiveLabel.textContent = 'Confirm before closing active sessions';
+
+      confirmCloseActiveCheckbox = document.createElement('input');
+      confirmCloseActiveCheckbox.type = 'checkbox';
+      confirmCloseActiveCheckbox.id = 'pref-confirm-close-active';
+      confirmCloseActiveCheckbox.checked = appState.preferences.confirmCloseActive;
+
+      confirmActiveRow.appendChild(confirmActiveLabel);
+      confirmActiveRow.appendChild(confirmCloseActiveCheckbox);
+      content.appendChild(confirmActiveRow);
+
+      const confirmInactiveRow = document.createElement('div');
+      confirmInactiveRow.className = 'modal-toggle-field';
+
+      const confirmInactiveLabel = document.createElement('label');
+      confirmInactiveLabel.htmlFor = 'pref-confirm-close-inactive';
+      confirmInactiveLabel.textContent = 'Confirm before closing inactive sessions';
+
+      confirmCloseInactiveCheckbox = document.createElement('input');
+      confirmCloseInactiveCheckbox.type = 'checkbox';
+      confirmCloseInactiveCheckbox.id = 'pref-confirm-close-inactive';
+      confirmCloseInactiveCheckbox.checked = appState.preferences.confirmCloseInactive;
+
+      confirmInactiveRow.appendChild(confirmInactiveLabel);
+      confirmInactiveRow.appendChild(confirmCloseInactiveCheckbox);
+      content.appendChild(confirmInactiveRow);
 
     } else if (section === 'sidebar') {
       const views = appState.preferences.sidebarViews ?? { configSections: true, gitPanel: true, sessionHistory: true, costFooter: true, readinessSection: true };
@@ -669,6 +703,12 @@ export function showPreferencesModal(): void {
     }
     if (autoTitleCheckbox) {
       appState.setPreference('autoTitleEnabled', autoTitleCheckbox.checked);
+    }
+    if (confirmCloseActiveCheckbox) {
+      appState.setPreference('confirmCloseActive', confirmCloseActiveCheckbox.checked);
+    }
+    if (confirmCloseInactiveCheckbox) {
+      appState.setPreference('confirmCloseInactive', confirmCloseInactiveCheckbox.checked);
     }
     if (defaultProviderSelect) {
       appState.setPreference('defaultProvider', defaultProviderSelect.getValue() as ProviderId);

--- a/src/renderer/components/sidebar.ts
+++ b/src/renderer/components/sidebar.ts
@@ -290,7 +290,6 @@ async function confirmRemoveProject(project: ProjectRecord): Promise<void> {
       message: 'The project and all its sessions will be removed. No files on disk will be affected.',
       detail,
       confirmLabel: 'Remove',
-      confirmDangerous: true,
     });
     if (!confirmed) return;
   } else {

--- a/src/renderer/components/sidebar.ts
+++ b/src/renderer/components/sidebar.ts
@@ -4,6 +4,9 @@ import { showPreferencesModal } from './preferences-modal.js';
 import { onChange as onCostChange, getAggregateCost } from '../session-cost.js';
 import { hasUnreadInProject, onChange as onUnreadChange } from '../session-unread.js';
 import { basename, lastSeparatorIndex } from '../../shared/platform.js';
+import { showConfirmDialog } from './confirm-dialog.js';
+import { getStatus } from '../session-activity.js';
+import { countActiveStatuses, buildWarningBannerDetail } from './confirm-helpers.js';
 
 const projectListEl = document.getElementById('project-list')!;
 let activeProjectContextMenu: HTMLElement | null = null;
@@ -275,12 +278,30 @@ function renderCostFooter(): void {
   }
 }
 
-function confirmRemoveProject(project: ProjectRecord): void {
-  const historyCount = project.sessionHistory?.length ?? 0;
-  const message = historyCount > 0
-    ? `Remove project "${project.name}"? This will delete all sessions and history (${historyCount} entries) from Vibeyard. No files on disk will be affected.`
-    : `Remove project "${project.name}"? No files on disk will be affected.`;
-  if (!confirm(message)) return;
+async function confirmRemoveProject(project: ProjectRecord): Promise<void> {
+  const statuses = project.sessions.map(s => getStatus(s.id));
+  const counts = countActiveStatuses(statuses);
+  const hasActive = counts.working + counts.waiting + counts.input > 0;
+
+  if (hasActive && appState.preferences.confirmCloseActive) {
+    const detail = buildWarningBannerDetail(counts);
+    const confirmed = await showConfirmDialog({
+      title: `Remove ${project.name}?`,
+      message: 'The project and all its sessions will be removed. No files on disk will be affected.',
+      detail,
+      confirmLabel: 'Remove',
+      confirmDangerous: true,
+    });
+    if (!confirmed) return;
+  } else {
+    // No active sessions — use simple native confirm for project removal
+    const historyCount = project.sessionHistory?.length ?? 0;
+    const message = historyCount > 0
+      ? `Remove project "${project.name}"? This will delete all sessions and history (${historyCount} entries) from Vibeyard. No files on disk will be affected.`
+      : `Remove project "${project.name}"? No files on disk will be affected.`;
+    if (!confirm(message)) return;
+  }
+
   appState.removeProject(project.id);
 }
 

--- a/src/renderer/components/tab-bar.ts
+++ b/src/renderer/components/tab-bar.ts
@@ -36,7 +36,6 @@ async function confirmBeforeClose(sessionId: string, sessionName: string): Promi
       title: 'Close active session?',
       message: `<span style="color:${status === 'working' ? '#e94560' : status === 'waiting' ? '#f4b400' : '#e67e22'}">&#9679;</span> &nbsp;<strong>${escapeHtml(sessionName)}</strong> is currently ${statusWord}.`,
       confirmLabel: 'Close',
-      confirmDangerous: true,
     });
   }
 
@@ -211,8 +210,7 @@ function showTabContextMenu(x: number, y: number, project: ProjectRecord, sessio
         message: '',
         detail,
         confirmLabel: 'Close All',
-        confirmDangerous: true,
-      });
+        });
       if (!confirmed) return;
     }
     appState.removeAllSessions(project.id);
@@ -237,8 +235,7 @@ function showTabContextMenu(x: number, y: number, project: ProjectRecord, sessio
           message: '',
           detail,
           confirmLabel: 'Close Others',
-          confirmDangerous: true,
-        });
+            });
         if (!confirmed) return;
       }
       appState.removeOtherSessions(project.id, session.id);
@@ -264,8 +261,7 @@ function showTabContextMenu(x: number, y: number, project: ProjectRecord, sessio
           message: '',
           detail,
           confirmLabel: 'Close to Right',
-          confirmDangerous: true,
-        });
+            });
         if (!confirmed) return;
       }
       appState.removeSessionsFromRight(project.id, session.id);
@@ -291,8 +287,7 @@ function showTabContextMenu(x: number, y: number, project: ProjectRecord, sessio
           message: '',
           detail,
           confirmLabel: 'Close to Left',
-          confirmDangerous: true,
-        });
+            });
         if (!confirmed) return;
       }
       appState.removeSessionsFromLeft(project.id, session.id);

--- a/src/renderer/components/tab-bar.ts
+++ b/src/renderer/components/tab-bar.ts
@@ -4,6 +4,8 @@ import { showModal, closeModal, setModalError, FieldDef } from './modal.js';
 import { onChange as onStatusChange, getStatus, type SessionStatus } from '../session-activity.js';
 import { onChange as onGitStatusChange, getGitStatus, getActiveGitPath, refreshGitStatus } from '../git-status.js';
 
+import { showConfirmDialog } from './confirm-dialog.js';
+import { countActiveStatuses, buildWarningBannerDetail } from './confirm-helpers.js';
 import { isUnread, onChange as onUnreadChange } from '../session-unread.js';
 import { showHelpDialog } from './help-dialog.js';
 import { showShareDialog } from './share-dialog.js';
@@ -23,6 +25,37 @@ const btnHelp = document.getElementById('btn-help')!;
 
 let activeContextMenu: HTMLElement | null = null;
 const prevStatus = new Map<string, SessionStatus>();
+
+async function confirmBeforeClose(sessionId: string, sessionName: string): Promise<boolean> {
+  const status = getStatus(sessionId);
+  const isActive = status === 'working' || status === 'waiting' || status === 'input';
+
+  if (isActive && appState.preferences.confirmCloseActive) {
+    const statusWord = status === 'input' ? 'waiting for input' : status;
+    return showConfirmDialog({
+      title: 'Close active session?',
+      message: `<span style="color:${status === 'working' ? '#e94560' : status === 'waiting' ? '#f4b400' : '#e67e22'}">&#9679;</span> &nbsp;<strong>${escapeHtml(sessionName)}</strong> is currently ${statusWord}.`,
+      confirmLabel: 'Close',
+      confirmDangerous: true,
+    });
+  }
+
+  if (!isActive && appState.preferences.confirmCloseInactive) {
+    return showConfirmDialog({
+      title: 'Close session?',
+      message: `Close "${escapeHtml(sessionName)}"?`,
+      confirmLabel: 'Close',
+    });
+  }
+
+  return true;
+}
+
+function escapeHtml(text: string): string {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
 
 function buildTooltip(status: SessionStatus, cliSessionId?: string): string {
   const statusLine = `Status: ${status}`;
@@ -147,10 +180,12 @@ function showTabContextMenu(x: number, y: number, project: ProjectRecord, sessio
   const closeItem = document.createElement('div');
   closeItem.className = 'tab-context-menu-item';
   closeItem.textContent = 'Close';
-  closeItem.addEventListener('click', (e) => {
+  closeItem.addEventListener('click', async (e) => {
     e.stopPropagation();
     hideTabContextMenu();
-    appState.removeSession(project.id, session.id);
+    if (await confirmBeforeClose(session.id, session.name)) {
+      appState.removeSession(project.id, session.id);
+    }
   });
 
   const sessionIdx = project.sessions.findIndex((s) => s.id === session.id);
@@ -162,9 +197,24 @@ function showTabContextMenu(x: number, y: number, project: ProjectRecord, sessio
   const closeAllItem = document.createElement('div');
   closeAllItem.className = 'tab-context-menu-item';
   closeAllItem.textContent = 'Close All';
-  closeAllItem.addEventListener('click', (e) => {
+  closeAllItem.addEventListener('click', async (e) => {
     e.stopPropagation();
     hideTabContextMenu();
+    const statuses = project.sessions.map(s => getStatus(s.id));
+    const counts = countActiveStatuses(statuses);
+    const hasActive = counts.working + counts.waiting + counts.input > 0;
+
+    if (hasActive && appState.preferences.confirmCloseActive) {
+      const detail = buildWarningBannerDetail(counts);
+      const confirmed = await showConfirmDialog({
+        title: 'Close all sessions?',
+        message: '',
+        detail,
+        confirmLabel: 'Close All',
+        confirmDangerous: true,
+      });
+      if (!confirmed) return;
+    }
     appState.removeAllSessions(project.id);
   });
 
@@ -172,9 +222,25 @@ function showTabContextMenu(x: number, y: number, project: ProjectRecord, sessio
   closeOthersItem.className = 'tab-context-menu-item' + (totalSessions <= 1 ? ' disabled' : '');
   closeOthersItem.textContent = 'Close Others';
   if (totalSessions > 1) {
-    closeOthersItem.addEventListener('click', (e) => {
+    closeOthersItem.addEventListener('click', async (e) => {
       e.stopPropagation();
       hideTabContextMenu();
+      const others = project.sessions.filter(s => s.id !== session.id);
+      const statuses = others.map(s => getStatus(s.id));
+      const counts = countActiveStatuses(statuses);
+      const hasActive = counts.working + counts.waiting + counts.input > 0;
+
+      if (hasActive && appState.preferences.confirmCloseActive) {
+        const detail = buildWarningBannerDetail(counts);
+        const confirmed = await showConfirmDialog({
+          title: 'Close other sessions?',
+          message: '',
+          detail,
+          confirmLabel: 'Close Others',
+          confirmDangerous: true,
+        });
+        if (!confirmed) return;
+      }
       appState.removeOtherSessions(project.id, session.id);
     });
   }
@@ -183,9 +249,25 @@ function showTabContextMenu(x: number, y: number, project: ProjectRecord, sessio
   closeRightItem.className = 'tab-context-menu-item' + (sessionIdx >= totalSessions - 1 ? ' disabled' : '');
   closeRightItem.textContent = 'Close to the Right';
   if (sessionIdx < totalSessions - 1) {
-    closeRightItem.addEventListener('click', (e) => {
+    closeRightItem.addEventListener('click', async (e) => {
       e.stopPropagation();
       hideTabContextMenu();
+      const rightSessions = project.sessions.slice(sessionIdx + 1);
+      const statuses = rightSessions.map(s => getStatus(s.id));
+      const counts = countActiveStatuses(statuses);
+      const hasActive = counts.working + counts.waiting + counts.input > 0;
+
+      if (hasActive && appState.preferences.confirmCloseActive) {
+        const detail = buildWarningBannerDetail(counts);
+        const confirmed = await showConfirmDialog({
+          title: 'Close sessions to the right?',
+          message: '',
+          detail,
+          confirmLabel: 'Close to Right',
+          confirmDangerous: true,
+        });
+        if (!confirmed) return;
+      }
       appState.removeSessionsFromRight(project.id, session.id);
     });
   }
@@ -194,9 +276,25 @@ function showTabContextMenu(x: number, y: number, project: ProjectRecord, sessio
   closeLeftItem.className = 'tab-context-menu-item' + (sessionIdx <= 0 ? ' disabled' : '');
   closeLeftItem.textContent = 'Close to the Left';
   if (sessionIdx > 0) {
-    closeLeftItem.addEventListener('click', (e) => {
+    closeLeftItem.addEventListener('click', async (e) => {
       e.stopPropagation();
       hideTabContextMenu();
+      const leftSessions = project.sessions.slice(0, sessionIdx);
+      const statuses = leftSessions.map(s => getStatus(s.id));
+      const counts = countActiveStatuses(statuses);
+      const hasActive = counts.working + counts.waiting + counts.input > 0;
+
+      if (hasActive && appState.preferences.confirmCloseActive) {
+        const detail = buildWarningBannerDetail(counts);
+        const confirmed = await showConfirmDialog({
+          title: 'Close sessions to the left?',
+          message: '',
+          detail,
+          confirmLabel: 'Close to Left',
+          confirmDangerous: true,
+        });
+        if (!confirmed) return;
+      }
       appState.removeSessionsFromLeft(project.id, session.id);
     });
   }
@@ -400,10 +498,12 @@ function render(): void {
     });
 
     // Middle-click to close
-    tab.addEventListener('auxclick', (e) => {
+    tab.addEventListener('auxclick', async (e) => {
       if (e.button === 1) {
         e.preventDefault();
-        appState.removeSession(project.id, session.id);
+        if (await confirmBeforeClose(session.id, session.name)) {
+          appState.removeSession(project.id, session.id);
+        }
       }
     });
 
@@ -417,8 +517,10 @@ function render(): void {
     });
 
     // Close button
-    tab.querySelector('.tab-close')!.addEventListener('click', () => {
-      appState.removeSession(project.id, session.id);
+    tab.querySelector('.tab-close')!.addEventListener('click', async () => {
+      if (await confirmBeforeClose(session.id, session.name)) {
+        appState.removeSession(project.id, session.id);
+      }
     });
 
     tab.addEventListener('dragstart', (e) => {

--- a/src/renderer/components/tab-bar.ts
+++ b/src/renderer/components/tab-bar.ts
@@ -31,7 +31,7 @@ async function confirmBeforeClose(sessionId: string, sessionName: string): Promi
   const isActive = status === 'working' || status === 'waiting' || status === 'input';
 
   if (isActive && appState.preferences.confirmCloseActive) {
-    const statusWord = status === 'input' ? 'waiting for input' : status;
+    const statusWord = status === 'input' ? 'needs input' : status;
     return showConfirmDialog({
       title: 'Close active session?',
       message: `<span style="color:${status === 'working' ? '#e94560' : status === 'waiting' ? '#f4b400' : '#e67e22'}">&#9679;</span> &nbsp;<strong>${escapeHtml(sessionName)}</strong> is currently ${statusWord}.`,

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -37,6 +37,7 @@ import type { InspectorEvent } from '../shared/types.js';
 import { getContext } from './session-context.js';
 import { initSessionInspector } from './components/session-inspector.js';
 import { loadProviderMetas } from './provider-availability.js';
+import { initCloseGuard } from './close-guard.js';
 
 let isQuitting = false;
 window.vibeyard.app.onQuitting(() => {
@@ -196,6 +197,8 @@ async function main(): Promise<void> {
 
   // Load persisted state
   await appState.load();
+
+  initCloseGuard();
 
   // Auto-open new project modal when no projects exist
   if (appState.projects.length === 0) {

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -41,6 +41,8 @@ const defaultPreferences: Preferences = {
   sessionHistoryEnabled: true,
   insightsEnabled: true,
   autoTitleEnabled: true,
+  confirmCloseActive: true,
+  confirmCloseInactive: false,
   readinessExcludedProviders: [],
   sidebarViews: { configSections: true, gitPanel: true, sessionHistory: true, costFooter: true, readinessSection: true },
 };

--- a/src/renderer/styles/modals.css
+++ b/src/renderer/styles/modals.css
@@ -543,3 +543,32 @@
   font-size: 11px;
   color: var(--text-muted);
 }
+
+/* Close confirmation dialog */
+.confirm-warning-banner {
+  background: rgba(233, 69, 96, 0.1);
+  border: 1px solid rgba(233, 69, 96, 0.3);
+  border-radius: 4px;
+  padding: 10px 12px;
+}
+
+.confirm-warning-header {
+  font-size: 12px;
+  color: #e94560;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.confirm-status-line {
+  font-size: 12px;
+  color: var(--text-secondary);
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.confirm-message {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -67,6 +67,8 @@ export interface VibeyardApi {
     getVersion(): Promise<string>;
     openExternal(url: string): Promise<void>;
     onQuitting(callback: () => void): () => void;
+    onConfirmClose(callback: () => void): () => void;
+    closeConfirmed(): void;
   };
   mcp: {
     connect(id: string, url: string): Promise<McpResult>;

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -69,6 +69,7 @@ export interface VibeyardApi {
     onQuitting(callback: () => void): () => void;
     onConfirmClose(callback: () => void): () => void;
     closeConfirmed(): void;
+    closeCancelled(): void;
   };
   mcp: {
     connect(id: string, url: string): Promise<McpResult>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -150,6 +150,8 @@ export interface Preferences {
   sessionHistoryEnabled: boolean;
   insightsEnabled: boolean;
   autoTitleEnabled: boolean;
+  confirmCloseActive: boolean;
+  confirmCloseInactive: boolean;
   defaultProvider?: ProviderId;
   statusLineConsent?: 'granted' | 'declined' | null;
   keybindings?: Record<string, string>;


### PR DESCRIPTION
## Summary
- Adds confirmation dialogs guarding three close actions when a session is in `working`/`waiting`/`input` state: tab close (X / middle-click / context menu), project removal (sidebar context menu), and window close (X / Alt+F4) via IPC round-trip.
- New `confirm-dialog.ts` module (Promise-based, separate from form-input `modal.ts`) and `confirm-helpers.ts` for status-aggregation banners. New `close-guard.ts` listens for `app:confirmClose` IPC and responds with `app:closeConfirmed`/`app:closeCancelled`.
- Adds two preferences in General: `confirmCloseActive` (default on) and `confirmCloseInactive` (default off). Cmd+Q / menu quit bypasses via the module-scoped `forceClose` flag set in `before-quit`.
- Includes co-located vitest coverage for the new modules. `jsdom` added as an explicit devDependency.

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] All tests pass (`npm test`)
- [ ] Tab X with an active session shows the minimal confirmation dialog
- [ ] Project removal with multiple active sessions shows aggregated status banner
- [ ] Window X / Alt+F4 with active sessions shows banner; cancel keeps app open
- [ ] Cmd+Q / menu Quit bypasses the dialog (via `before-quit`)
- [ ] Toggling `confirmCloseActive` off in Preferences disables all three dialogs
- [ ] No dialog appears when only inactive sessions are present (with default `confirmCloseInactive: false`)

## Dependencies
None. This is the foundation PR; #2 (terminal context menu) and #3 (sidebar usage indicator) are stacked on top of this branch and will rebase cleanly once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)