### PR TITLE
fix: CLAUDE.md recognition

### DIFF
--- a/src/main/readiness/checkers/ai-instructions.test.ts
+++ b/src/main/readiness/checkers/ai-instructions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'fs';
+import * as path from 'path';
 import { aiInstructionsProducer } from './ai-instructions';
 import type { AnalysisContext } from '../types';
 
@@ -75,6 +76,27 @@ describe('aiInstructionsProducer', () => {
     const tagged = aiInstructionsProducer.produce('/test/project', ctx);
     const check = tagged.find(t => t.check.id === 'claude-md-architecture')!.check;
     expect(check.status).toBe('pass');
+  });
+
+  it('uses .claude/CLAUDE.md when root CLAUDE.md is missing', () => {
+    mockFileExists({ [path.join('.claude', 'CLAUDE.md')]: '## Build\nnpm run build\n## Testing\nnpm test\n## Architecture\nReadiness architecture\n' });
+
+    const tagged = aiInstructionsProducer.produce('/test/project', ctx);
+
+    expect(tagged.find(t => t.check.id === 'claude-md-exists')!.check.status).toBe('pass');
+    expect(tagged.find(t => t.check.id === 'claude-md-build')!.check.status).toBe('pass');
+    expect(tagged.find(t => t.check.id === 'claude-md-test')!.check.status).toBe('pass');
+    expect(tagged.find(t => t.check.id === 'claude-md-architecture')!.check.status).toBe('pass');
+  });
+
+  it('prefers root CLAUDE.md over .claude/CLAUDE.md when both exist', () => {
+    mockFileExists({ 'CLAUDE.md': 'root only\n', [path.join('.claude', 'CLAUDE.md')]: '## Build\nnpm run build\n## Testing\nnpm test\n## Architecture\nDetailed\n' });
+
+    const tagged = aiInstructionsProducer.produce('/test/project', ctx);
+
+    expect(tagged.find(t => t.check.id === 'claude-md-build')!.check.status).toBe('fail');
+    expect(tagged.find(t => t.check.id === 'claude-md-test')!.check.status).toBe('fail');
+    expect(tagged.find(t => t.check.id === 'claude-md-architecture')!.check.status).toBe('fail');
   });
 
   it('warns for small CLAUDE.md', () => {

--- a/src/main/readiness/checkers/ai-instructions.ts
+++ b/src/main/readiness/checkers/ai-instructions.ts
@@ -14,8 +14,11 @@ export function makeInstructionProducer(providerId: ProviderId, opts: Instructio
   };
 }
 
-export const aiInstructionsProducer = makeInstructionProducer('claude', {
+export const claudeInstructionFileOpts: InstructionFileOpts = {
   fileName: 'CLAUDE.md',
+  fallbackDirectory: '.claude',
   idPrefix: 'claude-md',
   displayName: 'CLAUDE.md',
-});
+};
+
+export const aiInstructionsProducer = makeInstructionProducer('claude', claudeInstructionFileOpts);

--- a/src/main/readiness/checkers/claude-context.test.ts
+++ b/src/main/readiness/checkers/claude-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'fs';
 import * as child_process from 'child_process';
+import * as path from 'path';
 import { claudeContextProducer } from './claude-context';
 import type { AnalysisContext } from '../types';
 
@@ -16,6 +17,25 @@ beforeEach(() => {
 
 function makeCtx(trackedFiles: string[]): AnalysisContext {
   return { trackedFiles };
+}
+
+function mockInstructionFiles(files: Record<string, string>): void {
+  mockFs.statSync.mockImplementation((p: fs.PathLike) => {
+    const filePath = String(p);
+    for (const key of Object.keys(files)) {
+      if (filePath.endsWith(key)) {
+        return { isFile: () => true, isDirectory: () => false } as fs.Stats;
+      }
+    }
+    throw new Error('ENOENT');
+  });
+  mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
+    const filePath = String(p);
+    for (const [key, content] of Object.entries(files)) {
+      if (filePath.endsWith(key)) return content;
+    }
+    throw new Error('ENOENT');
+  });
 }
 
 describe('claudeContextProducer', () => {
@@ -40,11 +60,7 @@ describe('claudeContextProducer', () => {
 
   it('warns for CLAUDE.md between 300-500 lines', () => {
     const content = Array(400).fill('line').join('\n');
-    mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
-      if (String(p).endsWith('CLAUDE.md')) return content;
-      throw new Error('ENOENT');
-    });
-    mockFs.statSync.mockImplementation(() => { throw new Error('ENOENT'); });
+    mockInstructionFiles({ 'CLAUDE.md': content });
 
     const tagged = claudeContextProducer.produce('/test/project', makeCtx([]));
     const check = tagged.find(t => t.check.id === 'claude-md-bloat')!.check;
@@ -52,13 +68,30 @@ describe('claudeContextProducer', () => {
     expect(check.score).toBe(50);
   });
 
+  it('uses .claude/CLAUDE.md for bloat checks when root is missing', () => {
+    const content = Array(400).fill('line').join('\n');
+    mockInstructionFiles({ [path.join('.claude', 'CLAUDE.md')]: content });
+
+    const tagged = claudeContextProducer.produce('/test/project', makeCtx([]));
+    expect(tagged.find(t => t.check.id === 'claude-md-bloat')!.check.status).toBe('warning');
+  });
+
+  it('prefers root CLAUDE.md for bloat checks when both files exist', () => {
+    const rootContent = Array(50).fill('line').join('\n');
+    const fallbackContent = Array(600).fill('line').join('\n');
+
+    mockInstructionFiles({
+      'CLAUDE.md': rootContent,
+      [path.join('.claude', 'CLAUDE.md')]: fallbackContent,
+    });
+
+    const tagged = claudeContextProducer.produce('/test/project', makeCtx([]));
+    expect(tagged.find(t => t.check.id === 'claude-md-bloat')!.check.status).toBe('pass');
+  });
+
   it('fails for CLAUDE.md over 500 lines', () => {
     const content = Array(600).fill('line').join('\n');
-    mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
-      if (String(p).endsWith('CLAUDE.md')) return content;
-      throw new Error('ENOENT');
-    });
-    mockFs.statSync.mockImplementation(() => { throw new Error('ENOENT'); });
+    mockInstructionFiles({ 'CLAUDE.md': content });
 
     const tagged = claudeContextProducer.produce('/test/project', makeCtx([]));
     const check = tagged.find(t => t.check.id === 'claude-md-bloat')!.check;

--- a/src/main/readiness/checkers/claude-context.test.ts
+++ b/src/main/readiness/checkers/claude-context.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as child_process from 'child_process';
 import * as path from 'path';
 import { claudeContextProducer } from './claude-context';
+import { mockInstructionFiles } from '../test-utils';
 import type { AnalysisContext } from '../types';
 
 vi.mock('fs');
@@ -17,25 +18,6 @@ beforeEach(() => {
 
 function makeCtx(trackedFiles: string[]): AnalysisContext {
   return { trackedFiles };
-}
-
-function mockInstructionFiles(files: Record<string, string>): void {
-  mockFs.statSync.mockImplementation((p: fs.PathLike) => {
-    const filePath = String(p);
-    for (const key of Object.keys(files)) {
-      if (filePath.endsWith(key)) {
-        return { isFile: () => true, isDirectory: () => false } as fs.Stats;
-      }
-    }
-    throw new Error('ENOENT');
-  });
-  mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
-    const filePath = String(p);
-    for (const [key, content] of Object.entries(files)) {
-      if (filePath.endsWith(key)) return content;
-    }
-    throw new Error('ENOENT');
-  });
 }
 
 describe('claudeContextProducer', () => {
@@ -60,7 +42,7 @@ describe('claudeContextProducer', () => {
 
   it('warns for CLAUDE.md between 300-500 lines', () => {
     const content = Array(400).fill('line').join('\n');
-    mockInstructionFiles({ 'CLAUDE.md': content });
+    mockInstructionFiles(mockFs, { 'CLAUDE.md': content });
 
     const tagged = claudeContextProducer.produce('/test/project', makeCtx([]));
     const check = tagged.find(t => t.check.id === 'claude-md-bloat')!.check;
@@ -70,7 +52,7 @@ describe('claudeContextProducer', () => {
 
   it('uses .claude/CLAUDE.md for bloat checks when root is missing', () => {
     const content = Array(400).fill('line').join('\n');
-    mockInstructionFiles({ [path.join('.claude', 'CLAUDE.md')]: content });
+    mockInstructionFiles(mockFs, { [path.join('.claude', 'CLAUDE.md')]: content });
 
     const tagged = claudeContextProducer.produce('/test/project', makeCtx([]));
     expect(tagged.find(t => t.check.id === 'claude-md-bloat')!.check.status).toBe('warning');
@@ -80,7 +62,7 @@ describe('claudeContextProducer', () => {
     const rootContent = Array(50).fill('line').join('\n');
     const fallbackContent = Array(600).fill('line').join('\n');
 
-    mockInstructionFiles({
+    mockInstructionFiles(mockFs, {
       'CLAUDE.md': rootContent,
       [path.join('.claude', 'CLAUDE.md')]: fallbackContent,
     });
@@ -91,7 +73,7 @@ describe('claudeContextProducer', () => {
 
   it('fails for CLAUDE.md over 500 lines', () => {
     const content = Array(600).fill('line').join('\n');
-    mockInstructionFiles({ 'CLAUDE.md': content });
+    mockInstructionFiles(mockFs, { 'CLAUDE.md': content });
 
     const tagged = claudeContextProducer.produce('/test/project', makeCtx([]));
     const check = tagged.find(t => t.check.id === 'claude-md-bloat')!.check;

--- a/src/main/readiness/checkers/claude-context.ts
+++ b/src/main/readiness/checkers/claude-context.ts
@@ -4,6 +4,7 @@ import type { ReadinessCheck } from '../../../shared/types';
 import type { ReadinessCheckProducer, TaggedCheck, AnalysisContext } from '../types';
 import { fileExists } from '../utils';
 import { checkNotBloated } from './instruction-file-checks';
+import { claudeInstructionFileOpts } from './ai-instructions';
 
 const SENSITIVE_FILE_PATTERNS = [
   '.env', '.env.*',
@@ -88,7 +89,7 @@ export const claudeContextProducer: ReadinessCheckProducer = {
 
   produce(projectPath: string, ctx: AnalysisContext): TaggedCheck[] {
     return [
-      checkNotBloated(projectPath, { fileName: 'CLAUDE.md', idPrefix: 'claude-md', displayName: 'CLAUDE.md' }),
+      checkNotBloated(projectPath, claudeInstructionFileOpts),
       checkClaudeignore(projectPath, ctx.trackedFiles),
     ].map(check => ({ category: 'context', check }));
   },

--- a/src/main/readiness/checkers/codex-context.test.ts
+++ b/src/main/readiness/checkers/codex-context.test.ts
@@ -12,6 +12,19 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
+function mockInstructionFile(fileName: string, content: string): void {
+  mockFs.statSync.mockImplementation((p: fs.PathLike) => {
+    if (String(p).endsWith(fileName)) {
+      return { isFile: () => true, isDirectory: () => false } as fs.Stats;
+    }
+    throw new Error('ENOENT');
+  });
+  mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
+    if (String(p).endsWith(fileName)) return content;
+    throw new Error('ENOENT');
+  });
+}
+
 describe('codexContextProducer', () => {
   it('returns tagged check with context category', () => {
     mockFs.readFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
@@ -34,20 +47,14 @@ describe('codexContextProducer', () => {
   });
 
   it('passes for AGENTS.md under 300 lines', () => {
-    mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
-      if (String(p).endsWith('AGENTS.md')) return Array(200).fill('line').join('\n');
-      throw new Error('ENOENT');
-    });
+    mockInstructionFile('AGENTS.md', Array(200).fill('line').join('\n'));
 
     const tagged = codexContextProducer.produce('/test/project', ctx);
     expect(tagged[0].check.status).toBe('pass');
   });
 
   it('warns for AGENTS.md between 300-500 lines', () => {
-    mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
-      if (String(p).endsWith('AGENTS.md')) return Array(400).fill('line').join('\n');
-      throw new Error('ENOENT');
-    });
+    mockInstructionFile('AGENTS.md', Array(400).fill('line').join('\n'));
 
     const tagged = codexContextProducer.produce('/test/project', ctx);
     expect(tagged[0].check.status).toBe('warning');
@@ -55,10 +62,7 @@ describe('codexContextProducer', () => {
   });
 
   it('fails for AGENTS.md over 500 lines', () => {
-    mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
-      if (String(p).endsWith('AGENTS.md')) return Array(600).fill('line').join('\n');
-      throw new Error('ENOENT');
-    });
+    mockInstructionFile('AGENTS.md', Array(600).fill('line').join('\n'));
 
     const tagged = codexContextProducer.produce('/test/project', ctx);
     expect(tagged[0].check.status).toBe('fail');

--- a/src/main/readiness/checkers/codex-context.test.ts
+++ b/src/main/readiness/checkers/codex-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'fs';
 import { codexContextProducer } from './codex-context';
+import { mockInstructionFiles } from '../test-utils';
 import type { AnalysisContext } from '../types';
 
 vi.mock('fs');
@@ -11,19 +12,6 @@ const ctx: AnalysisContext = { trackedFiles: [] };
 beforeEach(() => {
   vi.resetAllMocks();
 });
-
-function mockInstructionFile(fileName: string, content: string): void {
-  mockFs.statSync.mockImplementation((p: fs.PathLike) => {
-    if (String(p).endsWith(fileName)) {
-      return { isFile: () => true, isDirectory: () => false } as fs.Stats;
-    }
-    throw new Error('ENOENT');
-  });
-  mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
-    if (String(p).endsWith(fileName)) return content;
-    throw new Error('ENOENT');
-  });
-}
 
 describe('codexContextProducer', () => {
   it('returns tagged check with context category', () => {
@@ -47,14 +35,14 @@ describe('codexContextProducer', () => {
   });
 
   it('passes for AGENTS.md under 300 lines', () => {
-    mockInstructionFile('AGENTS.md', Array(200).fill('line').join('\n'));
+    mockInstructionFiles(mockFs, { 'AGENTS.md': Array(200).fill('line').join('\n') });
 
     const tagged = codexContextProducer.produce('/test/project', ctx);
     expect(tagged[0].check.status).toBe('pass');
   });
 
   it('warns for AGENTS.md between 300-500 lines', () => {
-    mockInstructionFile('AGENTS.md', Array(400).fill('line').join('\n'));
+    mockInstructionFiles(mockFs, { 'AGENTS.md': Array(400).fill('line').join('\n') });
 
     const tagged = codexContextProducer.produce('/test/project', ctx);
     expect(tagged[0].check.status).toBe('warning');
@@ -62,7 +50,7 @@ describe('codexContextProducer', () => {
   });
 
   it('fails for AGENTS.md over 500 lines', () => {
-    mockInstructionFile('AGENTS.md', Array(600).fill('line').join('\n'));
+    mockInstructionFiles(mockFs, { 'AGENTS.md': Array(600).fill('line').join('\n') });
 
     const tagged = codexContextProducer.produce('/test/project', ctx);
     expect(tagged[0].check.status).toBe('fail');

--- a/src/main/readiness/checkers/gemini-context.test.ts
+++ b/src/main/readiness/checkers/gemini-context.test.ts
@@ -12,6 +12,19 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
+function mockInstructionFile(fileName: string, content: string): void {
+  mockFs.statSync.mockImplementation((p: fs.PathLike) => {
+    if (String(p).endsWith(fileName)) {
+      return { isFile: () => true, isDirectory: () => false } as fs.Stats;
+    }
+    throw new Error('ENOENT');
+  });
+  mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
+    if (String(p).endsWith(fileName)) return content;
+    throw new Error('ENOENT');
+  });
+}
+
 describe('geminiContextProducer', () => {
   it('returns tagged check with context category', () => {
     mockFs.readFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
@@ -34,20 +47,14 @@ describe('geminiContextProducer', () => {
   });
 
   it('passes for GEMINI.md under 300 lines', () => {
-    mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
-      if (String(p).endsWith('GEMINI.md')) return Array(200).fill('line').join('\n');
-      throw new Error('ENOENT');
-    });
+    mockInstructionFile('GEMINI.md', Array(200).fill('line').join('\n'));
 
     const tagged = geminiContextProducer.produce('/test/project', ctx);
     expect(tagged[0].check.status).toBe('pass');
   });
 
   it('warns for GEMINI.md between 300-500 lines', () => {
-    mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
-      if (String(p).endsWith('GEMINI.md')) return Array(400).fill('line').join('\n');
-      throw new Error('ENOENT');
-    });
+    mockInstructionFile('GEMINI.md', Array(400).fill('line').join('\n'));
 
     const tagged = geminiContextProducer.produce('/test/project', ctx);
     expect(tagged[0].check.status).toBe('warning');
@@ -55,10 +62,7 @@ describe('geminiContextProducer', () => {
   });
 
   it('fails for GEMINI.md over 500 lines', () => {
-    mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
-      if (String(p).endsWith('GEMINI.md')) return Array(600).fill('line').join('\n');
-      throw new Error('ENOENT');
-    });
+    mockInstructionFile('GEMINI.md', Array(600).fill('line').join('\n'));
 
     const tagged = geminiContextProducer.produce('/test/project', ctx);
     expect(tagged[0].check.status).toBe('fail');

--- a/src/main/readiness/checkers/gemini-context.test.ts
+++ b/src/main/readiness/checkers/gemini-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'fs';
 import { geminiContextProducer } from './gemini-context';
+import { mockInstructionFiles } from '../test-utils';
 import type { AnalysisContext } from '../types';
 
 vi.mock('fs');
@@ -11,19 +12,6 @@ const ctx: AnalysisContext = { trackedFiles: [] };
 beforeEach(() => {
   vi.resetAllMocks();
 });
-
-function mockInstructionFile(fileName: string, content: string): void {
-  mockFs.statSync.mockImplementation((p: fs.PathLike) => {
-    if (String(p).endsWith(fileName)) {
-      return { isFile: () => true, isDirectory: () => false } as fs.Stats;
-    }
-    throw new Error('ENOENT');
-  });
-  mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
-    if (String(p).endsWith(fileName)) return content;
-    throw new Error('ENOENT');
-  });
-}
 
 describe('geminiContextProducer', () => {
   it('returns tagged check with context category', () => {
@@ -47,14 +35,14 @@ describe('geminiContextProducer', () => {
   });
 
   it('passes for GEMINI.md under 300 lines', () => {
-    mockInstructionFile('GEMINI.md', Array(200).fill('line').join('\n'));
+    mockInstructionFiles(mockFs, { 'GEMINI.md': Array(200).fill('line').join('\n') });
 
     const tagged = geminiContextProducer.produce('/test/project', ctx);
     expect(tagged[0].check.status).toBe('pass');
   });
 
   it('warns for GEMINI.md between 300-500 lines', () => {
-    mockInstructionFile('GEMINI.md', Array(400).fill('line').join('\n'));
+    mockInstructionFiles(mockFs, { 'GEMINI.md': Array(400).fill('line').join('\n') });
 
     const tagged = geminiContextProducer.produce('/test/project', ctx);
     expect(tagged[0].check.status).toBe('warning');
@@ -62,7 +50,7 @@ describe('geminiContextProducer', () => {
   });
 
   it('fails for GEMINI.md over 500 lines', () => {
-    mockInstructionFile('GEMINI.md', Array(600).fill('line').join('\n'));
+    mockInstructionFiles(mockFs, { 'GEMINI.md': Array(600).fill('line').join('\n') });
 
     const tagged = geminiContextProducer.produce('/test/project', ctx);
     expect(tagged[0].check.status).toBe('fail');

--- a/src/main/readiness/checkers/instruction-file-checks.ts
+++ b/src/main/readiness/checkers/instruction-file-checks.ts
@@ -4,12 +4,28 @@ import { fileExists, readFileSafe } from '../utils';
 
 export interface InstructionFileOpts {
   fileName: string;      // e.g. 'CLAUDE.md' or 'AGENTS.md'
+  fallbackDirectory?: string; // e.g. '.claude'
   idPrefix: string;      // e.g. 'claude-md' or 'agents-md'
   displayName: string;   // e.g. 'CLAUDE.md' or 'AGENTS.md'
 }
 
+export function resolveInstructionFilePath(projectPath: string, opts: InstructionFileOpts): string | null {
+  const candidates = [
+    path.join(projectPath, opts.fileName),
+    opts.fallbackDirectory ? path.join(projectPath, opts.fallbackDirectory, opts.fileName) : null,
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  for (const candidate of candidates) {
+    if (fileExists(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
 export function checkFileExists(projectPath: string, opts: InstructionFileOpts): ReadinessCheck {
-  const exists = fileExists(path.join(projectPath, opts.fileName));
+  const exists = resolveInstructionFilePath(projectPath, opts) !== null;
   return {
     id: `${opts.idPrefix}-exists`,
     name: `${opts.displayName} exists`,
@@ -162,7 +178,8 @@ export function checkFileSize(content: string | null, opts: InstructionFileOpts)
 }
 
 export function checkNotBloated(projectPath: string, opts: InstructionFileOpts): ReadinessCheck {
-  const content = readFileSafe(path.join(projectPath, opts.fileName));
+  const instructionPath = resolveInstructionFilePath(projectPath, opts);
+  const content = instructionPath ? readFileSafe(instructionPath) : null;
   if (!content) {
     return {
       id: `${opts.idPrefix}-bloat`,
@@ -193,7 +210,8 @@ export function checkNotBloated(projectPath: string, opts: InstructionFileOpts):
 }
 
 export function runAllInstructionChecks(projectPath: string, opts: InstructionFileOpts): ReadinessCheck[] {
-  const content = readFileSafe(path.join(projectPath, opts.fileName));
+  const instructionPath = resolveInstructionFilePath(projectPath, opts);
+  const content = instructionPath ? readFileSafe(instructionPath) : null;
   return [
     checkFileExists(projectPath, opts),
     checkBuildCommands(content, opts),

--- a/src/main/readiness/checkers/instruction-file-checks.ts
+++ b/src/main/readiness/checkers/instruction-file-checks.ts
@@ -3,17 +3,18 @@ import type { ReadinessCheck } from '../../../shared/types';
 import { fileExists, readFileSafe } from '../utils';
 
 export interface InstructionFileOpts {
-  fileName: string;      // e.g. 'CLAUDE.md' or 'AGENTS.md'
+  fileName: string;           // e.g. 'CLAUDE.md' or 'AGENTS.md'
   fallbackDirectory?: string; // e.g. '.claude'
-  idPrefix: string;      // e.g. 'claude-md' or 'agents-md'
-  displayName: string;   // e.g. 'CLAUDE.md' or 'AGENTS.md'
+  idPrefix: string;           // e.g. 'claude-md' or 'agents-md'
+  displayName: string;        // e.g. 'CLAUDE.md' or 'AGENTS.md'
 }
 
 export function resolveInstructionFilePath(projectPath: string, opts: InstructionFileOpts): string | null {
-  const candidates = [
-    path.join(projectPath, opts.fileName),
-    opts.fallbackDirectory ? path.join(projectPath, opts.fallbackDirectory, opts.fileName) : null,
-  ].filter((candidate): candidate is string => Boolean(candidate));
+  const candidates = [path.join(projectPath, opts.fileName)];
+
+  if (opts.fallbackDirectory) {
+    candidates.push(path.join(projectPath, opts.fallbackDirectory, opts.fileName));
+  }
 
   for (const candidate of candidates) {
     if (fileExists(candidate)) {

--- a/src/main/readiness/test-utils.test.ts
+++ b/src/main/readiness/test-utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import { mockInstructionFiles } from './test-utils';
+
+vi.mock('fs');
+
+const mockFs = vi.mocked(fs);
+
+describe('mockInstructionFiles', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('stubs statSync and readFileSync for matching instruction files', () => {
+    mockInstructionFiles(mockFs, {
+      'AGENTS.md': 'agents content',
+      'nested/CLAUDE.md': 'claude content',
+    });
+
+    const agentsStats = mockFs.statSync('/tmp/project/AGENTS.md');
+    const claudeStats = mockFs.statSync('/tmp/project/nested/CLAUDE.md');
+
+    expect(agentsStats.isFile()).toBe(true);
+    expect(agentsStats.isDirectory()).toBe(false);
+    expect(claudeStats.isFile()).toBe(true);
+    expect(mockFs.readFileSync('/tmp/project/AGENTS.md', 'utf-8')).toBe('agents content');
+    expect(mockFs.readFileSync('/tmp/project/nested/CLAUDE.md', 'utf-8')).toBe('claude content');
+    expect(() => mockFs.statSync('/tmp/project/GEMINI.md')).toThrow('ENOENT');
+    expect(() => mockFs.readFileSync('/tmp/project/GEMINI.md', 'utf-8')).toThrow('ENOENT');
+  });
+});

--- a/src/main/readiness/test-utils.ts
+++ b/src/main/readiness/test-utils.ts
@@ -1,0 +1,27 @@
+import * as fs from 'fs';
+import { vi } from 'vitest';
+
+export function mockInstructionFiles(
+  mockFs: typeof fs,
+  files: Record<string, string>,
+): void {
+  vi.mocked(mockFs.statSync).mockImplementation((filePath: fs.PathLike) => {
+    const matchedFile = Object.keys(files).find(key => String(filePath).endsWith(key));
+
+    if (matchedFile) {
+      return { isFile: () => true, isDirectory: () => false } as fs.Stats;
+    }
+
+    throw new Error('ENOENT');
+  });
+
+  vi.mocked(mockFs.readFileSync).mockImplementation((filePath: fs.PathOrFileDescriptor) => {
+    const matchedEntry = Object.entries(files).find(([key]) => String(filePath).endsWith(key));
+
+    if (matchedEntry) {
+      return matchedEntry[1];
+    }
+
+    throw new Error('ENOENT');
+  });
+}


### PR DESCRIPTION
## Summary

Adds root-first readiness support for Claude instruction files by falling back to `.claude/CLAUDE.md` only when the root `CLAUDE.md` is missing. The change centralizes instruction-file resolution in the shared readiness helpers, keeps root `CLAUDE.md` as the preferred source, and updates the readiness tests to cover fallback-only and root-preferred behavior.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes
- [x] Manually tested in the app (if UI changes)

## Notes

This change is scoped to readiness analysis only and does not change runtime Claude CLI loading behavior. Test fixtures for Claude, Codex, and Gemini context checks were updated to mock file existence via `statSync`, because the shared resolver now checks whether a candidate file exists before reading it.