### PR TITLE
fix text corruption when drag-resizing the session window

### DIFF
--- a/src/renderer/components/project-terminal.ts
+++ b/src/renderer/components/project-terminal.ts
@@ -285,6 +285,23 @@ function fitActiveShell(): void {
   }
 }
 
+let fitShellsDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Trailing-debounced fit for resize storms (panel drag, ResizeObserver). Sending the
+ * PTY every intermediate size mid-drag desyncs the CLI's in-place redraw and leaves
+ * duplicated rows in scrollback; coalescing to one fit per settle avoids that. See
+ * `fitAllVisibleDebounced` in terminal-pane.ts for the full rationale.
+ */
+function fitShellsDebounced(delay = 100): void {
+  if (fitShellsDebounceTimer) clearTimeout(fitShellsDebounceTimer);
+  fitShellsDebounceTimer = setTimeout(() => {
+    fitShellsDebounceTimer = null;
+    fitActiveShell();
+    fitAllVisible();
+  }, delay);
+}
+
 export function toggleProjectTerminal(): void {
   const project = appState.activeProject;
   if (!project) return;
@@ -388,8 +405,7 @@ export function initProjectTerminal(): void {
       const delta = startY - ev.clientY;
       const newHeight = Math.max(80, Math.min(startHeight + delta, window.innerHeight - 150));
       panelEl.style.height = `${newHeight}px`;
-      fitActiveShell();
-      fitAllVisible();
+      fitShellsDebounced();
     };
 
     const onMouseUp = () => {
@@ -447,7 +463,7 @@ export function initProjectTerminal(): void {
   // Resize terminal when window resizes
   resizeObserver = new ResizeObserver(() => {
     if (currentProjectId && !panelEl.classList.contains('hidden')) {
-      fitActiveShell();
+      fitShellsDebounced();
     }
   });
   resizeObserver.observe(containerEl);

--- a/src/renderer/components/split-layout.ts
+++ b/src/renderer/components/split-layout.ts
@@ -13,6 +13,7 @@ import {
   showPane,
   hideAllPanes,
   fitAllVisible,
+  fitAllVisibleDebounced,
   setFocused,
   spawnTerminal,
   setPendingPrompt,
@@ -111,9 +112,10 @@ export function initSplitLayout(): void {
     if (project?.layout.mode === 'swarm') updateSwarmPaneStyles(project);
   });
 
-  // Refit on window resize
+  // Refit on window resize. Debounced so a drag-resize doesn't flood the PTY with
+  // intermediate sizes, which corrupts the CLI's in-place redraw (duplicated rows).
   window.addEventListener('resize', () => {
-    requestAnimationFrame(fitAllVisible);
+    fitAllVisibleDebounced();
   });
 
   // Click delegation for swarm mode: clicking a dimmed pane makes it active

--- a/src/renderer/components/terminal-pane.ts
+++ b/src/renderer/components/terminal-pane.ts
@@ -366,6 +366,27 @@ export function fitAllVisible(): void {
   }
 }
 
+let fitAllDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Trailing-debounced `fitAllVisible`, for resize storms (window drag-resize,
+ * ResizeObserver). A drag fires resize events ~60×/sec; firing `fit()` — and the
+ * `pty.resize()` SIGWINCH behind it — on every one floods the CLI with intermediate
+ * sizes. An in-place-redrawing TUI (e.g. Claude Code) tracks how many rows its last
+ * frame occupied to know how many to erase before repainting; when the width changes
+ * mid-frame that bookkeeping desyncs from xterm's actual wrapping, so stale rows are
+ * left behind and committed to scrollback as duplicates (persistent text corruption).
+ * Coalescing to a single fit once the drag settles means the CLI only ever sees a
+ * stable size, so it always redraws cleanly.
+ */
+export function fitAllVisibleDebounced(delay = 100): void {
+  if (fitAllDebounceTimer) clearTimeout(fitAllDebounceTimer);
+  fitAllDebounceTimer = setTimeout(() => {
+    fitAllDebounceTimer = null;
+    fitAllVisible();
+  }, delay);
+}
+
 export function getSearchAddon(sessionId: string): SearchAddon | undefined {
   return instances.get(sessionId)?.searchAddon;
 }


### PR DESCRIPTION
## Problem

When gradually drag-resizing — most visibly the divider between the project terminal panel and the session area, but also the OS window — text in an active session terminal gets corrupted, with some rows appearing twice. The duplication persists after the drag ends.

## Root cause

A resize drag fires resize/mousemove events ~60×/sec, and every one called `fit()` → `pty.resize()`, flooding the CLI's PTY with SIGWINCH at sizes that are invalidated a frame later. An in-place-redrawing TUI (e.g. Claude Code) repaints by tracking how many rows its last frame occupied, then moving the cursor up and erasing that many before reprinting. When the size changes mid-frame, that row bookkeeping desyncs from xterm's actual wrapping, so stale rows are left un-erased and committed into scrollback as duplicates — hence the persistent "parts appear twice" corruption. A single-jump resize (e.g. maximize) never triggered it; only a gradual drag did.

## Fix

Trailing-debounce the resize-driven fit (100ms) so the CLI only ever receives a **stable** terminal size and always redraws cleanly. Applied to the three resize-storm sources:

1. The OS window `resize` listener (`split-layout.ts`)
2. The project-terminal `ResizeObserver` (`project-terminal.ts`)
3. The panel divider drag `mousemove` (`project-terminal.ts`)

The divider drag's `mouseup` keeps its immediate authoritative fit, so the final size is always correct. Trade-off: the session terminal no longer reflows live mid-drag — it holds, then snaps when the drag settles (the safe behavior, since intermediate sizes are exactly what caused the corruption).

## Testing

- `npm test` — all 132 files / 1747 tests pass
- `npm run build` — clean
- Manually verified: dragging the terminal/session divider with an active Claude session no longer doubles text

🤖 Generated with [Claude Code](https://claude.com/claude-code)