### PR TITLE
Make paste keyboard shortcut customizable from Preferences

### DIFF
--- a/docs/superpowers/plans/2026-04-29-customizable-paste-shortcut.md
+++ b/docs/superpowers/plans/2026-04-29-customizable-paste-shortcut.md
@@ -1,0 +1,943 @@
+# Customizable Paste Shortcut Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users change the keyboard shortcut used for paste, app-wide, from the existing Preferences → Shortcuts panel. Default is unchanged (`Cmd+V` on macOS, `Ctrl+V` on Linux/Windows).
+
+**Architecture:** Single cross-platform paste pipeline. Main-process `before-input-event` listener intercepts the configured paste accelerator, prevents Chromium's native handler, and tells the renderer to dispatch. Renderer routes by `document.activeElement`: terminal panes get bracketed-paste-aware PTY writes; native inputs delegate to `webContents.paste()` for proper cursor/undo/IME handling. The Edit menu shows the active binding label without registering its own accelerator.
+
+**Tech Stack:** Electron, TypeScript, Vitest (v8 coverage), xterm.js, existing `ShortcutManager` + `keybindings` preferences.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-customizable-paste-shortcut-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/main/paste-accelerator.ts` — owns the main-side accelerator state, parses Electron `Input` events, installs the `before-input-event` listener.
+- `src/main/paste-accelerator.test.ts` — unit tests for accelerator matching.
+- `src/renderer/paste-dispatcher.ts` — receives `paste:dispatch` IPC; classifies focus target; routes to terminal-paste or native-paste path.
+- `src/renderer/paste-dispatcher.test.ts` — unit tests for `classifyTarget` and the bracketed-paste write helper.
+
+**Modified files:**
+- `src/renderer/shortcuts.ts` — add `paste` entry to `SHORTCUT_DEFAULTS` under new `Editing` category.
+- `src/renderer/shortcuts.test.ts` — coverage for the new entry.
+- `src/main/main.ts` — install `paste-accelerator` listener after window creation.
+- `src/main/ipc-handlers.ts` — register `paste:set-accelerator` and `paste:native` channels.
+- `src/main/menu.ts` — Edit-menu paste item shows active accelerator label with `registerAccelerator: false`.
+- `src/preload/preload.ts` — expose `paste` namespace on `window.vibeyard`.
+- `src/renderer/index.ts` — initialize dispatcher, push initial accelerator to main, re-push on `preferences-changed`.
+- `src/renderer/components/terminal-utils.ts` — remove the hardcoded Windows Ctrl+V branch (paste is unified through the dispatcher).
+- `src/renderer/components/terminal-utils.test.ts` — remove tests for the removed Ctrl+V handler.
+- `src/renderer/components/terminal-pane.ts` — drop `writeToPty` argument; expose `writeToFocusedTerminal` and `getFocusedTerminalBracketedPaste`.
+- `src/renderer/components/project-terminal.ts` — drop `writeToPty` argument from `attachClipboardCopyHandler` call.
+
+---
+
+### Task 1: Add `paste` entry to SHORTCUT_DEFAULTS
+
+**Files:**
+- Modify: `src/renderer/shortcuts.ts:53` (append entry, end of `SHORTCUT_DEFAULTS`)
+- Test: `src/renderer/shortcuts.test.ts` (append a new describe block)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/renderer/shortcuts.test.ts` (after the last existing `describe` block):
+
+```ts
+describe('paste shortcut', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('navigator', { platform: 'Linux x86_64' });
+    mockAppState.preferences.keybindings = {};
+  });
+
+  it('paste shortcut is present in SHORTCUT_DEFAULTS with default CmdOrCtrl+V', async () => {
+    const { SHORTCUT_DEFAULTS } = await import('./shortcuts');
+    const paste = SHORTCUT_DEFAULTS.find((s) => s.id === 'paste');
+    expect(paste).toBeDefined();
+    expect(paste!.defaultKeys).toBe('CmdOrCtrl+V');
+    expect(paste!.label).toBe('Paste');
+    expect(paste!.category).toBe('Editing');
+  });
+
+  it('shortcutManager.getKeys returns default for paste when no override', async () => {
+    const { shortcutManager } = await import('./shortcuts');
+    expect(shortcutManager.getKeys('paste')).toBe('CmdOrCtrl+V');
+  });
+
+  it('shortcutManager.getKeys returns override for paste when set', async () => {
+    mockAppState.preferences.keybindings = { paste: 'CmdOrCtrl+Shift+V' };
+    const { shortcutManager } = await import('./shortcuts');
+    expect(shortcutManager.getKeys('paste')).toBe('CmdOrCtrl+Shift+V');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/renderer/shortcuts.test.ts`
+Expected: 3 new tests fail with `paste` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/renderer/shortcuts.ts`, append one line to `SHORTCUT_DEFAULTS` (currently ending at line 52, before the closing `];` on line 53):
+
+```ts
+  { id: 'paste', label: 'Paste', category: 'Editing', defaultKeys: 'CmdOrCtrl+V' },
+```
+
+The final array entry just before `];` should now be the paste line.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/renderer/shortcuts.test.ts`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/shortcuts.ts src/renderer/shortcuts.test.ts
+git commit -m "add paste shortcut entry to SHORTCUT_DEFAULTS"
+```
+
+---
+
+### Task 2: Main-process accelerator matching helper (pure function, TDD)
+
+**Files:**
+- Create: `src/main/paste-accelerator.ts`
+- Test: `src/main/paste-accelerator.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/main/paste-accelerator.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { matchesPasteAccelerator } from './paste-accelerator';
+
+type Input = {
+  type: 'keyDown' | 'keyUp';
+  key: string;
+  control: boolean;
+  meta: boolean;
+  shift: boolean;
+  alt: boolean;
+  isComposing?: boolean;
+};
+
+function makeInput(over: Partial<Input>): Input {
+  return {
+    type: 'keyDown',
+    key: 'V',
+    control: false,
+    meta: false,
+    shift: false,
+    alt: false,
+    isComposing: false,
+    ...over,
+  };
+}
+
+describe('matchesPasteAccelerator', () => {
+  it('matches Ctrl+V on Linux/Windows when accelerator is CmdOrCtrl+V', () => {
+    const input = makeInput({ control: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'linux')).toBe(true);
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'win32')).toBe(true);
+  });
+
+  it('matches Cmd+V on macOS when accelerator is CmdOrCtrl+V', () => {
+    const input = makeInput({ meta: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'darwin')).toBe(true);
+  });
+
+  it('does not match Ctrl+V on macOS when accelerator is CmdOrCtrl+V', () => {
+    const input = makeInput({ control: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'darwin')).toBe(false);
+  });
+
+  it('matches Ctrl+Shift+V exactly', () => {
+    const input = makeInput({ control: true, shift: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, 'Ctrl+Shift+V', 'linux')).toBe(true);
+  });
+
+  it('does not match when extra modifier present', () => {
+    const input = makeInput({ control: true, shift: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'linux')).toBe(false);
+  });
+
+  it('does not match when modifier missing', () => {
+    const input = makeInput({ key: 'V' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'linux')).toBe(false);
+  });
+
+  it('case-insensitive on letter keys', () => {
+    const input = makeInput({ control: true, key: 'v' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'linux')).toBe(true);
+  });
+
+  it('only matches keyDown events', () => {
+    const input = makeInput({ type: 'keyUp', control: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'linux')).toBe(false);
+  });
+
+  it('does not match when isComposing is true (IME)', () => {
+    const input = makeInput({ control: true, key: 'V', isComposing: true });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'linux')).toBe(false);
+  });
+
+  it('returns false for empty accelerator', () => {
+    const input = makeInput({ control: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, '', 'linux')).toBe(false);
+  });
+
+  it('returns false for malformed accelerator', () => {
+    const input = makeInput({ control: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, '+++', 'linux')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/main/paste-accelerator.test.ts`
+Expected: cannot find module `./paste-accelerator`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/main/paste-accelerator.ts`:
+
+```ts
+import type { BrowserWindow } from 'electron';
+
+export type Platform = NodeJS.Platform;
+
+export interface InputLike {
+  type: 'keyDown' | 'keyUp' | string;
+  key: string;
+  control: boolean;
+  meta: boolean;
+  shift: boolean;
+  alt: boolean;
+  isComposing?: boolean;
+}
+
+interface ParsedAccelerator {
+  ctrl: boolean;
+  meta: boolean;
+  shift: boolean;
+  alt: boolean;
+  key: string;
+}
+
+function parseAccelerator(accelerator: string, platform: Platform): ParsedAccelerator | null {
+  if (!accelerator) return null;
+  const parts = accelerator.split('+').map((p) => p.trim()).filter(Boolean);
+  if (parts.length === 0) return null;
+
+  let ctrl = false;
+  let meta = false;
+  let shift = false;
+  let alt = false;
+  let key = '';
+
+  for (const part of parts) {
+    const lower = part.toLowerCase();
+    if (lower === 'cmdorctrl') {
+      if (platform === 'darwin') meta = true;
+      else ctrl = true;
+    } else if (lower === 'ctrl' || lower === 'control') {
+      ctrl = true;
+    } else if (lower === 'cmd' || lower === 'command' || lower === 'meta') {
+      meta = true;
+    } else if (lower === 'shift') {
+      shift = true;
+    } else if (lower === 'alt' || lower === 'option') {
+      alt = true;
+    } else {
+      if (key) return null; // multiple non-modifier keys
+      key = part;
+    }
+  }
+
+  if (!key) return null;
+  return { ctrl, meta, shift, alt, key };
+}
+
+export function matchesPasteAccelerator(
+  input: InputLike,
+  accelerator: string,
+  platform: Platform = process.platform,
+): boolean {
+  if (input.type !== 'keyDown') return false;
+  if (input.isComposing) return false;
+
+  const parsed = parseAccelerator(accelerator, platform);
+  if (!parsed) return false;
+
+  if (parsed.ctrl !== input.control) return false;
+  if (parsed.meta !== input.meta) return false;
+  if (parsed.shift !== input.shift) return false;
+  if (parsed.alt !== input.alt) return false;
+
+  const inputKey = input.key;
+  if (inputKey === parsed.key) return true;
+  if (inputKey.length === 1 && parsed.key.length === 1
+      && inputKey.toLowerCase() === parsed.key.toLowerCase()) return true;
+  return false;
+}
+
+let currentAccelerator = 'CmdOrCtrl+V';
+let listenerInstalled = false;
+let installedWindow: BrowserWindow | null = null;
+
+export function setPasteAccelerator(accelerator: string): void {
+  currentAccelerator = accelerator || 'CmdOrCtrl+V';
+}
+
+export function getPasteAccelerator(): string {
+  return currentAccelerator;
+}
+
+export function installPasteListener(window: BrowserWindow): void {
+  if (listenerInstalled && installedWindow === window) return;
+  listenerInstalled = true;
+  installedWindow = window;
+
+  window.webContents.on('before-input-event', (event, input) => {
+    if (matchesPasteAccelerator(input as InputLike, currentAccelerator)) {
+      event.preventDefault();
+      window.webContents.send('paste:dispatch');
+    }
+  });
+}
+
+// Test-only: reset module state between tests.
+export function _resetForTesting(): void {
+  currentAccelerator = 'CmdOrCtrl+V';
+  listenerInstalled = false;
+  installedWindow = null;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/main/paste-accelerator.test.ts`
+Expected: all 11 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/paste-accelerator.ts src/main/paste-accelerator.test.ts
+git commit -m "add main-process paste accelerator matcher and listener"
+```
+
+---
+
+### Task 3: Renderer paste-dispatcher (focus classifier + paste helpers, TDD)
+
+**Files:**
+- Create: `src/renderer/paste-dispatcher.ts`
+- Test: `src/renderer/paste-dispatcher.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/renderer/paste-dispatcher.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('./state.js', () => ({
+  appState: { preferences: {} },
+}));
+
+import { classifyTarget, buildPtyPasteString } from './paste-dispatcher';
+
+describe('classifyTarget', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns "terminal" for an element inside .terminal-pane', () => {
+    document.body.innerHTML = '<div class="terminal-pane"><canvas id="t"></canvas></div>';
+    const el = document.getElementById('t')!;
+    expect(classifyTarget(el)).toBe('terminal');
+  });
+
+  it('returns "input" for an <input>', () => {
+    document.body.innerHTML = '<input id="i" type="text" />';
+    const el = document.getElementById('i')!;
+    expect(classifyTarget(el)).toBe('input');
+  });
+
+  it('returns "input" for a <textarea>', () => {
+    document.body.innerHTML = '<textarea id="t"></textarea>';
+    const el = document.getElementById('t')!;
+    expect(classifyTarget(el)).toBe('input');
+  });
+
+  it('returns "input" for contenteditable', () => {
+    document.body.innerHTML = '<div id="c" contenteditable="true">x</div>';
+    const el = document.getElementById('c')!;
+    expect(classifyTarget(el)).toBe('input');
+  });
+
+  it('returns "other" for body', () => {
+    expect(classifyTarget(document.body)).toBe('other');
+  });
+
+  it('returns "other" for null', () => {
+    expect(classifyTarget(null)).toBe('other');
+  });
+});
+
+describe('buildPtyPasteString', () => {
+  it('returns plain text when bracketed paste mode is off', () => {
+    expect(buildPtyPasteString('hello', false)).toBe('hello');
+  });
+
+  it('wraps text in bracketed-paste sequences when bracketed paste mode is on', () => {
+    expect(buildPtyPasteString('hello', true)).toBe('\x1b[200~hello\x1b[201~');
+  });
+
+  it('returns empty string for empty input regardless of mode', () => {
+    expect(buildPtyPasteString('', false)).toBe('');
+    expect(buildPtyPasteString('', true)).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/renderer/paste-dispatcher.test.ts`
+Expected: cannot find module `./paste-dispatcher`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/renderer/paste-dispatcher.ts`:
+
+```ts
+export type PasteTarget = 'terminal' | 'input' | 'other';
+
+export function classifyTarget(el: Element | null): PasteTarget {
+  if (!el) return 'other';
+  if (el.closest('.terminal-pane')) return 'terminal';
+  const tag = el.tagName?.toLowerCase();
+  if (tag === 'input' || tag === 'textarea') return 'input';
+  if ((el as HTMLElement).isContentEditable) return 'input';
+  return 'other';
+}
+
+export function buildPtyPasteString(text: string, bracketedPasteMode: boolean): string {
+  if (!text) return '';
+  return bracketedPasteMode ? `\x1b[200~${text}\x1b[201~` : text;
+}
+
+type WriteToFocusedTerminal = (data: string) => boolean;
+type GetBracketedPaste = () => boolean;
+
+export function createPasteDispatcher(deps: {
+  writeToFocusedTerminal: WriteToFocusedTerminal;
+  isFocusedTerminalBracketedPaste: GetBracketedPaste;
+  pasteNative: () => void;
+}) {
+  return async function dispatchPaste(): Promise<void> {
+    const target = classifyTarget(document.activeElement);
+    if (target === 'terminal') {
+      let text = '';
+      try {
+        text = await navigator.clipboard.readText();
+      } catch {
+        return;
+      }
+      const bp = deps.isFocusedTerminalBracketedPaste();
+      const data = buildPtyPasteString(text, bp);
+      if (data) deps.writeToFocusedTerminal(data);
+    } else if (target === 'input') {
+      deps.pasteNative();
+    }
+    // 'other' → no-op
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/renderer/paste-dispatcher.test.ts`
+Expected: all 9 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/paste-dispatcher.ts src/renderer/paste-dispatcher.test.ts
+git commit -m "add renderer paste dispatcher with focus classifier"
+```
+
+---
+
+### Task 4: IPC handlers (`paste:set-accelerator`, `paste:native`)
+
+**Files:**
+- Modify: `src/main/ipc-handlers.ts:1-10` (imports), `:225` (insert after `menu:rebuild`)
+
+- [ ] **Step 1: Add imports**
+
+In `src/main/ipc-handlers.ts`, add to the top imports (the line with `import { createAppMenu } from './menu';`):
+
+```ts
+import { setPasteAccelerator, installPasteListener } from './paste-accelerator';
+```
+
+- [ ] **Step 2: Add IPC handlers**
+
+In `src/main/ipc-handlers.ts`, immediately after the `menu:rebuild` handler (around line 225), insert:
+
+```ts
+  ipcMain.handle('paste:set-accelerator', (_event, accelerator: string) => {
+    setPasteAccelerator(accelerator);
+    const win = BrowserWindow.getAllWindows()[0];
+    if (win) installPasteListener(win);
+  });
+
+  ipcMain.handle('paste:native', () => {
+    const win = BrowserWindow.getFocusedWindow();
+    win?.webContents.paste();
+  });
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `npx tsc -p tsconfig.main.json --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/ipc-handlers.ts
+git commit -m "add paste:set-accelerator and paste:native IPC handlers"
+```
+
+---
+
+### Task 5: Expose `paste` namespace in preload
+
+**Files:**
+- Modify: `src/preload/preload.ts:120-138` (interface), `:282-302` (implementation)
+
+- [ ] **Step 1: Add the type to the `VibeyardApi` interface**
+
+In `src/preload/preload.ts`, immediately after the `clipboard` block (which currently ends at line 122), insert:
+
+```ts
+  paste: {
+    setAccelerator(accelerator: string): Promise<void>;
+    native(): Promise<void>;
+    onDispatch(callback: () => void): () => void;
+  };
+```
+
+- [ ] **Step 2: Add the implementation**
+
+In `src/preload/preload.ts`, immediately after the `clipboard` implementation (which currently ends at line 284 with `},`), insert:
+
+```ts
+  paste: {
+    setAccelerator: (accelerator: string) => ipcRenderer.invoke('paste:set-accelerator', accelerator),
+    native: () => ipcRenderer.invoke('paste:native'),
+    onDispatch: (callback) => onChannel('paste:dispatch', () => callback()),
+  },
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `npx tsc -p tsconfig.preload.json --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/preload/preload.ts
+git commit -m "expose paste namespace on preload bridge"
+```
+
+---
+
+### Task 6: Update Edit menu paste item to display configured accelerator
+
+**Files:**
+- Modify: `src/main/menu.ts:1-3` (imports), `:50-69` (Edit submenu)
+
+- [ ] **Step 1: Add import**
+
+In `src/main/menu.ts`, change line 2:
+
+```ts
+import { isMac, isWin } from './platform';
+```
+
+to:
+
+```ts
+import { isMac, isWin } from './platform';
+import { getPasteAccelerator } from './paste-accelerator';
+```
+
+- [ ] **Step 2: Update Edit submenu — Windows branch**
+
+In `src/main/menu.ts`, replace the Windows Edit-submenu paste line (currently `{ label: 'Paste', click: () => focusedContents()?.paste() },` near line 56) with:
+
+```ts
+        {
+          label: 'Paste',
+          accelerator: getPasteAccelerator(),
+          registerAccelerator: false,
+          click: () => focusedContents()?.paste(),
+        },
+```
+
+- [ ] **Step 3: Update Edit submenu — Mac/Linux branch**
+
+In `src/main/menu.ts`, replace the Mac/Linux paste lines (currently `{ role: 'paste' as const },` and `{ role: 'pasteAndMatchStyle' as const },` near lines 65-66) with:
+
+```ts
+        {
+          label: 'Paste',
+          accelerator: getPasteAccelerator(),
+          registerAccelerator: false,
+          click: () => focusedContents()?.paste(),
+        },
+        { role: 'pasteAndMatchStyle' as const },
+```
+
+(`pasteAndMatchStyle` keeps its default behavior; only the plain Paste item picks up the user accelerator.)
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run: `npx tsc -p tsconfig.main.json --noEmit`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/menu.ts
+git commit -m "show user-configured paste accelerator label on Edit menu"
+```
+
+---
+
+### Task 7: Wire paste listener installation in main.ts
+
+**Files:**
+- Modify: `src/main/main.ts:1-10` (imports), `:75` (after window creation)
+
+- [ ] **Step 1: Add import**
+
+In `src/main/main.ts`, add to imports (e.g. next to `import { createAppMenu } from './menu';` around line 6):
+
+```ts
+import { installPasteListener } from './paste-accelerator';
+```
+
+- [ ] **Step 2: Install listener after window creation**
+
+In `src/main/main.ts`, immediately before the closing `}` of `createWindow()` (just after the `mainWindow.on('closed', ...)` block ending around line 75), add:
+
+```ts
+  installPasteListener(mainWindow);
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `npx tsc -p tsconfig.main.json --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/main.ts
+git commit -m "install paste accelerator listener on main window creation"
+```
+
+---
+
+### Task 8: Wire dispatcher in renderer + push accelerator to main
+
+**Files:**
+- Modify: `src/renderer/index.ts:1-10` (imports), `:206-220` (startup + preferences-changed block)
+
+- [ ] **Step 1: Add imports**
+
+In `src/renderer/index.ts`, add to imports near the top:
+
+```ts
+import { createPasteDispatcher } from './paste-dispatcher.js';
+import { shortcutManager } from './shortcuts.js';
+import { writeToFocusedTerminal, getFocusedTerminalBracketedPaste } from './components/terminal-pane.js';
+```
+
+(If `shortcutManager` is already imported, skip that line. The two terminal-pane helpers will be added in Task 9; for now this import will not yet resolve until Task 9 adds them — order Task 9 immediately after this task's commit.)
+
+- [ ] **Step 2: Initialize dispatcher and push initial accelerator**
+
+In `src/renderer/index.ts`, immediately after `await appState.load();` (currently line 207), insert:
+
+```ts
+  const dispatchPaste = createPasteDispatcher({
+    writeToFocusedTerminal,
+    isFocusedTerminalBracketedPaste: getFocusedTerminalBracketedPaste,
+    pasteNative: () => { window.vibeyard.paste.native().catch(() => {}); },
+  });
+  window.vibeyard.paste.onDispatch(() => { dispatchPaste().catch(() => {}); });
+
+  const initialPasteAccel = shortcutManager.getKeys('paste') || 'CmdOrCtrl+V';
+  await window.vibeyard.paste.setAccelerator(initialPasteAccel);
+```
+
+- [ ] **Step 3: Re-push accelerator on `preferences-changed`**
+
+In `src/renderer/index.ts`, find the existing `appState.on('preferences-changed', () => { ... })` block (currently lines 214-220) and add inside its callback, after the existing theme lines:
+
+```ts
+    const pasteAccel = shortcutManager.getKeys('paste') || 'CmdOrCtrl+V';
+    window.vibeyard.paste.setAccelerator(pasteAccel).catch(() => {});
+    window.vibeyard.menu.rebuild(appState.preferences.debugMode ?? false).catch(() => {});
+```
+
+- [ ] **Step 4: Defer build verification to Task 9**
+
+The `writeToFocusedTerminal` and `getFocusedTerminalBracketedPaste` exports don't exist yet. Don't run the build until Task 9 is done. Skip to commit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/index.ts
+git commit -m "wire paste dispatcher and push accelerator to main on prefs change"
+```
+
+---
+
+### Task 9: Expose terminal-pane paste helpers; remove hardcoded Windows Ctrl+V
+
+**Files:**
+- Modify: `src/renderer/components/terminal-pane.ts` (add two helpers near `setFocused`)
+- Modify: `src/renderer/components/terminal-utils.ts:31-79` (remove Windows Ctrl+V branch)
+
+- [ ] **Step 1: Inspect existing terminal-pane state structure**
+
+Read `src/renderer/components/terminal-pane.ts` to confirm the shape of `instances` (the `Map<string, ...>` of session terminals). Each instance should have a `terminal: Terminal` property and the session id; PTY writes go through `window.vibeyard.pty.write(sessionId, data)`. The `focusedSessionId` module-level variable is set by `setFocused`.
+
+- [ ] **Step 2: Add the two new helpers in terminal-pane.ts**
+
+In `src/renderer/components/terminal-pane.ts`, append after the existing `setFocused` function (around line 319):
+
+```ts
+/** Returns true if any text was sent to the focused session's PTY. */
+export function writeToFocusedTerminal(data: string): boolean {
+  if (!focusedSessionId) return false;
+  if (!data) return false;
+  window.vibeyard.pty.write(focusedSessionId, data);
+  return true;
+}
+
+/** Returns whether the focused terminal currently has bracketed-paste mode enabled. */
+export function getFocusedTerminalBracketedPaste(): boolean {
+  if (!focusedSessionId) return false;
+  const instance = instances.get(focusedSessionId);
+  if (!instance) return false;
+  const modes = (instance.terminal as { modes?: { bracketedPasteMode?: boolean } }).modes;
+  return !!modes?.bracketedPasteMode;
+}
+```
+
+- [ ] **Step 3: Remove the hardcoded Windows Ctrl+V handler in terminal-utils.ts**
+
+In `src/renderer/components/terminal-utils.ts`, delete lines 59-72 (the `// Windows: Ctrl+V → async paste clipboard to PTY` block), leaving the surrounding handler code intact. Also remove the now-unused `writeToPty` parameter from `attachClipboardCopyHandler`:
+
+Replace lines 31-35 (the function signature):
+
+```ts
+export function attachClipboardCopyHandler(
+  terminal: Terminal,
+  extend?: ExtraKeyHandler,
+  writeToPty?: (data: string) => void
+): void {
+```
+
+with:
+
+```ts
+export function attachClipboardCopyHandler(
+  terminal: Terminal,
+  extend?: ExtraKeyHandler,
+): void {
+```
+
+Also update the JSDoc above (lines 18-30) to remove the Ctrl+V/`writeToPty` references — keep only the documentation for the remaining handlers (Cmd/Ctrl+F bubble, Ctrl+Shift+C copy, Windows Ctrl+C copy/SIGINT).
+
+- [ ] **Step 4: Update both callers of `attachClipboardCopyHandler`**
+
+Two callers pass `writeToPty` as a third argument and must be updated. First confirm via grep:
+
+```bash
+grep -rn "attachClipboardCopyHandler" src/renderer/components/
+```
+
+Expected matches: `terminal-pane.ts:105` and `project-terminal.ts:87`.
+
+In `src/renderer/components/terminal-pane.ts`, replace lines 102-111:
+
+```ts
+  const writeToPty = (data: string) => window.vibeyard.pty.write(sessionId, data);
+
+  // Send CSI u encoding for Shift+Enter so Claude CLI treats it as newline
+  attachClipboardCopyHandler(terminal, (e) => {
+    if (e.shiftKey && e.key === 'Enter') {
+      if (e.type === 'keydown') window.vibeyard.pty.write(sessionId, '\x1b[13;2u');
+      e.preventDefault();
+      return false;
+    }
+  }, writeToPty);
+```
+
+with:
+
+```ts
+  // Send CSI u encoding for Shift+Enter so Claude CLI treats it as newline
+  attachClipboardCopyHandler(terminal, (e) => {
+    if (e.shiftKey && e.key === 'Enter') {
+      if (e.type === 'keydown') window.vibeyard.pty.write(sessionId, '\x1b[13;2u');
+      e.preventDefault();
+      return false;
+    }
+  });
+```
+
+In `src/renderer/components/project-terminal.ts:87`, replace:
+
+```ts
+  attachClipboardCopyHandler(terminal, undefined, (data) => window.vibeyard.pty.write(sessionId, data));
+```
+
+with:
+
+```ts
+  attachClipboardCopyHandler(terminal);
+```
+
+- [ ] **Step 5: Update terminal-utils.test.ts — remove Ctrl+V tests**
+
+In `src/renderer/components/terminal-utils.test.ts`, the Windows-section `describe` block contains tests for the removed Ctrl+V behavior. Delete the following test cases:
+
+- `'Ctrl+V returns false and pastes clipboard to PTY'`
+- `'Ctrl+V calls preventDefault to suppress native paste event'`
+- `'Ctrl+V wraps text in bracketed paste escapes when mode is enabled'`
+- `'Ctrl+V does not paste empty clipboard'`
+- `'Ctrl+V without writeToPty falls through to default'`
+- `'Ctrl+V does not call writeToPty on keyup'`
+
+Also delete the import / use of `mockClipboardRead` if it becomes unused after removing those tests, and any test in this file that passes `writeToPty` as the third argument to `attachClipboardCopyHandler` (the signature no longer accepts it).
+
+If the only remaining content of the Windows `describe` block is `Ctrl+Shift+C still works for copy`, keep that test.
+
+(Bracketed-paste behavior is now covered by `paste-dispatcher.test.ts > buildPtyPasteString`.)
+
+- [ ] **Step 6: Verify the renderer builds**
+
+Run: `npm run build`
+Expected: build succeeds — main, preload, and renderer all compile.
+
+- [ ] **Step 7: Run all tests**
+
+Run: `npm test`
+Expected: all tests pass (the new tests from Tasks 1-3 included; Ctrl+V tests removed).
+
+- [ ] **Step 8: Commit**
+
+Stage all modified files (verify with `git status` first):
+
+```bash
+git add src/renderer/components/terminal-pane.ts \
+        src/renderer/components/terminal-utils.ts \
+        src/renderer/components/terminal-utils.test.ts \
+        src/renderer/components/project-terminal.ts
+git commit -m "unify paste through dispatcher; remove hardcoded Windows Ctrl+V"
+```
+
+---
+
+### Task 10: Manual smoke test on Linux
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Launch the app**
+
+Run: `npm start`
+Expected: app launches without errors in the terminal output.
+
+- [ ] **Step 2: Verify default paste in terminal**
+
+1. Copy some text (`echo hello | xclip -selection clipboard` or use any other source).
+2. Open or create a session terminal.
+3. Press `Ctrl+V`.
+4. Expected: the text appears at the shell prompt. If the shell uses bracketed paste (most modern shells do), the text is wrapped properly with no spurious Ctrl+V control characters.
+
+- [ ] **Step 3: Verify default paste in board task modal**
+
+1. Open Kanban view, click `+` to create a task.
+2. Click into the title input.
+3. Press `Ctrl+V`.
+4. Expected: clipboard text inserted at cursor. Cursor advances correctly. Undo (`Ctrl+Z`) reverts the paste.
+
+- [ ] **Step 4: Rebind paste to `Ctrl+Shift+V`**
+
+1. Open Preferences → Shortcuts.
+2. Find `Editing → Paste`.
+3. Click Record, press `Ctrl+Shift+V`, save.
+4. Expected: the row updates to show the new binding.
+
+- [ ] **Step 5: Verify rebinding takes effect**
+
+1. In a terminal, press `Ctrl+V`. Expected: nothing pastes; the `^V` literal is **not** sent to the shell either (because the renderer's xterm key handler suppresses it via `shortcutManager.matchesAnyShortcut`).
+2. Press `Ctrl+Shift+V`. Expected: clipboard text pastes into terminal.
+3. Click into a board task input. Press `Ctrl+V` — nothing pastes. Press `Ctrl+Shift+V` — paste works.
+
+- [ ] **Step 6: Verify Edit menu shows the binding**
+
+1. Open the application's Edit menu.
+2. Expected: the Paste item displays `Ctrl+Shift+V` (or the platform-equivalent symbol) next to it.
+
+- [ ] **Step 7: Reset to default**
+
+1. In Preferences → Shortcuts → Paste, click Reset.
+2. Verify `Ctrl+V` works again in both terminal and inputs.
+
+- [ ] **Step 8: Verify Linux primary-selection middle-click paste still works**
+
+1. Select some text in the terminal with the mouse (it auto-copies to primary selection).
+2. Click somewhere else in the terminal, then middle-click.
+3. Expected: selected text is pasted. (This path is independent of our changes — regression check only.)
+
+- [ ] **Step 9: Commit no further changes**
+
+If any issues surface, file fixes as new commits before declaring success. Do not amend prior commits.
+
+---
+
+## Mac / Windows Verification (Deferred)
+
+Implementer is on Linux. The following must be verified before merge by someone with access to those platforms; flag in PR description:
+
+- **macOS:** repeat Steps 2-7 of Task 10 with default `Cmd+V`. Specifically check no double-paste in inputs, and that `pasteAndMatchStyle` (Cmd+Shift+V default) still works as a separate menu item.
+- **Windows:** repeat Steps 2-7 of Task 10 with default `Ctrl+V`. Specifically watch for double-paste in board task modal inputs (the original Electron-on-Windows quirk this design works around).
+
+---
+
+## Definition of Done
+
+- All tests in `npm test` pass.
+- `npm run build` succeeds.
+- Manual smoke test (Task 10) on Linux passes every step.
+- All commits land on `feature/customizable-paste-shortcut` (branched from `main`).
+- PR description calls out Mac/Windows verification gap.

--- a/docs/superpowers/specs/2026-04-29-customizable-paste-shortcut-design.md
+++ b/docs/superpowers/specs/2026-04-29-customizable-paste-shortcut-design.md
@@ -1,0 +1,138 @@
+# Customizable Paste Shortcut — Design
+
+**Date:** 2026-04-29
+**Branch:** `feature/customizable-paste-shortcut`
+**Status:** Approved (pending user spec review)
+
+## Goal
+
+Let users change the keyboard shortcut used for paste, app-wide, from the existing Preferences → Shortcuts panel. Default behavior is unchanged (`Cmd+V` on macOS, `Ctrl+V` on Linux/Windows).
+
+## Non-Goals
+
+- Customizing copy or cut shortcuts (paste only).
+- Multiple paste bindings simultaneously (one configurable shortcut, matching every other entry in `SHORTCUT_DEFAULTS`).
+- File / image paste behavior changes — text only for the terminal path; native input path delegates to Chromium and inherits whatever it already does for non-text.
+- Browser-tab webview internal paste behavior.
+- Linux X11 primary-selection middle-click paste — unaffected by this change.
+
+## Architecture
+
+### New shortcut entry
+
+Add one entry to `SHORTCUT_DEFAULTS` in `src/renderer/shortcuts.ts`:
+
+```ts
+{ id: 'paste', label: 'Paste', category: 'Editing', defaultKeys: 'CmdOrCtrl+V' }
+```
+
+No existing category fits cleanly (existing categories are `Sessions`, `Panels`, `Search & Help`), so add a new `Editing` category. The Preferences → Shortcuts UI in `preferences-modal.ts` iterates `SHORTCUT_DEFAULTS` already, so no UI components change.
+
+### New main-process module
+
+`src/main/paste-accelerator.ts` owns:
+
+- The currently configured paste accelerator (Electron `Accelerator` string).
+- A `before-input-event` listener attached to the BrowserWindow's webContents.
+- A function to update the configured accelerator without rebuilding the window.
+
+The listener parses each `Input` event into a normalized accelerator string (e.g. `Ctrl+Shift+V`) and compares to the configured one. On match (and not in IME composition):
+
+1. `event.preventDefault()` — stops Chromium's native handler.
+2. `mainWindow.webContents.send('paste:dispatch')` — hands off to renderer.
+
+### IPC
+
+New `paste` namespace exposed via the preload bridge:
+
+| Channel | Direction | Purpose |
+|---|---|---|
+| `paste:set-accelerator` | renderer → main | Push the active accelerator. Sent at startup and whenever the user changes it. |
+| `paste:dispatch` | main → renderer | Notify renderer that a paste was triggered; renderer decides where it lands. |
+| `paste:native` | renderer → main | Renderer asks main to call `webContents.paste()` for the focused input. |
+
+### Renderer dispatch
+
+In the renderer, a top-level handler subscribes to `paste:dispatch`. It inspects `document.activeElement`:
+
+- **Terminal pane** (xterm canvas / its container) → existing PTY paste path: `navigator.clipboard.readText()` + write to PTY with bracketed-paste handling.
+- **Native input** (`<input>`, `<textarea>`, contenteditable) → call `paste:native` IPC; main calls `mainWindow.webContents.paste()` so Chromium's native paste runs (cursor position, undo, IME all preserved).
+- **Other** → no-op.
+
+The hardcoded Windows `Ctrl+V` handler at `src/renderer/components/terminal-utils.ts:59-72` is **removed**. The terminal paste path is unified through `paste:dispatch`.
+
+### Edit menu integration
+
+`src/main/menu.ts` Edit-menu items get the active accelerator string for display only:
+
+- `accelerator: <user-key>`
+- `registerAccelerator: false`
+
+The menu shows the binding label but does not register it as a global accelerator (avoids double-firing). When the user changes the shortcut, the renderer triggers a menu rebuild via the existing `menu:rebuild` IPC handler (`src/main/ipc-handlers.ts:223`).
+
+### Preference storage
+
+Reuses the existing `keybindings: Record<string, string>` field on `Preferences` (`src/shared/types.ts`). The `paste` shortcut id is just one more entry. Persistence and the override mechanism (`shortcutManager.setOverride`, `getKeys`) work unchanged.
+
+## Data Flow
+
+1. **App start.** Renderer reads `preferences.keybindings.paste` (falling back to default `CmdOrCtrl+V`) and sends `paste:set-accelerator` to main.
+2. **Listener install.** Main stores the accelerator and ensures the `before-input-event` listener is attached.
+3. **Keystroke.** User presses a key. Main's listener checks for a match — if no match, returns; if matched and not IME-composing, prevents default and sends `paste:dispatch`.
+4. **Renderer routing.** Renderer classifies `document.activeElement`:
+   - Terminal: read clipboard, write to PTY with bracketed-paste.
+   - Input: send `paste:native` to main.
+   - Other: ignore.
+5. **Native input paste.** Main receives `paste:native`, calls `mainWindow.webContents.paste()`. Chromium handles cursor, undo, IME.
+6. **User edits shortcut.** Renderer sends new accelerator via `paste:set-accelerator`. Main swaps it in. Edit menu rebuilds for display.
+
+## Edge Cases
+
+- **Empty / invalid accelerator string.** Fall back to default `CmdOrCtrl+V`. Validate against Electron's accelerator format before applying.
+- **IME composition.** When `event.isComposing` is true (or equivalent on the main-side `Input` event), do not dispatch.
+- **Conflict with existing shortcuts.** If the user picks a binding already used by another action, behavior is what `shortcutManager` already does for any shortcut conflict — out of scope to redesign here.
+- **Modifier-only or empty bindings.** Validation rejects them (matches existing shortcut recording UX).
+- **App backgrounded.** `before-input-event` only fires for the focused window's webContents. No global hook.
+- **Webview / browser-tab pane.** `before-input-event` does not fire for inner webviews. Their internal paste behavior is unchanged.
+
+## Testing
+
+### Unit
+
+- Extend `src/renderer/shortcuts.test.ts` to cover the new `paste` entry: default value, override + reset, presence in `SHORTCUT_DEFAULTS`.
+- Add `src/main/paste-accelerator.test.ts` covering accelerator-string ↔ `Input` event matching (modifier permutations, case, `CmdOrCtrl` resolution per platform).
+- Add a renderer-side test for the `document.activeElement` classifier (terminal / input / other).
+
+### Manual (Linux — primary verification)
+
+1. Default `Ctrl+V` pastes into terminal. ✅
+2. Default `Ctrl+V` pastes into board task modal text input. ✅
+3. Open Preferences → Shortcuts, rebind `paste` to `Ctrl+Shift+V`. Verify both terminal and input fields paste on the new combo and **not** on `Ctrl+V`.
+4. Reset to default; verify behavior reverts.
+5. Bracketed-paste mode in terminal still triggers on paste.
+6. Edit menu shows the active binding label.
+7. Linux X11 middle-click primary-selection paste still works in terminal (regression check).
+
+### Manual (deferred — flagged in PR)
+
+- macOS: same flow with `Cmd+V` default.
+- Windows: same flow with `Ctrl+V` default; specifically check no double-paste in input fields.
+
+## Files Touched (estimate)
+
+- `src/renderer/shortcuts.ts` — add `paste` entry.
+- `src/renderer/shortcuts.test.ts` — coverage for new entry.
+- `src/renderer/state.ts` — push accelerator to main on startup and on `preferences-changed`.
+- `src/renderer/components/terminal-utils.ts` — remove hardcoded Windows handler; expose paste-into-PTY function for new dispatch path.
+- `src/renderer/paste-dispatcher.ts` (new) — receives `paste:dispatch`, routes by focus.
+- `src/main/paste-accelerator.ts` (new) — listener, current-accelerator state.
+- `src/main/paste-accelerator.test.ts` (new) — accelerator-matching tests.
+- `src/main/ipc-handlers.ts` — `paste:set-accelerator`, `paste:native` handlers.
+- `src/main/menu.ts` — accelerator label on Edit menu paste item; `registerAccelerator: false`.
+- `src/preload/preload.ts` — expose `paste` namespace.
+
+## Risks
+
+- **Subtle main-side accelerator parsing bugs.** Mitigation: dedicated unit tests for `Input` ↔ accelerator matching.
+- **Mac/Windows verification gap.** Implementer is on Linux. Mitigation: design uses cross-platform primitives (`before-input-event`, `webContents.paste()`); call out gap in PR description.
+- **Menu rebuild cost.** Rebuilds on every shortcut change. Acceptable — same pattern as other shortcut changes already trigger.

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "electron": "^41.0.0",
         "electron-builder": "^26.8.1",
         "esbuild": "^0.27.4",
+        "happy-dom": "^20.8.9",
         "typescript": "^5.7.0",
         "vitest": "^4.1.0"
       },
@@ -1908,6 +1909,23 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -3844,6 +3862,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -4619,6 +4650,24 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -7714,6 +7763,16 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7788,6 +7847,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "electron": "^41.0.0",
     "electron-builder": "^26.8.1",
     "esbuild": "^0.27.4",
+    "happy-dom": "^20.8.9",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"
   },

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -15,6 +15,7 @@ import { watchFile as watchFileForChanges, unwatchFile as unwatchFileForChanges,
 import { registerMcpHandlers } from './mcp-ipc-handlers';
 import { checkForUpdates, quitAndInstall } from './auto-updater';
 import { createAppMenu } from './menu';
+import { setPasteAccelerator, installPasteListener } from './paste-accelerator';
 import { getProvider, getProviderMeta, getAllProviderMetas } from './providers/registry';
 import { buildHandoffPrompt } from './providers/resume-handoff';
 import { searchSessions } from './session-deep-search';
@@ -222,6 +223,17 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle('menu:rebuild', (_event, debugMode: boolean) => {
     createAppMenu(debugMode);
+  });
+
+  ipcMain.handle('paste:set-accelerator', (_event, accelerator: string) => {
+    setPasteAccelerator(accelerator);
+    const win = BrowserWindow.getAllWindows()[0];
+    if (win) installPasteListener(win);
+  });
+
+  ipcMain.handle('paste:native', () => {
+    const win = BrowserWindow.getFocusedWindow();
+    win?.webContents.paste();
   });
 
   ipcMain.handle('clipboard:write', (_event, text: string) => {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -233,7 +233,7 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle('paste:native', () => {
     const win = BrowserWindow.getFocusedWindow();
-    win?.webContents.paste();
+    if (win && !win.isDestroyed()) win.webContents.paste();
   });
 
   ipcMain.handle('clipboard:write', (_event, text: string) => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4,6 +4,7 @@ import { registerIpcHandlers, resetHookWatcher } from './ipc-handlers';
 import { killAllPtys } from './pty-manager';
 import { flushState, loadState } from './store';
 import { createAppMenu } from './menu';
+import { installPasteListener } from './paste-accelerator';
 import { restartAndResync } from './hook-status';
 import { initProviders, getAllProviders } from './providers/registry';
 import { initAutoUpdater } from './auto-updater';
@@ -73,6 +74,8 @@ function createWindow(): void {
     resetHookWatcher();
     mainWindow = null;
   });
+
+  installPasteListener(mainWindow);
 }
 
 app.whenReady().then(async () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4,7 +4,7 @@ import { registerIpcHandlers, resetHookWatcher } from './ipc-handlers';
 import { killAllPtys } from './pty-manager';
 import { flushState, loadState } from './store';
 import { createAppMenu } from './menu';
-import { installPasteListener } from './paste-accelerator';
+import { installPasteListener, resetPasteListener } from './paste-accelerator';
 import { restartAndResync } from './hook-status';
 import { initProviders, getAllProviders } from './providers/registry';
 import { initAutoUpdater } from './auto-updater';
@@ -72,6 +72,7 @@ function createWindow(): void {
   mainWindow.on('closed', () => {
     killAllPtys();
     resetHookWatcher();
+    resetPasteListener();
     mainWindow = null;
   });
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,5 +1,6 @@
 import { app, Menu, BrowserWindow } from 'electron';
 import { isMac, isWin } from './platform';
+import { getPasteAccelerator } from './paste-accelerator';
 
 export function createAppMenu(debugMode = false): void {
 
@@ -53,7 +54,12 @@ export function createAppMenu(debugMode = false): void {
         { type: 'separator' as const },
         { label: 'Cut', click: () => focusedContents()?.cut() },
         { label: 'Copy', click: () => focusedContents()?.copy() },
-        { label: 'Paste', click: () => focusedContents()?.paste() },
+        {
+          label: 'Paste',
+          accelerator: getPasteAccelerator(),
+          registerAccelerator: false,
+          click: () => focusedContents()?.paste(),
+        },
         { label: 'Delete', click: () => focusedContents()?.delete() },
         { label: 'Select All', click: () => focusedContents()?.selectAll() },
       ] : [
@@ -62,7 +68,12 @@ export function createAppMenu(debugMode = false): void {
         { type: 'separator' as const },
         { role: 'cut' as const },
         { role: 'copy' as const },
-        { role: 'paste' as const },
+        {
+          label: 'Paste',
+          accelerator: getPasteAccelerator(),
+          registerAccelerator: false,
+          click: () => focusedContents()?.paste(),
+        },
         { role: 'pasteAndMatchStyle' as const },
         { role: 'delete' as const },
         { role: 'selectAll' as const },

--- a/src/main/paste-accelerator.test.ts
+++ b/src/main/paste-accelerator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { matchesPasteAccelerator } from './paste-accelerator';
 
 type Input = {
@@ -79,5 +79,109 @@ describe('matchesPasteAccelerator', () => {
   it('returns false for malformed accelerator', () => {
     const input = makeInput({ control: true, key: 'V' });
     expect(matchesPasteAccelerator(input, '+++', 'linux')).toBe(false);
+  });
+});
+
+describe('paste-accelerator stateful API', () => {
+  beforeEach(async () => {
+    const mod = await import('./paste-accelerator');
+    mod._resetForTesting();
+  });
+
+  it('getPasteAccelerator returns default initially', async () => {
+    const { getPasteAccelerator } = await import('./paste-accelerator');
+    expect(getPasteAccelerator()).toBe('CmdOrCtrl+V');
+  });
+
+  it('setPasteAccelerator round-trips via getPasteAccelerator', async () => {
+    const { setPasteAccelerator, getPasteAccelerator } = await import('./paste-accelerator');
+    setPasteAccelerator('CmdOrCtrl+Shift+V');
+    expect(getPasteAccelerator()).toBe('CmdOrCtrl+Shift+V');
+  });
+
+  it('setPasteAccelerator with empty string falls back to default', async () => {
+    const { setPasteAccelerator, getPasteAccelerator } = await import('./paste-accelerator');
+    setPasteAccelerator('CmdOrCtrl+Shift+V');
+    setPasteAccelerator('');
+    expect(getPasteAccelerator()).toBe('CmdOrCtrl+V');
+  });
+
+  it('_resetForTesting restores the default accelerator', async () => {
+    const { setPasteAccelerator, getPasteAccelerator, _resetForTesting } = await import('./paste-accelerator');
+    setPasteAccelerator('Ctrl+Shift+V');
+    _resetForTesting();
+    expect(getPasteAccelerator()).toBe('CmdOrCtrl+V');
+  });
+
+  it('installPasteListener registers a before-input-event handler exactly once for the same window', async () => {
+    const { installPasteListener } = await import('./paste-accelerator');
+    const on = vi.fn();
+    const send = vi.fn();
+    const fakeWindow = { webContents: { on, send } } as unknown as Parameters<typeof installPasteListener>[0];
+    installPasteListener(fakeWindow);
+    installPasteListener(fakeWindow);
+    expect(on).toHaveBeenCalledTimes(1);
+    expect(on).toHaveBeenCalledWith('before-input-event', expect.any(Function));
+  });
+
+  it('installPasteListener does not attach a second listener to a different window once one is installed', async () => {
+    const { installPasteListener } = await import('./paste-accelerator');
+    const on1 = vi.fn();
+    const on2 = vi.fn();
+    const w1 = { webContents: { on: on1, send: vi.fn() } } as unknown as Parameters<typeof installPasteListener>[0];
+    const w2 = { webContents: { on: on2, send: vi.fn() } } as unknown as Parameters<typeof installPasteListener>[0];
+    installPasteListener(w1);
+    installPasteListener(w2);
+    expect(on1).toHaveBeenCalledTimes(1);
+    expect(on2).not.toHaveBeenCalled();
+  });
+
+  it('on matching keydown the listener prevents default and sends paste:dispatch', async () => {
+    const { installPasteListener, setPasteAccelerator } = await import('./paste-accelerator');
+    setPasteAccelerator('CmdOrCtrl+V');
+    let captured: ((event: { preventDefault: () => void }, input: unknown) => void) | null = null;
+    const on = vi.fn((_evt: string, handler: (event: { preventDefault: () => void }, input: unknown) => void) => {
+      captured = handler;
+    });
+    const send = vi.fn();
+    const fakeWindow = { webContents: { on, send } } as unknown as Parameters<typeof installPasteListener>[0];
+    installPasteListener(fakeWindow);
+
+    const preventDefault = vi.fn();
+    captured!({ preventDefault }, {
+      type: 'keyDown',
+      key: 'V',
+      control: true,
+      meta: false,
+      shift: false,
+      alt: false,
+      isComposing: false,
+    });
+    expect(preventDefault).toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith('paste:dispatch');
+  });
+
+  it('on non-matching keydown the listener does not prevent default or send', async () => {
+    const { installPasteListener } = await import('./paste-accelerator');
+    let captured: ((event: { preventDefault: () => void }, input: unknown) => void) | null = null;
+    const on = vi.fn((_evt: string, handler: (event: { preventDefault: () => void }, input: unknown) => void) => {
+      captured = handler;
+    });
+    const send = vi.fn();
+    const fakeWindow = { webContents: { on, send } } as unknown as Parameters<typeof installPasteListener>[0];
+    installPasteListener(fakeWindow);
+
+    const preventDefault = vi.fn();
+    captured!({ preventDefault }, {
+      type: 'keyDown',
+      key: 'A',
+      control: true,
+      meta: false,
+      shift: false,
+      alt: false,
+      isComposing: false,
+    });
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
   });
 });

--- a/src/main/paste-accelerator.test.ts
+++ b/src/main/paste-accelerator.test.ts
@@ -136,6 +136,19 @@ describe('paste-accelerator stateful API', () => {
     expect(on2).not.toHaveBeenCalled();
   });
 
+  it('after resetPasteListener, installPasteListener attaches to a freshly recreated window', async () => {
+    const { installPasteListener, resetPasteListener } = await import('./paste-accelerator');
+    const on1 = vi.fn();
+    const on2 = vi.fn();
+    const w1 = { webContents: { on: on1, send: vi.fn() } } as unknown as Parameters<typeof installPasteListener>[0];
+    const w2 = { webContents: { on: on2, send: vi.fn() } } as unknown as Parameters<typeof installPasteListener>[0];
+    installPasteListener(w1);
+    resetPasteListener();
+    installPasteListener(w2);
+    expect(on1).toHaveBeenCalledTimes(1);
+    expect(on2).toHaveBeenCalledTimes(1);
+  });
+
   it('on matching keydown the listener prevents default and sends paste:dispatch', async () => {
     const { installPasteListener, setPasteAccelerator } = await import('./paste-accelerator');
     setPasteAccelerator('CmdOrCtrl+V');

--- a/src/main/paste-accelerator.test.ts
+++ b/src/main/paste-accelerator.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { matchesPasteAccelerator } from './paste-accelerator';
+
+type Input = {
+  type: 'keyDown' | 'keyUp';
+  key: string;
+  control: boolean;
+  meta: boolean;
+  shift: boolean;
+  alt: boolean;
+  isComposing?: boolean;
+};
+
+function makeInput(over: Partial<Input>): Input {
+  return {
+    type: 'keyDown',
+    key: 'V',
+    control: false,
+    meta: false,
+    shift: false,
+    alt: false,
+    isComposing: false,
+    ...over,
+  };
+}
+
+describe('matchesPasteAccelerator', () => {
+  it('matches Ctrl+V on Linux/Windows when accelerator is CmdOrCtrl+V', () => {
+    const input = makeInput({ control: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'linux')).toBe(true);
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'win32')).toBe(true);
+  });
+
+  it('matches Cmd+V on macOS when accelerator is CmdOrCtrl+V', () => {
+    const input = makeInput({ meta: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'darwin')).toBe(true);
+  });
+
+  it('does not match Ctrl+V on macOS when accelerator is CmdOrCtrl+V', () => {
+    const input = makeInput({ control: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'darwin')).toBe(false);
+  });
+
+  it('matches Ctrl+Shift+V exactly', () => {
+    const input = makeInput({ control: true, shift: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, 'Ctrl+Shift+V', 'linux')).toBe(true);
+  });
+
+  it('does not match when extra modifier present', () => {
+    const input = makeInput({ control: true, shift: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'linux')).toBe(false);
+  });
+
+  it('does not match when modifier missing', () => {
+    const input = makeInput({ key: 'V' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'linux')).toBe(false);
+  });
+
+  it('case-insensitive on letter keys', () => {
+    const input = makeInput({ control: true, key: 'v' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'linux')).toBe(true);
+  });
+
+  it('only matches keyDown events', () => {
+    const input = makeInput({ type: 'keyUp', control: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'linux')).toBe(false);
+  });
+
+  it('does not match when isComposing is true (IME)', () => {
+    const input = makeInput({ control: true, key: 'V', isComposing: true });
+    expect(matchesPasteAccelerator(input, 'CmdOrCtrl+V', 'linux')).toBe(false);
+  });
+
+  it('returns false for empty accelerator', () => {
+    const input = makeInput({ control: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, '', 'linux')).toBe(false);
+  });
+
+  it('returns false for malformed accelerator', () => {
+    const input = makeInput({ control: true, key: 'V' });
+    expect(matchesPasteAccelerator(input, '+++', 'linux')).toBe(false);
+  });
+});

--- a/src/main/paste-accelerator.ts
+++ b/src/main/paste-accelerator.ts
@@ -2,6 +2,7 @@ import type { BrowserWindow } from 'electron';
 
 export type Platform = NodeJS.Platform;
 
+
 export interface InputLike {
   type: 'keyDown' | 'keyUp' | string;
   key: string;
@@ -79,7 +80,6 @@ export function matchesPasteAccelerator(
 
 let currentAccelerator = 'CmdOrCtrl+V';
 let listenerInstalled = false;
-let installedWindow: BrowserWindow | null = null;
 
 export function setPasteAccelerator(accelerator: string): void {
   currentAccelerator = accelerator || 'CmdOrCtrl+V';
@@ -91,13 +91,13 @@ export function getPasteAccelerator(): string {
 
 /**
  * Install the paste accelerator listener on the given window's webContents.
- * Idempotent: subsequent calls are no-ops, even with a different window
- * (the app is single-main-window). Pre-existing listener stays attached.
+ * Idempotent: subsequent calls are no-ops while a listener is already
+ * installed. Call `resetPasteListener` after the window is destroyed so a
+ * freshly recreated window (e.g. macOS dock-reopen) gets its own listener.
  */
 export function installPasteListener(window: BrowserWindow): void {
   if (listenerInstalled) return;
   listenerInstalled = true;
-  installedWindow = window;
 
   window.webContents.on('before-input-event', (event, input) => {
     if (matchesPasteAccelerator(input as InputLike, currentAccelerator)) {
@@ -107,9 +107,12 @@ export function installPasteListener(window: BrowserWindow): void {
   });
 }
 
+export function resetPasteListener(): void {
+  listenerInstalled = false;
+}
+
 // Test-only: reset module state between tests.
 export function _resetForTesting(): void {
   currentAccelerator = 'CmdOrCtrl+V';
   listenerInstalled = false;
-  installedWindow = null;
 }

--- a/src/main/paste-accelerator.ts
+++ b/src/main/paste-accelerator.ts
@@ -89,8 +89,13 @@ export function getPasteAccelerator(): string {
   return currentAccelerator;
 }
 
+/**
+ * Install the paste accelerator listener on the given window's webContents.
+ * Idempotent: subsequent calls are no-ops, even with a different window
+ * (the app is single-main-window). Pre-existing listener stays attached.
+ */
 export function installPasteListener(window: BrowserWindow): void {
-  if (listenerInstalled && installedWindow === window) return;
+  if (listenerInstalled) return;
   listenerInstalled = true;
   installedWindow = window;
 

--- a/src/main/paste-accelerator.ts
+++ b/src/main/paste-accelerator.ts
@@ -1,0 +1,110 @@
+import type { BrowserWindow } from 'electron';
+
+export type Platform = NodeJS.Platform;
+
+export interface InputLike {
+  type: 'keyDown' | 'keyUp' | string;
+  key: string;
+  control: boolean;
+  meta: boolean;
+  shift: boolean;
+  alt: boolean;
+  isComposing?: boolean;
+}
+
+interface ParsedAccelerator {
+  ctrl: boolean;
+  meta: boolean;
+  shift: boolean;
+  alt: boolean;
+  key: string;
+}
+
+function parseAccelerator(accelerator: string, platform: Platform): ParsedAccelerator | null {
+  if (!accelerator) return null;
+  const parts = accelerator.split('+').map((p) => p.trim()).filter(Boolean);
+  if (parts.length === 0) return null;
+
+  let ctrl = false;
+  let meta = false;
+  let shift = false;
+  let alt = false;
+  let key = '';
+
+  for (const part of parts) {
+    const lower = part.toLowerCase();
+    if (lower === 'cmdorctrl') {
+      if (platform === 'darwin') meta = true;
+      else ctrl = true;
+    } else if (lower === 'ctrl' || lower === 'control') {
+      ctrl = true;
+    } else if (lower === 'cmd' || lower === 'command' || lower === 'meta') {
+      meta = true;
+    } else if (lower === 'shift') {
+      shift = true;
+    } else if (lower === 'alt' || lower === 'option') {
+      alt = true;
+    } else {
+      if (key) return null; // multiple non-modifier keys
+      key = part;
+    }
+  }
+
+  if (!key) return null;
+  return { ctrl, meta, shift, alt, key };
+}
+
+export function matchesPasteAccelerator(
+  input: InputLike,
+  accelerator: string,
+  platform: Platform = process.platform,
+): boolean {
+  if (input.type !== 'keyDown') return false;
+  if (input.isComposing) return false;
+
+  const parsed = parseAccelerator(accelerator, platform);
+  if (!parsed) return false;
+
+  if (parsed.ctrl !== input.control) return false;
+  if (parsed.meta !== input.meta) return false;
+  if (parsed.shift !== input.shift) return false;
+  if (parsed.alt !== input.alt) return false;
+
+  const inputKey = input.key;
+  if (inputKey === parsed.key) return true;
+  if (inputKey.length === 1 && parsed.key.length === 1
+      && inputKey.toLowerCase() === parsed.key.toLowerCase()) return true;
+  return false;
+}
+
+let currentAccelerator = 'CmdOrCtrl+V';
+let listenerInstalled = false;
+let installedWindow: BrowserWindow | null = null;
+
+export function setPasteAccelerator(accelerator: string): void {
+  currentAccelerator = accelerator || 'CmdOrCtrl+V';
+}
+
+export function getPasteAccelerator(): string {
+  return currentAccelerator;
+}
+
+export function installPasteListener(window: BrowserWindow): void {
+  if (listenerInstalled && installedWindow === window) return;
+  listenerInstalled = true;
+  installedWindow = window;
+
+  window.webContents.on('before-input-event', (event, input) => {
+    if (matchesPasteAccelerator(input as InputLike, currentAccelerator)) {
+      event.preventDefault();
+      window.webContents.send('paste:dispatch');
+    }
+  });
+}
+
+// Test-only: reset module state between tests.
+export function _resetForTesting(): void {
+  currentAccelerator = 'CmdOrCtrl+V';
+  listenerInstalled = false;
+  installedWindow = null;
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -120,6 +120,11 @@ export interface VibeyardApi {
   clipboard: {
     write(text: string): Promise<void>;
   };
+  paste: {
+    setAccelerator(accelerator: string): Promise<void>;
+    native(): Promise<void>;
+    onDispatch(callback: () => void): () => void;
+  };
   zoom: {
     set(factor: number): void;
   };
@@ -281,6 +286,11 @@ const api: VibeyardApi = {
   },
   clipboard: {
     write: (text: string) => ipcRenderer.invoke('clipboard:write', text),
+  },
+  paste: {
+    setAccelerator: (accelerator: string) => ipcRenderer.invoke('paste:set-accelerator', accelerator),
+    native: () => ipcRenderer.invoke('paste:native'),
+    onDispatch: (callback) => onChannel('paste:dispatch', () => callback()),
   },
   zoom: {
     set: (factor: number) => {

--- a/src/renderer/components/project-terminal.ts
+++ b/src/renderer/components/project-terminal.ts
@@ -84,7 +84,7 @@ function createShell(projectId: string): ShellTerminalInstance {
   const shellId = crypto.randomUUID();
   const sessionId = `shell-${projectId}-${shellId}`;
 
-  attachClipboardCopyHandler(terminal, undefined, (data) => window.vibeyard.pty.write(sessionId, data));
+  attachClipboardCopyHandler(terminal);
 
   const instance: ShellTerminalInstance = {
     id: shellId,

--- a/src/renderer/components/terminal-pane.ts
+++ b/src/renderer/components/terminal-pane.ts
@@ -99,8 +99,6 @@ export function createTerminalPane(
     }
   }));
 
-  const writeToPty = (data: string) => window.vibeyard.pty.write(sessionId, data);
-
   // Send CSI u encoding for Shift+Enter so Claude CLI treats it as newline
   attachClipboardCopyHandler(terminal, (e) => {
     if (e.shiftKey && e.key === 'Enter') {
@@ -108,7 +106,7 @@ export function createTerminalPane(
       e.preventDefault();
       return false;
     }
-  }, writeToPty);
+  });
 
   const instance: TerminalInstance = {
     terminal,
@@ -316,6 +314,23 @@ export function setFocused(sessionId: string): void {
       instance.element.classList.remove('focused');
     }
   }
+}
+
+/** Returns true if any text was sent to the focused session's PTY. */
+export function writeToFocusedTerminal(data: string): boolean {
+  if (!focusedSessionId) return false;
+  if (!data) return false;
+  window.vibeyard.pty.write(focusedSessionId, data);
+  return true;
+}
+
+/** Returns whether the focused terminal currently has bracketed-paste mode enabled. */
+export function getFocusedTerminalBracketedPaste(): boolean {
+  if (!focusedSessionId) return false;
+  const instance = instances.get(focusedSessionId);
+  if (!instance) return false;
+  const modes = (instance.terminal as { modes?: { bracketedPasteMode?: boolean } }).modes;
+  return !!modes?.bracketedPasteMode;
 }
 
 export function handlePtyData(sessionId: string, data: string): void {

--- a/src/renderer/components/terminal-pane.ts
+++ b/src/renderer/components/terminal-pane.ts
@@ -180,11 +180,15 @@ export function setPendingPrompt(sessionId: string, prompt: string): void {
   }
 }
 
+function readBracketedPasteMode(terminal: Terminal): boolean {
+  const modes = (terminal as unknown as { modes?: { bracketedPasteMode?: boolean } }).modes;
+  return !!modes?.bracketedPasteMode;
+}
+
 export function injectPromptIntoRunningSession(sessionId: string, prompt: string): boolean {
   const instance = instances.get(sessionId);
   if (!instance || !instance.spawned || instance.exited) return false;
-  const modes = (instance.terminal as unknown as { modes?: { bracketedPasteMode?: boolean } }).modes;
-  const bp = modes?.bracketedPasteMode;
+  const bp = readBracketedPasteMode(instance.terminal);
   const payload = bp ? `\x1b[200~${prompt}\x1b[201~` : prompt;
   window.vibeyard.pty.write(sessionId, payload);
   window.vibeyard.pty.write(sessionId, '\r');
@@ -318,8 +322,7 @@ export function setFocused(sessionId: string): void {
 
 /** Returns true if any text was sent to the focused session's PTY. */
 export function writeToFocusedTerminal(data: string): boolean {
-  if (!focusedSessionId) return false;
-  if (!data) return false;
+  if (!focusedSessionId || !data) return false;
   window.vibeyard.pty.write(focusedSessionId, data);
   return true;
 }
@@ -329,8 +332,7 @@ export function getFocusedTerminalBracketedPaste(): boolean {
   if (!focusedSessionId) return false;
   const instance = instances.get(focusedSessionId);
   if (!instance) return false;
-  const modes = (instance.terminal as { modes?: { bracketedPasteMode?: boolean } }).modes;
-  return !!modes?.bracketedPasteMode;
+  return readBracketedPasteMode(instance.terminal);
 }
 
 export function handlePtyData(sessionId: string, data: string): void {

--- a/src/renderer/components/terminal-utils.test.ts
+++ b/src/renderer/components/terminal-utils.test.ts
@@ -41,14 +41,12 @@ vi.mock('@xterm/addon-webgl', () => ({
 import { attachClipboardCopyHandler, attachCopyOnSelect, loadWebglWithFallback } from './terminal-utils.js';
 
 const mockClipboardWrite = vi.fn().mockResolvedValue(undefined);
-const mockClipboardRead = vi.fn();
 const mockVibeyardClipboardWrite = vi.fn().mockResolvedValue(undefined);
 
 class FakeTerminal {
   private keyHandler: ((e: KeyboardEvent) => boolean) | null = null;
   private selectionListener: (() => void) | null = null;
   private _selection = '';
-  modes = { bracketedPasteMode: false };
 
   attachCustomKeyEventHandler(handler: (e: KeyboardEvent) => boolean): void {
     this.keyHandler = handler;
@@ -68,13 +66,12 @@ class FakeTerminal {
 function stubPlatform(platform: string) {
   vi.stubGlobal('navigator', {
     platform,
-    clipboard: { writeText: mockClipboardWrite, readText: mockClipboardRead },
+    clipboard: { writeText: mockClipboardWrite },
   });
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockClipboardRead.mockResolvedValue('');
   mockMatchesAnyShortcut.mockReturnValue(false);
   mockPreferences.copyOnSelect = false;
   vi.stubGlobal('window', { vibeyard: { clipboard: { write: mockVibeyardClipboardWrite } } });
@@ -174,16 +171,6 @@ describe('attachClipboardCopyHandler (macOS)', () => {
     expect(mockClipboardWrite).not.toHaveBeenCalled();
   });
 
-  it('does not intercept Ctrl+V (lets xterm send control char)', () => {
-    const terminal = new FakeTerminal();
-    const writeToPty = vi.fn();
-    attachClipboardCopyHandler(terminal as any, undefined, writeToPty);
-
-    const result = terminal.simulateKey({ ctrlKey: true, key: 'v', type: 'keydown' });
-
-    expect(result).toBe(true);
-    expect(writeToPty).not.toHaveBeenCalled();
-  });
 });
 
 describe('attachClipboardCopyHandler (Windows)', () => {
@@ -224,75 +211,6 @@ describe('attachClipboardCopyHandler (Windows)', () => {
 
     expect(result).toBe(false);
     expect(mockClipboardWrite).not.toHaveBeenCalled();
-  });
-
-  it('Ctrl+V returns false and pastes clipboard to PTY', async () => {
-    const terminal = new FakeTerminal();
-    const writeToPty = vi.fn();
-    mockClipboardRead.mockResolvedValue('pasted text');
-    attachClipboardCopyHandler(terminal as any, undefined, writeToPty);
-
-    const result = terminal.simulateKey({ ctrlKey: true, key: 'v', type: 'keydown', preventDefault: vi.fn() });
-
-    expect(result).toBe(false);
-    await vi.waitFor(() => expect(writeToPty).toHaveBeenCalledWith('pasted text'));
-  });
-
-  it('Ctrl+V calls preventDefault to suppress native paste event', () => {
-    const terminal = new FakeTerminal();
-    const writeToPty = vi.fn();
-    const preventDefault = vi.fn();
-    mockClipboardRead.mockResolvedValue('text');
-    attachClipboardCopyHandler(terminal as any, undefined, writeToPty);
-
-    terminal.simulateKey({ ctrlKey: true, key: 'v', type: 'keydown', preventDefault });
-
-    expect(preventDefault).toHaveBeenCalled();
-  });
-
-  it('Ctrl+V wraps text in bracketed paste escapes when mode is enabled', async () => {
-    const terminal = new FakeTerminal();
-    terminal.modes.bracketedPasteMode = true;
-    const writeToPty = vi.fn();
-    mockClipboardRead.mockResolvedValue('pasted');
-    attachClipboardCopyHandler(terminal as any, undefined, writeToPty);
-
-    terminal.simulateKey({ ctrlKey: true, key: 'v', type: 'keydown', preventDefault: vi.fn() });
-
-    await vi.waitFor(() => expect(writeToPty).toHaveBeenCalledWith('\x1b[200~pasted\x1b[201~'));
-  });
-
-  it('Ctrl+V does not paste empty clipboard', async () => {
-    const terminal = new FakeTerminal();
-    const writeToPty = vi.fn();
-    mockClipboardRead.mockResolvedValue('');
-    attachClipboardCopyHandler(terminal as any, undefined, writeToPty);
-
-    terminal.simulateKey({ ctrlKey: true, key: 'v', type: 'keydown', preventDefault: vi.fn() });
-
-    await Promise.resolve();
-    expect(writeToPty).not.toHaveBeenCalled();
-  });
-
-  it('Ctrl+V without writeToPty falls through to default', () => {
-    const terminal = new FakeTerminal();
-    attachClipboardCopyHandler(terminal as any);
-
-    const result = terminal.simulateKey({ ctrlKey: true, key: 'v', type: 'keydown' });
-
-    expect(result).toBe(true);
-  });
-
-  it('Ctrl+V does not call writeToPty on keyup', async () => {
-    const terminal = new FakeTerminal();
-    const writeToPty = vi.fn();
-    mockClipboardRead.mockResolvedValue('text');
-    attachClipboardCopyHandler(terminal as any, undefined, writeToPty);
-
-    terminal.simulateKey({ ctrlKey: true, key: 'v', type: 'keyup', preventDefault: vi.fn() });
-
-    await Promise.resolve();
-    expect(writeToPty).not.toHaveBeenCalled();
   });
 
   it('Ctrl+Shift+C still works for copy', () => {

--- a/src/renderer/components/terminal-utils.ts
+++ b/src/renderer/components/terminal-utils.ts
@@ -26,7 +26,7 @@ export function attachCopyOnSelect(terminal: Terminal): void {
  */
 export function attachClipboardCopyHandler(
   terminal: Terminal,
-  extend?: ExtraKeyHandler,
+  extend?: ExtraKeyHandler
 ): void {
   terminal.attachCustomKeyEventHandler((e) => {
     // Cmd/Ctrl+F: bubble to document for search

--- a/src/renderer/components/terminal-utils.ts
+++ b/src/renderer/components/terminal-utils.ts
@@ -20,18 +20,13 @@ export function attachCopyOnSelect(terminal: Terminal): void {
  * - Cmd/Ctrl+F: bubbles up to document (prevents xterm from consuming it)
  * - Ctrl+Shift+C: copies selected text to clipboard
  * - Windows Ctrl+C: copies if selection exists, otherwise passes through as SIGINT
- * - Windows Ctrl+V: pastes clipboard content to PTY (requires writeToPty)
  *
  * Pass an optional `extend` handler for terminal-specific key behavior.
  * Return false to suppress the key, undefined to fall through to default.
- *
- * Pass `writeToPty` to enable Ctrl+V paste on Windows — it receives the
- * clipboard text and should forward it to the PTY.
  */
 export function attachClipboardCopyHandler(
   terminal: Terminal,
   extend?: ExtraKeyHandler,
-  writeToPty?: (data: string) => void
 ): void {
   terminal.attachCustomKeyEventHandler((e) => {
     // Cmd/Ctrl+F: bubble to document for search
@@ -54,21 +49,6 @@ export function attachClipboardCopyHandler(
         return false;
       }
       return true; // no selection — let xterm send \x03
-    }
-
-    // Windows: Ctrl+V → async paste clipboard to PTY
-    if (isWin && e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && e.key === 'v' && writeToPty) {
-      if (e.type === 'keydown') {
-        navigator.clipboard.readText().then((text) => {
-          if (!text) return;
-          // Respect bracketed paste mode if the shell enabled it
-          const modes = (terminal as any).modes;
-          const bp = modes?.bracketedPasteMode;
-          writeToPty(bp ? `\x1b[200~${text}\x1b[201~` : text);
-        }).catch(() => {});
-      }
-      e.preventDefault(); // prevent native paste event from firing
-      return false; // suppress \x16
     }
 
     // Let registered app shortcuts bubble to document listener

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -41,6 +41,9 @@ import { initBoard } from './components/board/board-view.js';
 import { initBoardSessionSync } from './board-session-sync.js';
 import { getZoomFactor } from './zoom.js';
 import { confirmAppClose } from './session-close.js';
+import { createPasteDispatcher } from './paste-dispatcher.js';
+import { shortcutManager } from './shortcuts.js';
+import { writeToFocusedTerminal, getFocusedTerminalBracketedPaste } from './components/terminal-pane.js';
 
 let isQuitting = false;
 window.vibeyard.app.onQuitting(() => {
@@ -206,6 +209,16 @@ async function main(): Promise<void> {
   // Load persisted state
   await appState.load();
 
+  const dispatchPaste = createPasteDispatcher({
+    writeToFocusedTerminal,
+    isFocusedTerminalBracketedPaste: getFocusedTerminalBracketedPaste,
+    pasteNative: () => { window.vibeyard.paste.native().catch(() => {}); },
+  });
+  window.vibeyard.paste.onDispatch(() => { dispatchPaste().catch(() => {}); });
+
+  const initialPasteAccel = shortcutManager.getKeys('paste') || 'CmdOrCtrl+V';
+  await window.vibeyard.paste.setAccelerator(initialPasteAccel);
+
   // Apply theme from loaded preferences
   const initialTheme = appState.preferences.theme ?? 'dark';
   document.documentElement.dataset.theme = initialTheme;
@@ -217,6 +230,9 @@ async function main(): Promise<void> {
     applyThemeToAllTerminals(theme);
     applyThemeToAllShells(theme);
     applyThemeToAllRemoteTerminals(theme);
+    const pasteAccel = shortcutManager.getKeys('paste') || 'CmdOrCtrl+V';
+    window.vibeyard.paste.setAccelerator(pasteAccel).catch(() => {});
+    window.vibeyard.menu.rebuild(appState.preferences.debugMode ?? false).catch(() => {});
   });
   const savedZoom = getZoomFactor();
   if (savedZoom !== 1.0) window.vibeyard.zoom.set(savedZoom);

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -218,6 +218,7 @@ async function main(): Promise<void> {
 
   const initialPasteAccel = shortcutManager.getKeys('paste') || 'CmdOrCtrl+V';
   await window.vibeyard.paste.setAccelerator(initialPasteAccel);
+  await window.vibeyard.menu.rebuild(appState.preferences.debugMode ?? false);
 
   // Apply theme from loaded preferences
   const initialTheme = appState.preferences.theme ?? 'dark';

--- a/src/renderer/paste-dispatcher.test.ts
+++ b/src/renderer/paste-dispatcher.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('./state.js', () => ({
+  appState: { preferences: {} },
+}));
+
+import { classifyTarget, buildPtyPasteString } from './paste-dispatcher';
+
+describe('classifyTarget', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns "terminal" for an element inside .terminal-pane', () => {
+    document.body.innerHTML = '<div class="terminal-pane"><canvas id="t"></canvas></div>';
+    const el = document.getElementById('t')!;
+    expect(classifyTarget(el)).toBe('terminal');
+  });
+
+  it('returns "input" for an <input>', () => {
+    document.body.innerHTML = '<input id="i" type="text" />';
+    const el = document.getElementById('i')!;
+    expect(classifyTarget(el)).toBe('input');
+  });
+
+  it('returns "input" for a <textarea>', () => {
+    document.body.innerHTML = '<textarea id="t"></textarea>';
+    const el = document.getElementById('t')!;
+    expect(classifyTarget(el)).toBe('input');
+  });
+
+  it('returns "input" for contenteditable', () => {
+    document.body.innerHTML = '<div id="c" contenteditable="true">x</div>';
+    const el = document.getElementById('c')!;
+    expect(classifyTarget(el)).toBe('input');
+  });
+
+  it('returns "other" for body', () => {
+    expect(classifyTarget(document.body)).toBe('other');
+  });
+
+  it('returns "other" for null', () => {
+    expect(classifyTarget(null)).toBe('other');
+  });
+});
+
+describe('buildPtyPasteString', () => {
+  it('returns plain text when bracketed paste mode is off', () => {
+    expect(buildPtyPasteString('hello', false)).toBe('hello');
+  });
+
+  it('wraps text in bracketed-paste sequences when bracketed paste mode is on', () => {
+    expect(buildPtyPasteString('hello', true)).toBe('\x1b[200~hello\x1b[201~');
+  });
+
+  it('returns empty string for empty input regardless of mode', () => {
+    expect(buildPtyPasteString('', false)).toBe('');
+    expect(buildPtyPasteString('', true)).toBe('');
+  });
+});

--- a/src/renderer/paste-dispatcher.ts
+++ b/src/renderer/paste-dispatcher.ts
@@ -1,0 +1,42 @@
+export type PasteTarget = 'terminal' | 'input' | 'other';
+
+export function classifyTarget(el: Element | null): PasteTarget {
+  if (!el) return 'other';
+  if (el.closest('.terminal-pane')) return 'terminal';
+  const tag = el.tagName?.toLowerCase();
+  if (tag === 'input' || tag === 'textarea') return 'input';
+  if ((el as HTMLElement).isContentEditable) return 'input';
+  return 'other';
+}
+
+export function buildPtyPasteString(text: string, bracketedPasteMode: boolean): string {
+  if (!text) return '';
+  return bracketedPasteMode ? `\x1b[200~${text}\x1b[201~` : text;
+}
+
+type WriteToFocusedTerminal = (data: string) => boolean;
+type GetBracketedPaste = () => boolean;
+
+export function createPasteDispatcher(deps: {
+  writeToFocusedTerminal: WriteToFocusedTerminal;
+  isFocusedTerminalBracketedPaste: GetBracketedPaste;
+  pasteNative: () => void;
+}) {
+  return async function dispatchPaste(): Promise<void> {
+    const target = classifyTarget(document.activeElement);
+    if (target === 'terminal') {
+      let text = '';
+      try {
+        text = await navigator.clipboard.readText();
+      } catch {
+        return;
+      }
+      const bp = deps.isFocusedTerminalBracketedPaste();
+      const data = buildPtyPasteString(text, bp);
+      if (data) deps.writeToFocusedTerminal(data);
+    } else if (target === 'input') {
+      deps.pasteNative();
+    }
+    // 'other' → no-op
+  };
+}

--- a/src/renderer/shortcuts.test.ts
+++ b/src/renderer/shortcuts.test.ts
@@ -452,30 +452,58 @@ describe('shortcutManager singleton', () => {
   });
 });
 
-describe('paste shortcut', () => {
+describe('paste shortcut (Linux)', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.stubGlobal('navigator', { platform: 'Linux x86_64' });
     mockAppState.preferences.keybindings = {};
   });
 
-  it('paste shortcut is present in SHORTCUT_DEFAULTS with default CmdOrCtrl+V', async () => {
+  it('default is Ctrl+Shift+V to match Linux terminal convention', async () => {
     const { SHORTCUT_DEFAULTS } = await import('./shortcuts');
     const paste = SHORTCUT_DEFAULTS.find((s) => s.id === 'paste');
     expect(paste).toBeDefined();
-    expect(paste!.defaultKeys).toBe('CmdOrCtrl+V');
+    expect(paste!.defaultKeys).toBe('Ctrl+Shift+V');
     expect(paste!.label).toBe('Paste');
     expect(paste!.category).toBe('Editing');
   });
 
-  it('shortcutManager.getKeys returns default for paste when no override', async () => {
+  it('shortcutManager.getKeys returns Ctrl+Shift+V for paste when no override', async () => {
     const { shortcutManager } = await import('./shortcuts');
-    expect(shortcutManager.getKeys('paste')).toBe('CmdOrCtrl+V');
+    expect(shortcutManager.getKeys('paste')).toBe('Ctrl+Shift+V');
   });
 
   it('shortcutManager.getKeys returns override for paste when set', async () => {
-    mockAppState.preferences.keybindings = { paste: 'CmdOrCtrl+Shift+V' };
+    mockAppState.preferences.keybindings = { paste: 'CmdOrCtrl+V' };
     const { shortcutManager } = await import('./shortcuts');
-    expect(shortcutManager.getKeys('paste')).toBe('CmdOrCtrl+Shift+V');
+    expect(shortcutManager.getKeys('paste')).toBe('CmdOrCtrl+V');
+  });
+});
+
+describe('paste shortcut (Mac)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('navigator', { platform: 'MacIntel' });
+    mockAppState.preferences.keybindings = {};
+  });
+
+  it('default is CmdOrCtrl+V on macOS', async () => {
+    const { SHORTCUT_DEFAULTS } = await import('./shortcuts');
+    const paste = SHORTCUT_DEFAULTS.find((s) => s.id === 'paste');
+    expect(paste!.defaultKeys).toBe('CmdOrCtrl+V');
+  });
+});
+
+describe('paste shortcut (Windows)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('navigator', { platform: 'Win32' });
+    mockAppState.preferences.keybindings = {};
+  });
+
+  it('default is CmdOrCtrl+V on Windows', async () => {
+    const { SHORTCUT_DEFAULTS } = await import('./shortcuts');
+    const paste = SHORTCUT_DEFAULTS.find((s) => s.id === 'paste');
+    expect(paste!.defaultKeys).toBe('CmdOrCtrl+V');
   });
 });

--- a/src/renderer/shortcuts.test.ts
+++ b/src/renderer/shortcuts.test.ts
@@ -451,3 +451,31 @@ describe('shortcutManager singleton', () => {
     expect(shortcutManager).toBeInstanceOf(ShortcutManager);
   });
 });
+
+describe('paste shortcut', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('navigator', { platform: 'Linux x86_64' });
+    mockAppState.preferences.keybindings = {};
+  });
+
+  it('paste shortcut is present in SHORTCUT_DEFAULTS with default CmdOrCtrl+V', async () => {
+    const { SHORTCUT_DEFAULTS } = await import('./shortcuts');
+    const paste = SHORTCUT_DEFAULTS.find((s) => s.id === 'paste');
+    expect(paste).toBeDefined();
+    expect(paste!.defaultKeys).toBe('CmdOrCtrl+V');
+    expect(paste!.label).toBe('Paste');
+    expect(paste!.category).toBe('Editing');
+  });
+
+  it('shortcutManager.getKeys returns default for paste when no override', async () => {
+    const { shortcutManager } = await import('./shortcuts');
+    expect(shortcutManager.getKeys('paste')).toBe('CmdOrCtrl+V');
+  });
+
+  it('shortcutManager.getKeys returns override for paste when set', async () => {
+    mockAppState.preferences.keybindings = { paste: 'CmdOrCtrl+Shift+V' };
+    const { shortcutManager } = await import('./shortcuts');
+    expect(shortcutManager.getKeys('paste')).toBe('CmdOrCtrl+Shift+V');
+  });
+});

--- a/src/renderer/shortcuts.ts
+++ b/src/renderer/shortcuts.ts
@@ -50,6 +50,7 @@ export const SHORTCUT_DEFAULTS: ShortcutDefault[] = [
   { id: 'zoom-in', label: 'Zoom In', category: 'View', defaultKeys: 'CmdOrCtrl+=' },
   { id: 'zoom-out', label: 'Zoom Out', category: 'View', defaultKeys: 'CmdOrCtrl+-' },
   { id: 'zoom-reset', label: 'Reset Zoom', category: 'View', defaultKeys: 'CmdOrCtrl+0' },
+  { id: 'paste', label: 'Paste', category: 'Editing', defaultKeys: 'CmdOrCtrl+V' },
 ];
 
 /** Convert accelerator string to platform-specific display string */

--- a/src/renderer/shortcuts.ts
+++ b/src/renderer/shortcuts.ts
@@ -1,5 +1,5 @@
 import { appState } from './state.js';
-import { isMac } from './platform.js';
+import { isMac, isLinux } from './platform.js';
 
 export interface ShortcutDef {
   id: string;
@@ -50,7 +50,7 @@ export const SHORTCUT_DEFAULTS: ShortcutDefault[] = [
   { id: 'zoom-in', label: 'Zoom In', category: 'View', defaultKeys: 'CmdOrCtrl+=' },
   { id: 'zoom-out', label: 'Zoom Out', category: 'View', defaultKeys: 'CmdOrCtrl+-' },
   { id: 'zoom-reset', label: 'Reset Zoom', category: 'View', defaultKeys: 'CmdOrCtrl+0' },
-  { id: 'paste', label: 'Paste', category: 'Editing', defaultKeys: 'CmdOrCtrl+V' },
+  { id: 'paste', label: 'Paste', category: 'Editing', defaultKeys: isLinux ? 'Ctrl+Shift+V' : 'CmdOrCtrl+V' },
 ];
 
 /** Convert accelerator string to platform-specific display string */

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -88,6 +88,11 @@ export interface VibeyardApi {
   clipboard: {
     write(text: string): Promise<void>;
   };
+  paste: {
+    setAccelerator(accelerator: string): Promise<void>;
+    native(): Promise<void>;
+    onDispatch(callback: () => void): () => void;
+  };
   menu: {
     onNewProject(callback: () => void): () => void;
     onNewSession(callback: () => void): () => void;

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -104,5 +104,6 @@ export interface VibeyardApi {
     onUsageStats(callback: () => void): () => void;
     onToggleInspector(callback: () => void): () => void;
     onCloseSession(callback: () => void): () => void;
+    rebuild(debugMode: boolean): Promise<void>;
   };
 }


### PR DESCRIPTION
## Summary
- Adds a `paste` entry to `SHORTCUT_DEFAULTS` under a new `Editing` category, surfacing it automatically in Preferences → Shortcuts. Defaults are platform-aware: `Cmd+V` on macOS, `Ctrl+V` on Windows, **`Ctrl+Shift+V` on Linux** (matches GNOME Terminal / Konsole convention so `Ctrl+V` next to `Ctrl+C` is not a footgun in shells).
- Routes paste through a single cross-platform pipeline: a main-process `before-input-event` listener matches the configured accelerator and tells the renderer to dispatch; the renderer routes by `document.activeElement` — terminal panes get bracketed-paste-aware PTY writes; native inputs delegate to `webContents.paste()` for proper cursor/undo/IME.
- Removes the hardcoded Windows `Ctrl+V` branch from `terminal-utils.ts` and the `writeToPty` argument from `attachClipboardCopyHandler` so paste no longer leaks into xterm key handlers.
- Edit menu shows the active binding label with `registerAccelerator: false` (label only, no double-firing); rebuilt on startup and on `preferences-changed`.

## Architecture
New files:
- `src/main/paste-accelerator.ts` — owns accelerator state, parses `Input` events, installs the `before-input-event` listener (idempotent; resets on window close so macOS dock-reopen works).
- `src/renderer/paste-dispatcher.ts` — receives `paste:dispatch`, classifies focus, routes paste.

New IPC channels (preload `paste` namespace): `paste:set-accelerator` (renderer → main), `paste:dispatch` (main → renderer), `paste:native` (renderer → main).

Design doc: `docs/superpowers/specs/2026-04-29-customizable-paste-shortcut-design.md`
Plan: `docs/superpowers/plans/2026-04-29-customizable-paste-shortcut.md`

## Test plan
**Automated** (passes on this branch):
- [x] `npm run build` succeeds (main, preload, renderer)
- [x] `npm test` — 1386 tests pass
- [x] Unit tests added for `matchesPasteAccelerator`, the listener install lifecycle, the focus classifier, the bracketed-paste string builder, and per-platform paste defaults

**Manual smoke test (Linux, completed):**
- [x] Default `Ctrl+Shift+V` pastes into a session terminal with bracketed paste
- [x] Default `Ctrl+Shift+V` pastes into a board task-modal text input (cursor + undo correct)
- [x] Rebound `Ctrl+V` works in both terminal and inputs; old `Ctrl+Shift+V` is suppressed
- [x] Edit menu shows the active accelerator label (correct on startup too)
- [x] Reset reverts behavior
- [x] X11 middle-click primary-selection paste still works (regression)

## Known follow-ups
- **macOS / Windows verification deferred** — implementer is on Linux. Design uses cross-platform primitives (`before-input-event`, `webContents.paste()`), but a macOS reviewer should re-verify Cmd+V default + dock-icon close-and-reopen (listener resets on window close), and a Windows reviewer should specifically check no double-paste in board task-modal inputs.
- **Project-terminal panel paste path** — the project shell terminal element doesn't carry the `.terminal-pane` class, so `classifyTarget` routes it as `'input'` → `webContents.paste()` rather than the bracketed-paste path. Paste still works, but via a different codepath than session terminals. Adding the class would unify the two paths.
