### PR TITLE
Add 'Open in Explorer' / 'Open folder in Explorer' to file-tree and sidebar

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -538,6 +538,10 @@ export function registerIpcHandlers(): void {
     return shell.openExternal(url);
   });
 
+  // Opens a directory in the OS file manager (Explorer / Finder / xdg-open).
+  // shell.openPath resolves to '' on success or an error string on failure.
+  ipcMain.handle('app:openInFileManager', (_event, dirPath: string) => shell.openPath(dirPath));
+
   ipcMain.handle('git:getStatus', (_event, projectPath: string) => getGitStatus(projectPath));
 
   ipcMain.handle('git:getRemoteUrl', (_event, projectPath: string) => getGitRemoteUrl(projectPath));

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -98,6 +98,7 @@ export interface VibeyardApi {
     focus(): void;
     getVersion(): Promise<string>;
     openExternal(url: string): Promise<void>;
+    openInFileManager(dirPath: string): Promise<void>;
     getBrowserPreloadPath(): Promise<string>;
     onQuitting(callback: () => void): () => void;
     onConfirmClose(callback: () => void): () => void;
@@ -289,6 +290,7 @@ const api: VibeyardApi = {
     focus: () => { ipcRenderer.send('app:focus'); },
     getVersion: () => ipcRenderer.invoke('app:getVersion'),
     openExternal: (url: string) => ipcRenderer.invoke('app:openExternal', url),
+    openInFileManager: (dirPath: string) => ipcRenderer.invoke('app:openInFileManager', dirPath),
     getBrowserPreloadPath: () => ipcRenderer.invoke('app:getBrowserPreloadPath'),
     onQuitting: (cb: () => void) => onChannel('app:quitting', cb),
     onConfirmClose: (cb: () => void) => onChannel('app:confirmClose', cb),

--- a/src/renderer/components/file-tree.ts
+++ b/src/renderer/components/file-tree.ts
@@ -4,7 +4,9 @@ import { showContextMenu, MenuOption } from './board/board-context-menu.js';
 import { showConfirmModal, showPropertiesDialog } from './modal.js';
 import { FILE_PATH_DRAG_TYPE } from '../drag-types.js';
 import { estimateTokens, TOKEN_COUNT_MAX_CHARS } from '../../shared/token-estimate.js';
-import { isPathUnder } from '../../shared/platform.js';
+import { isPathUnder, dirname } from '../../shared/platform.js';
+import { t } from '../i18n.js';
+import { fileManagerLabelKey, openFolderLabelKey } from '../file-manager-label.js';
 
 export interface DirEntry {
   name: string;
@@ -252,7 +254,13 @@ function createEntry(projectId: string, depth: number, entry: DirEntry): HTMLEle
     row.addEventListener('contextmenu', (e) => {
       e.preventDefault();
       e.stopPropagation();
-      showContextMenu(e.clientX, e.clientY, [deleteMenuOption(entry)]);
+      showContextMenu(e.clientX, e.clientY, [
+        {
+          label: t(fileManagerLabelKey()),
+          action: () => { window.vibeyard.app.openInFileManager(entry.path); },
+        },
+        deleteMenuOption(entry),
+      ]);
     });
     return [row, subContainer];
   }
@@ -272,6 +280,10 @@ function createEntry(projectId: string, depth: number, entry: DirEntry): HTMLEle
     e.preventDefault();
     e.stopPropagation();
     showContextMenu(e.clientX, e.clientY, [
+      {
+        label: t(openFolderLabelKey()),
+        action: () => { window.vibeyard.app.openInFileManager(dirname(entry.path)); },
+      },
       {
         label: 'Open in Browser',
         action: () => {

--- a/src/renderer/components/sidebar.ts
+++ b/src/renderer/components/sidebar.ts
@@ -19,6 +19,7 @@ import { mountGitPanel, closeGitPanel } from './git-panel.js';
 import { gitChangeCount, onChange as onGitStatusChange } from '../git-status.js';
 import { ICON_KANBAN, ICON_TEAM, ICON_OVERVIEW, ICON_SESSIONS, ICON_FILES, ICON_GIT } from '../icons.js';
 import { t } from '../i18n.js';
+import { fileManagerLabelKey } from '../file-manager-label.js';
 
 type ProjectPanel = 'history' | 'files' | 'git' | null;
 const projectPanelOpen = new Map<string, ProjectPanel>();
@@ -369,6 +370,11 @@ function buildProjectActions(
     filesBtn.addEventListener('click', (e) => {
       e.stopPropagation();
       setProjectPanel(project.id, openPanel === 'files' ? null : 'files');
+    });
+    filesBtn.addEventListener('contextmenu', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      showFilesContextMenu(e.clientX, e.clientY, project);
     });
     actions.appendChild(filesBtn);
   }
@@ -752,6 +758,38 @@ function hideProjectContextMenu(): void {
     activeProjectContextMenu.remove();
     activeProjectContextMenu = null;
   }
+}
+
+/**
+ * Right-click menu on the Files button: a single "Open in <Explorer/Finder/…>"
+ * item that opens the project's directory in the OS file manager. Reuses the
+ * project context-menu's close machinery (activeProjectContextMenu + the
+ * document click/Escape listeners registered in initSidebar).
+ */
+function showFilesContextMenu(x: number, y: number, project: ProjectRecord): void {
+  hideProjectContextMenu();
+
+  const menu = document.createElement('div');
+  menu.className = 'tab-context-menu';
+  menu.style.left = `${x}px`;
+  menu.style.top = `${y}px`;
+
+  const openItem = document.createElement('div');
+  openItem.className = 'tab-context-menu-item';
+  openItem.textContent = t(fileManagerLabelKey());
+  openItem.addEventListener('click', (e) => {
+    e.stopPropagation();
+    hideProjectContextMenu();
+    window.vibeyard.app.openInFileManager(project.path);
+  });
+
+  menu.appendChild(openItem);
+  document.body.appendChild(menu);
+  activeProjectContextMenu = menu;
+
+  const rect = menu.getBoundingClientRect();
+  if (rect.right > window.innerWidth) menu.style.left = `${window.innerWidth - rect.width - 4}px`;
+  if (rect.bottom > window.innerHeight) menu.style.top = `${window.innerHeight - rect.height - 4}px`;
 }
 
 /** Project-level settings dialog. Currently just the default Claude profile. */

--- a/src/renderer/file-manager-label.ts
+++ b/src/renderer/file-manager-label.ts
@@ -1,0 +1,15 @@
+// Per-OS i18n key for a "open in the OS file manager" label, so the text
+// reads naturally (Explorer on Windows, Finder on macOS, File Manager elsewhere).
+// Shared by the sidebar Files button and the file-tree context menus.
+export function fileManagerLabelKey(): string {
+  if (/win/i.test(navigator.platform)) return 'contextMenu.files.openInExplorer';
+  if (/mac/i.test(navigator.platform)) return 'contextMenu.files.openInFinder';
+  return 'contextMenu.files.openInFileManager';
+}
+
+/** i18n key for "open the containing folder in the OS file manager". */
+export function openFolderLabelKey(): string {
+  if (/win/i.test(navigator.platform)) return 'contextMenu.files.openFolderInExplorer';
+  if (/mac/i.test(navigator.platform)) return 'contextMenu.files.openFolderInFinder';
+  return 'contextMenu.files.openFolderInFileManager';
+}

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -142,6 +142,14 @@
       "settings": "Project Settings…",
       "removeProject": "Remove Project"
     },
+    "files": {
+      "openInExplorer": "Open in Explorer",
+      "openInFinder": "Open in Finder",
+      "openInFileManager": "Open in File Manager",
+      "openFolderInExplorer": "Open folder in Explorer",
+      "openFolderInFinder": "Open folder in Finder",
+      "openFolderInFileManager": "Open folder in File Manager"
+    },
     "tab": {
       "rename": "Rename",
       "close": "Close",

--- a/src/renderer/locales/zh-CN.json
+++ b/src/renderer/locales/zh-CN.json
@@ -142,6 +142,14 @@
       "settings": "项目设置…",
       "removeProject": "移除项目"
     },
+    "files": {
+      "openInExplorer": "在资源管理器中打开",
+      "openInFinder": "在 Finder 中打开",
+      "openInFileManager": "在文件管理器中打开",
+      "openFolderInExplorer": "在资源管理器中打开文件夹",
+      "openFolderInFinder": "在 Finder 中打开文件夹",
+      "openFolderInFileManager": "在文件管理器中打开文件夹"
+    },
     "tab": {
       "rename": "重命名",
       "close": "关闭",

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -75,6 +75,7 @@ export interface VibeyardApi {
     focus(): void;
     getVersion(): Promise<string>;
     openExternal(url: string): Promise<void>;
+    openInFileManager(dirPath: string): Promise<void>;
     onQuitting(callback: () => void): () => void;
   };
   chromeImport: {


### PR DESCRIPTION
## Summary

Adds a right-click "open in the OS file manager" affordance in two places, so you can jump from the UI straight into Explorer / Finder / xdg-open for a project or a specific folder.

- **Sidebar Files button** — right-click shows a single "Open in Explorer" (Finder / File Manager, per-OS) item that opens the project's directory.
- **File-tree context menus** —
  - right-click a **folder** → "Open in Explorer" opens that folder;
  - right-click a **file** → "Open folder in Explorer" opens its parent directory.

Labels are i18n'd (en + zh-CN) and chosen per OS so they read naturally.

## How it works

- New `app:openInFileManager` IPC (main `ipc-handlers.ts`) → `shell.openPath(dir)`, exposed through preload as `window.vibeyard.app.openInFileManager`.
- Shared per-OS label helper in `src/renderer/file-manager-label.ts`, reused by both the sidebar and the file tree.
- File-tree menus reuse the existing `showContextMenu` + `deleteMenuOption` machinery; no new DOM/CSS.

## Testing

- `npm run build` — all three targets compile.
- `npm test` — 1868 pass. The one failure is a pre-existing, environment-specific Windows locale issue in `big-initial-context.test.ts` (expects `50,000`, gets `50.000`); unrelated to these changes and present on upstream `main` too.

No main/preload behavior changes beyond the new IPC handler.