### PR TITLE
feat: critical sidebar enhancement

### DIFF
--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -52,4 +52,9 @@ copyDir(
   path.join(dist, 'assets', 'providers')
 );
 
+copyFile(
+  path.join(root, 'assets', 'subway.mp4'),
+  path.join(dist, 'assets', 'subway.mp4')
+);
+
 console.log('Assets copied.');

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -25,6 +25,10 @@
         <div id="project-list"></div>
         <div id="git-panel"></div>
       </div>
+      <div id="subway-banner">
+        <video class="subway-banner-video" muted loop playsinline></video>
+        <div class="subway-banner-placeholder">Subway Surfers (placeholder)</div>
+      </div>
       <div id="sidebar-discussions"></div>
       <div id="sidebar-footer"></div>
     </div>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -26,8 +26,7 @@
         <div id="git-panel"></div>
       </div>
       <div id="subway-banner">
-        <video class="subway-banner-video" muted loop playsinline></video>
-        <div class="subway-banner-placeholder">Subway Surfers (placeholder)</div>
+        <video class="subway-banner-video" src="assets/subway.mp4" autoplay muted loop playsinline></video>
       </div>
       <div id="sidebar-discussions"></div>
       <div id="sidebar-footer"></div>

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -103,6 +103,9 @@ export function initKeybindings(): void {
   shortcutManager.registerHandler('zoom-in', zoomIn);
   shortcutManager.registerHandler('zoom-out', zoomOut);
   shortcutManager.registerHandler('zoom-reset', zoomReset);
+  shortcutManager.registerHandler('toggle-subway-banner', () => {
+    document.getElementById('subway-banner')?.classList.toggle('subway-banner-hidden');
+  });
 
   document.addEventListener('keydown', (e) => {
     shortcutManager.matchEvent(e);

--- a/src/renderer/shortcuts.ts
+++ b/src/renderer/shortcuts.ts
@@ -50,6 +50,7 @@ export const SHORTCUT_DEFAULTS: ShortcutDefault[] = [
   { id: 'zoom-in', label: 'Zoom In', category: 'View', defaultKeys: 'CmdOrCtrl+=' },
   { id: 'zoom-out', label: 'Zoom Out', category: 'View', defaultKeys: 'CmdOrCtrl+-' },
   { id: 'zoom-reset', label: 'Reset Zoom', category: 'View', defaultKeys: 'CmdOrCtrl+0' },
+  { id: 'toggle-subway-banner', label: 'Toggle Subway Banner', category: 'View', defaultKeys: 'CmdOrCtrl+Shift+S' },
 ];
 
 /** Convert accelerator string to platform-specific display string */

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -402,16 +402,3 @@
   object-fit: cover;
   display: block;
 }
-
-.subway-banner-placeholder {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 11px;
-  color: var(--text-muted);
-  text-align: center;
-  padding: 8px;
-  pointer-events: none;
-}

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -396,6 +396,10 @@
   overflow: hidden;
 }
 
+#subway-banner.subway-banner-hidden {
+  display: none;
+}
+
 .subway-banner-video {
   width: 100%;
   height: 100%;

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -56,6 +56,7 @@
 #sidebar.collapsed .sidebar-title,
 #sidebar.collapsed .sidebar-header-actions,
 #sidebar.collapsed #sidebar-footer,
+#sidebar.collapsed #subway-banner,
 #sidebar.collapsed #git-panel,
 #sidebar.collapsed .project-item,
 #sidebar.collapsed .project-panel,
@@ -381,4 +382,36 @@
 
 .update-banner-btn.hidden {
   display: none;
+}
+
+/* --- Subway Surfers banner (bottom of sidebar, above discussions) --- */
+
+#subway-banner {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 27 / 40;
+  flex-shrink: 0;
+  background: var(--bg-primary);
+  border-top: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.subway-banner-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.subway-banner-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-align: center;
+  padding: 8px;
+  pointer-events: none;
 }


### PR DESCRIPTION
Adds a looping Subway Surfers video to the sidebar, nestled between the project list and Discussions. Vibeyard already gives you a kanban board, a team tab, multi-session swarm mode, and live cost tracking — but until now it has been missing the one feature that actually keeps people on TikTok at 2am. Fixing that.

- New `#subway-banner` element above `#sidebar-discussions` in `index.html`, holding an autoplay/muted/loop/playsinline `<video>` pointed at `assets/subway.mp4`
- 27:40 aspect-ratio CSS in `styles/sidebar.css`, `object-fit: cover` so it fills whatever sidebar width you've dragged it to
- Hides automatically when the sidebar is collapsed (added to the existing `#sidebar.collapsed` selector list)
- New `Toggle Subway Banner` shortcut in the **View** category, default `Cmd/Ctrl+Shift+S`, for the rare moments you need to focus
- `scripts/copy-assets.js` copies `subway.mp4` into `dist/renderer/assets/` on build so the renderer can find it

This entire feature was built end-to-end inside Vibeyard itself.

<img width="1512" height="981" alt="screenshot" src="https://github.com/user-attachments/assets/73c778f2-a534-47c7-ad03-6625cf7ac406" />