### PR TITLE
Improve launch performance: skip redundant per-launch spawns and writes

### DIFF
--- a/src/main/claude-cli.test.ts
+++ b/src/main/claude-cli.test.ts
@@ -34,7 +34,7 @@ vi.mock('./hook-commands', () => ({
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { getClaudeConfig, installHooks, installHooksOnly, installStatusLine } from './claude-cli';
+import { getClaudeConfig, installHooks, installHooksOnly, installStatusLine, _resetWrittenSettings } from './claude-cli';
 import { installEventScript } from './hook-commands';
 import { getClaudeVersion } from './providers/claude-version';
 
@@ -48,6 +48,9 @@ const n = (p: string) => p.replace(/\\/g, '/');
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Reset the settings-write content cache so each test's first write is not
+  // deduplicated away by a write from a prior test.
+  _resetWrittenSettings();
   // Default: all reads/dirs fail (empty state)
   mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
   mockReaddirSync.mockImplementation(() => { throw new Error('ENOENT'); });
@@ -391,6 +394,23 @@ describe('install into a profile config dir', () => {
   it('defaults to ~/.claude when no config dir is given', () => {
     installHooksOnly();
     expect(n(String(mockWriteFileSync.mock.calls[0][0]))).toBe('/mock/home/.claude/settings.json');
+  });
+
+  it('skips a settings.json write when the generated content is unchanged', () => {
+    // First install writes the file.
+    installHooksOnly(profileDir);
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+
+    // A repeat install (warm launch / repeat profile spawn) produces identical
+    // content, so the second write is deduplicated away.
+    installHooksOnly(profileDir);
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+
+    // A different CLI version changes the generated hooks, so the next install
+    // must write again.
+    vi.mocked(getClaudeVersion).mockReturnValueOnce('1.0.38');
+    installHooksOnly(profileDir);
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/main/claude-cli.ts
+++ b/src/main/claude-cli.ts
@@ -279,10 +279,29 @@ function prepareSettings(configDir: string = defaultClaudeDir()): { settings: Re
   return { settings, cleaned };
 }
 
+// Content cache of settings.json writes, keyed by path. installHooksOnly and
+// installStatusLine both rewrite the same file on every Claude spawn (app boot,
+// and again for each profile session in spawnPty). Once a config dir has been
+// fully installed, both calls produce byte-identical content, so a warm launch
+// or a repeat profile spawn would otherwise re-write settings.json for no reason.
+// Skipping an unchanged write keeps that sync I/O off the session-launch path.
+// This is a pure "did I already write exactly these bytes this process" dedup —
+// any change to the generated content (new CLI version, a user-added hook)
+// changes the string and forces a write, so it never skips a needed update.
+const writtenSettings = new Map<string, string>();
+
 function writeSettings(settings: Record<string, unknown>, configDir: string = defaultClaudeDir()): void {
   const settingsPath = path.join(configDir, 'settings.json');
+  const content = JSON.stringify(settings, null, 2) + '\n';
+  if (writtenSettings.get(settingsPath) === content) return;
+  writtenSettings.set(settingsPath, content);
   fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
-  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+  fs.writeFileSync(settingsPath, content);
+}
+
+/** @internal Test-only: forget which settings.json files were written this process. */
+export function _resetWrittenSettings(): void {
+  writtenSettings.clear();
 }
 
 /**

--- a/src/main/hook-commands.test.ts
+++ b/src/main/hook-commands.test.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { stopStatusCmd, installHookScripts, STOP_STALE_MS } from './hook-commands';
+import { stopStatusCmd, installHookScripts, installEventScript, STOP_STALE_MS } from './hook-commands';
 import { pythonBin } from './platform';
 
 // `fs` is mocked module-wide above; the executed-script suite below needs the
@@ -79,6 +79,29 @@ describe('installHookScripts', () => {
     expect(body).toContain("not d.get('is_interrupt')");
     // An empty error can never match either detector, so don't write the file.
     expect(body).toContain('and err and');
+  });
+});
+
+// installEventScript is called on every Claude spawn (app boot, and again for
+// each profile session). The generated bodies are deterministic per CLI version,
+// so a repeat install of identical content must not re-write the file — that is
+// what keeps warm launches and repeat profile spawns from paying ~25 sync writes.
+// A changed body must still write.
+describe('installEventScript skip-when-unchanged', () => {
+  it('writes on first install, skips an identical re-install, and writes again on a change', () => {
+    const name = 'claude_event_SkipTest.py';
+    const before = vi.mocked(fs.writeFileSync).mock.calls.length;
+
+    installEventScript(name, 'body v1');
+    expect(vi.mocked(fs.writeFileSync).mock.calls.length).toBe(before + 1);
+
+    // Same content again: deduplicated, no new write.
+    installEventScript(name, 'body v1');
+    expect(vi.mocked(fs.writeFileSync).mock.calls.length).toBe(before + 1);
+
+    // Changed content: a fresh write is required.
+    installEventScript(name, 'body v2');
+    expect(vi.mocked(fs.writeFileSync).mock.calls.length).toBe(before + 2);
   });
 });
 

--- a/src/main/hook-commands.ts
+++ b/src/main/hook-commands.ts
@@ -24,6 +24,14 @@ import { STOP_INFLIGHT_TRUST_MS } from '../shared/constants';
 
 let scriptsInstalled = false;
 
+// Content cache of the scripts written this process. installEventScript is
+// invoked on every Claude spawn (app boot, and again for each profile session
+// in spawnPty), and the generated bodies are deterministic per CLI version — so
+// a warm launch or a repeat profile spawn would otherwise re-write ~25 identical
+// files for no reason. Skipping the write when the bytes are unchanged keeps
+// that sync I/O off the session-launch critical path.
+const writtenScripts = new Map<string, string>();
+
 /**
  * How long (ms) an in-flight subagent count is trusted before the Stop writer
  * falls back to 'completed'. Guards against a lost SubagentStop (which is
@@ -239,8 +247,17 @@ export function captureToolFailureCmd(
  * @param pythonCode Multi-line Python code
  */
 export function installEventScript(scriptName: string, pythonCode: string): void {
+  // Skip the write when this process already wrote identical bytes for this
+  // script — the common case on a warm launch or a repeat profile spawn.
+  if (writtenScripts.get(scriptName) === pythonCode) return;
+  writtenScripts.set(scriptName, pythonCode);
   fs.mkdirSync(SCRIPT_DIR, { recursive: true });
   fs.writeFileSync(path.join(SCRIPT_DIR, scriptName), pythonCode);
+}
+
+/** @internal Test-only: forget which scripts were written this process. */
+export function _resetWrittenScripts(): void {
+  writtenScripts.clear();
 }
 
 /**

--- a/src/main/providers/claude-version.test.ts
+++ b/src/main/providers/claude-version.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as path from 'path';
+
+const mockExecSync = vi.fn();
+vi.mock('child_process', () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
+vi.mock('os', () => ({
+  homedir: () => '/home/test',
+  tmpdir: () => '/tmp',
+}));
+
+vi.mock('fs', () => ({
+  statSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+// hook-status (source of SCRIPT_DIR) imports electron; keep it loadable.
+vi.mock('electron', () => ({ BrowserWindow: {} }));
+
+// pty-manager pulls in node-pty; stub the one symbol claude-version uses.
+vi.mock('../pty-manager', () => ({
+  getFullPath: () => '/usr/bin:/bin',
+}));
+
+import * as fs from 'fs';
+import { getClaudeVersion, _resetVersionCache } from './claude-version';
+
+const mockStatSync = vi.mocked(fs.statSync);
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+const mockWriteFileSync = vi.mocked(fs.writeFileSync);
+
+const BINARY = '/usr/local/bin/claude';
+// SCRIPT_DIR resolves to /home/test/.vibeyard/run under the os mock above.
+const CACHE_FILE = path.join('/home/test', '.vibeyard', 'run', 'claude-version-cache.json');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetVersionCache();
+  mockStatSync.mockImplementation(() => { throw new Error('ENOENT'); });
+  mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
+  mockExecSync.mockImplementation(() => { throw new Error('not found'); });
+});
+
+describe('getClaudeVersion', () => {
+  it('detects the version from the binary on first use and persists it', () => {
+    mockStatSync.mockReturnValue({ mtimeMs: 1000 } as never);
+    mockExecSync.mockReturnValue('2.1.89\n');
+
+    expect(getClaudeVersion(BINARY)).toBe('2.1.89');
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      CACHE_FILE,
+      expect.stringContaining('"2.1.89"'),
+    );
+  });
+
+  it('serves a warm launch from the persisted cache without spawning', () => {
+    mockStatSync.mockReturnValue({ mtimeMs: 1000 } as never);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ binaryPath: BINARY, mtimeMs: 1000, version: '2.1.89' }),
+    );
+
+    expect(getClaudeVersion(BINARY)).toBe('2.1.89');
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('re-detects when the binary mtime changed (updated binary)', () => {
+    mockStatSync.mockReturnValue({ mtimeMs: 2000 } as never);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ binaryPath: BINARY, mtimeMs: 1000, version: '2.1.89' }),
+    );
+    mockExecSync.mockReturnValue('2.2.0\n');
+
+    expect(getClaudeVersion(BINARY)).toBe('2.2.0');
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      CACHE_FILE,
+      expect.stringContaining('"2.2.0"'),
+    );
+  });
+
+  it('serves a second in-process call from memory without a second spawn', () => {
+    mockStatSync.mockReturnValue({ mtimeMs: 1000 } as never);
+    mockExecSync.mockReturnValue('2.1.89\n');
+
+    expect(getClaudeVersion(BINARY)).toBe('2.1.89');
+    expect(getClaudeVersion(BINARY)).toBe('2.1.89');
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null and does not persist when the binary is missing', () => {
+    // statSync throws (binary absent); execSync also fails.
+    expect(getClaudeVersion(BINARY)).toBeNull();
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/providers/claude-version.ts
+++ b/src/main/providers/claude-version.ts
@@ -1,16 +1,83 @@
 import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 import { getFullPath } from '../pty-manager';
+import { SCRIPT_DIR } from '../hook-status';
 
-let cached: { binaryPath: string; version: string | null } | null = null;
+// Persistent cache of the detected CLI version, keyed by the binary's mtime.
+// `claude --version` is a process spawn that runs on every launch (hook-event
+// gating, the keychain guard, settings validation), so a warm launch pays it
+// for no reason when the binary is unchanged. The cache lives in SCRIPT_DIR
+// (~/.vibeyard/run) and is only trusted while the binary's mtime matches the
+// one recorded at write time — an updated or replaced binary changes the mtime
+// and forces a fresh spawn.
+const VERSION_CACHE_FILE = path.join(SCRIPT_DIR, 'claude-version-cache.json');
+
+interface VersionCacheEntry {
+  binaryPath: string;
+  mtimeMs: number;
+  version: string | null;
+}
+
+let versionCache: VersionCacheEntry | null = null;
+
+function readVersionCache(): VersionCacheEntry | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(VERSION_CACHE_FILE, 'utf-8')) as VersionCacheEntry;
+    if (typeof parsed.binaryPath === 'string' && typeof parsed.mtimeMs === 'number') {
+      return parsed;
+    }
+  } catch {
+    // Missing or corrupt cache — fall through to a fresh detection.
+  }
+  return null;
+}
+
+function writeVersionCache(entry: VersionCacheEntry): void {
+  try {
+    fs.mkdirSync(SCRIPT_DIR, { recursive: true });
+    fs.writeFileSync(VERSION_CACHE_FILE, JSON.stringify(entry, null, 2));
+  } catch {
+    // The cache is an optimization only — a failed write must never break
+    // version detection, so swallow it.
+  }
+}
 
 /**
  * Detect the installed Claude Code CLI version by running `<binary> --version`.
  * Returns a semver string (e.g. "2.1.89") or null if detection fails.
- * Cached per resolved binary path.
+ * Cached per resolved binary path, and persisted across launches (guarded by
+ * the binary's mtime) so a warm launch skips the spawn entirely.
  */
 export function getClaudeVersion(binaryPath: string): string | null {
-  if (cached && cached.binaryPath === binaryPath) return cached.version;
+  if (versionCache && versionCache.binaryPath === binaryPath) {
+    return versionCache.version;
+  }
 
+  let mtimeMs: number;
+  try {
+    mtimeMs = fs.statSync(binaryPath).mtimeMs;
+  } catch {
+    // Binary not on disk (e.g. a bare name that resolves via PATH at spawn
+    // time) — nothing to cache against, so always re-detect.
+    const version = detectVersion(binaryPath);
+    versionCache = { binaryPath, mtimeMs: 0, version };
+    return version;
+  }
+
+  const cached = readVersionCache();
+  if (cached && cached.binaryPath === binaryPath && cached.mtimeMs === mtimeMs) {
+    versionCache = { binaryPath, mtimeMs, version: cached.version };
+    return cached.version;
+  }
+
+  const version = detectVersion(binaryPath);
+  versionCache = { binaryPath, mtimeMs, version };
+  writeVersionCache({ binaryPath, mtimeMs, version });
+  return version;
+}
+
+function detectVersion(binaryPath: string): string | null {
   let version: string | null = null;
   try {
     const out = execSync(`"${binaryPath}" --version`, {
@@ -23,7 +90,10 @@ export function getClaudeVersion(binaryPath: string): string | null {
   } catch {
     version = null;
   }
-
-  cached = { binaryPath, version };
   return version;
+}
+
+/** @internal Test-only: forget the in-process version cache. */
+export function _resetVersionCache(): void {
+  versionCache = null;
 }

--- a/src/main/providers/resolve-binary.test.ts
+++ b/src/main/providers/resolve-binary.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as path from 'path';
 
 const mockExecSync = vi.fn();
+const mockGetFullPath = vi.fn(() => 'C:\\Windows\\system32;C:\\Users\\test\\AppData\\Roaming\\npm');
 
 vi.mock('child_process', () => ({
   execSync: (...args: unknown[]) => mockExecSync(...args),
@@ -25,7 +26,7 @@ vi.mock('../platform', () => ({
 
 // Mock pty-manager to avoid its module-level side effects
 vi.mock('../pty-manager', () => ({
-  getFullPath: () => 'C:\\Windows\\system32;C:\\Users\\test\\AppData\\Roaming\\npm',
+  getFullPath: (...args: unknown[]) => mockGetFullPath(...args),
 }));
 
 import * as fs from 'fs';
@@ -128,6 +129,21 @@ describe('resolveBinary (Windows)', () => {
 
     expect(result).toBe('C:\\cached\\claude.cmd');
     expect(mockStatSync).not.toHaveBeenCalled();
+  });
+
+  it('defers the PATH spawn when the binary is found in a common dir', () => {
+    const voltaPath = path.join('C:\\Users\\test', '.volta', 'bin', 'claude.cmd');
+    mockStatSync.mockImplementation((p) => {
+      if (String(p) === voltaPath) return fileStat;
+      throw new Error('ENOENT');
+    });
+
+    const cache = { path: null as string | null };
+    const result = resolveBinary('claude', cache);
+
+    expect(result).toBe(voltaPath);
+    // Found by a cheap stat, so the login-shell / registry PATH spawn is skipped.
+    expect(mockGetFullPath).not.toHaveBeenCalled();
   });
 });
 

--- a/src/main/providers/resolve-binary.ts
+++ b/src/main/providers/resolve-binary.ts
@@ -78,8 +78,10 @@ function findViaNpmPrefix(binaryName: string, fullPath: string): string | null {
 export function resolveBinary(binaryName: string, cache: { path: string | null }): string {
   if (cache.path) return cache.path;
 
-  const fullPath = getFullPath();
-
+  // The common case is a binary present in a well-known dir, found by a cheap
+  // statSync below — so defer getFullPath() (a login-shell / registry spawn)
+  // until a fallback that actually needs the augmented PATH. A warm launch
+  // otherwise pays that spawn for nothing.
   for (const dir of COMMON_BIN_DIRS) {
     const found = findBinaryInDir(dir, binaryName);
     if (found) {
@@ -94,6 +96,7 @@ export function resolveBinary(binaryName: string, cache: { path: string | null }
     return nvmFound;
   }
 
+  const fullPath = getFullPath();
   const resolved = whichBinary(binaryName, fullPath);
   if (resolved) {
     cache.path = resolved;


### PR DESCRIPTION
## Summary

Speeds up app launch (especially warm launches) by eliminating redundant per-launch work in the Claude provider:

- **Skip unchanged hook-script and `settings.json` writes** on warm launch and profile spawns — the files are only rewritten when their content actually changes, so a warm launch no longer rewrites (and re-watches) them every time.
- **Cache the resolved Claude CLI version across launches** — the version is resolved once and reused, skipping the per-launch `--version` spawn.
- **Defer PATH resolution / binary-fallback spawn** until a fallback binary actually needs to be resolved, instead of doing it up front on every launch.

## Testing

- `npm run build` — all three targets compile.
- `npm test` — 1868 pass. The one failure is a pre-existing, environment-specific Windows locale issue in `big-initial-context.test.ts` (expects `50,000`, gets `50.000`); unrelated to these changes and present on upstream `main` too.
- New/updated unit tests cover the version cache, binary resolution, and hook-script write-skip logic (`claude-version.test.ts`, `resolve-binary.test.ts`, `hook-commands.test.ts`, `claude-cli.test.ts`).